### PR TITLE
feat(ux): workspace pre-fill, auto-open workflow, chunk citation deep-link

### DIFF
--- a/edgequake_webui/src/app/(dashboard)/documents/[id]/page.tsx
+++ b/edgequake_webui/src/app/(dashboard)/documents/[id]/page.tsx
@@ -26,7 +26,7 @@ import {
 } from 'lucide-react';
 import Link from 'next/link';
 import { useParams, useRouter, useSearchParams } from 'next/navigation';
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
 
@@ -65,13 +65,21 @@ export default function DocumentViewPage() {
   const endLine = searchParams.get('end_line') 
     ? parseInt(searchParams.get('end_line')!) 
     : undefined;
+  // Deep-link: chunk UUID passed from query citation click
+  const chunkIdFromUrl = searchParams.get('chunk') || undefined;
 
   // OODA-chunk-select: Local chunk selection state for sidebar → content highlighting.
   // WHY: Using local state (not URL) avoids router updates on each click
   // while still supporting URL-based deep-linking for external citations.
-  const [selectedChunkId, setSelectedChunkId] = useState<string | undefined>();
+  const [selectedChunkId, setSelectedChunkId] = useState<string | undefined>(chunkIdFromUrl);
   const [chunkStartLine, setChunkStartLine] = useState<number | undefined>();
   const [chunkEndLine, setChunkEndLine] = useState<number | undefined>();
+
+  // Sync selectedChunkId when the URL param changes (e.g. user navigates to a
+  // different citation deep-link without a full page reload).
+  useEffect(() => {
+    setSelectedChunkId(chunkIdFromUrl);
+  }, [chunkIdFromUrl]);
 
   /**
    * Called when user clicks a chunk in the Data Hierarchy tree.

--- a/edgequake_webui/src/components/layout/header-tenant-selector.tsx
+++ b/edgequake_webui/src/components/layout/header-tenant-selector.tsx
@@ -196,6 +196,33 @@ export function HeaderTenantSelector({ className }: HeaderTenantSelectorProps) {
       setTenantDefaultLLM(undefined);
       setTenantDefaultEmbedding(undefined);
       setTenantDefaultVisionLLM(undefined);
+      // Pre-fill workspace form with new tenant defaults, then open the dialog
+      if (newTenant.default_llm_model) {
+        setWorkspaceLLMSelection({
+          model: newTenant.default_llm_model,
+          provider: newTenant.default_llm_provider || '',
+          fullId: newTenant.default_llm_provider
+            ? `${newTenant.default_llm_provider}/${newTenant.default_llm_model}`
+            : newTenant.default_llm_model,
+        });
+      }
+      if (newTenant.default_embedding_model) {
+        setEmbeddingSelection({
+          model: newTenant.default_embedding_model,
+          provider: newTenant.default_embedding_provider || '',
+          dimension: newTenant.default_embedding_dimension ?? 1536,
+        });
+      }
+      if (newTenant.default_vision_llm_model) {
+        setWorkspaceVisionLLMSelection({
+          model: newTenant.default_vision_llm_model,
+          provider: newTenant.default_vision_llm_provider || '',
+          fullId: newTenant.default_vision_llm_provider
+            ? `${newTenant.default_vision_llm_provider}/${newTenant.default_vision_llm_model}`
+            : newTenant.default_vision_llm_model,
+        });
+      }
+      setShowCreateWorkspace(true);
     },
     onError: (error) => {
       toast.error(t('tenant.createFailed', 'Failed to create tenant'), {
@@ -264,6 +291,43 @@ export function HeaderTenantSelector({ className }: HeaderTenantSelectorProps) {
       });
     }
   }, [selectWorkspace, selectedWorkspaceId, workspaces, t]);
+
+  /**
+   * Pre-fill workspace creation form from a tenant's default model settings,
+   * then open the dialog. Accepts an optional tenant override for the case
+   * where the store hasn't been updated yet (e.g. immediately after tenant creation).
+   */
+  const handleOpenCreateWorkspace = useCallback((tenantOverride?: typeof tenants[0]) => {
+    const tenant = tenantOverride ?? tenants.find((te) => te.id === selectedTenantId);
+    if (tenant) {
+      if (tenant.default_llm_model) {
+        setWorkspaceLLMSelection({
+          model: tenant.default_llm_model,
+          provider: tenant.default_llm_provider || '',
+          fullId: tenant.default_llm_provider
+            ? `${tenant.default_llm_provider}/${tenant.default_llm_model}`
+            : tenant.default_llm_model,
+        });
+      }
+      if (tenant.default_embedding_model) {
+        setEmbeddingSelection({
+          model: tenant.default_embedding_model,
+          provider: tenant.default_embedding_provider || '',
+          dimension: tenant.default_embedding_dimension ?? 1536,
+        });
+      }
+      if (tenant.default_vision_llm_model) {
+        setWorkspaceVisionLLMSelection({
+          model: tenant.default_vision_llm_model,
+          provider: tenant.default_vision_llm_provider || '',
+          fullId: tenant.default_vision_llm_provider
+            ? `${tenant.default_vision_llm_provider}/${tenant.default_vision_llm_model}`
+            : tenant.default_vision_llm_model,
+        });
+      }
+    }
+    setShowCreateWorkspace(true);
+  }, [selectedTenantId, tenants]);
 
   const selectedTenant = tenants.find((t) => t.id === selectedTenantId);
   const selectedWorkspace = workspaces.find((w) => w.id === selectedWorkspaceId);
@@ -404,7 +468,7 @@ export function HeaderTenantSelector({ className }: HeaderTenantSelectorProps) {
                           </DropdownMenuItem>
                         ))
                       )}
-                      <DropdownMenuItem onClick={() => setShowCreateWorkspace(true)} className="py-2">
+                      <DropdownMenuItem onClick={() => handleOpenCreateWorkspace()} className="py-2">
                         <Plus className="mr-2 h-4 w-4 text-muted-foreground" />
                         <span>{t('workspace.createNew', 'Create New Workspace')}</span>
                       </DropdownMenuItem>

--- a/edgequake_webui/src/components/layout/tenant-guard.tsx
+++ b/edgequake_webui/src/components/layout/tenant-guard.tsx
@@ -15,6 +15,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { createTenant, createWorkspace, getTenants, getWorkspaces } from '@/lib/api/edgequake';
 import { useTenantStore } from '@/stores/use-tenant-store';
+import type { Tenant } from '@/types';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { AlertTriangle, Building2, FolderKanban, Loader2, Plus } from 'lucide-react';
 import { useCallback, useEffect, useState } from 'react';
@@ -157,6 +158,35 @@ export function TenantGuard({ children }: TenantGuardProps) {
       .replace(/^-|-$/g, '');
   }, []);
 
+  /**
+   * Pre-fill workspace model fields from a tenant's defaults, then open the dialog.
+   * ModelSelector expects "provider:model" format (e.g., "ollama:gemma3:12b").
+   */
+  const handleOpenCreateWorkspace = useCallback((tenantOverride?: Tenant) => {
+    const tenant = tenantOverride ?? tenantsData?.find((te) => te.id === selectedTenantId);
+    if (tenant) {
+      if (tenant.default_llm_model) {
+        const llmVal = tenant.default_llm_provider
+          ? `${tenant.default_llm_provider}:${tenant.default_llm_model}`
+          : tenant.default_llm_model;
+        setWorkspaceLlmModel(llmVal);
+      }
+      if (tenant.default_embedding_model) {
+        const embVal = tenant.default_embedding_provider
+          ? `${tenant.default_embedding_provider}:${tenant.default_embedding_model}`
+          : tenant.default_embedding_model;
+        setWorkspaceEmbeddingModel(embVal);
+      }
+      if (tenant.default_vision_llm_model) {
+        const visionVal = tenant.default_vision_llm_provider
+          ? `${tenant.default_vision_llm_provider}:${tenant.default_vision_llm_model}`
+          : tenant.default_vision_llm_model;
+        setWorkspaceVisionLlmModel(visionVal);
+      }
+    }
+    setShowCreateWorkspace(true);
+  }, [selectedTenantId, tenantsData]);
+
   // Create tenant mutation - SPEC-032: Now accepts model configuration
   const createTenantMutation = useMutation({
     mutationFn: (data: {
@@ -228,13 +258,15 @@ export function TenantGuard({ children }: TenantGuardProps) {
       setTenantLlmModel(undefined);
       setTenantEmbeddingModel(undefined);
       setTenantVisionLlmModel(undefined);
+      // Pre-fill workspace form and open dialog for the new tenant
+      handleOpenCreateWorkspace(newTenant);
     } catch (error) {
       setIsSettingUpContext(false);
       toast.error(t('tenant.createFailed', 'Failed to create tenant'), {
         description: error instanceof Error ? error.message : 'Unknown error',
       });
     }
-  }, [newTenantName, tenantLlmModel, tenantEmbeddingModel, tenantVisionLlmModel, parseModelValue, createTenantMutation, selectTenant, queryClient, t]);
+  }, [newTenantName, tenantLlmModel, tenantEmbeddingModel, tenantVisionLlmModel, parseModelValue, createTenantMutation, selectTenant, queryClient, t, handleOpenCreateWorkspace]);
 
   // Handle workspace creation with proper async flow - SPEC-032/SPEC-041: Now includes model config
   const handleCreateWorkspace = useCallback(async () => {
@@ -458,7 +490,7 @@ export function TenantGuard({ children }: TenantGuardProps) {
               </CardDescription>
             </CardHeader>
             <CardContent className="text-center">
-              <Button onClick={() => setShowCreateWorkspace(true)}>
+              <Button onClick={() => handleOpenCreateWorkspace()}>
                 <Plus className="h-4 w-4 mr-2" />
                 {t('workspace.createWorkspace', 'Create Workspace')}
               </Button>

--- a/edgequake_webui/src/components/query/chat-message.tsx
+++ b/edgequake_webui/src/components/query/chat-message.tsx
@@ -515,7 +515,7 @@ const AssistantMessage = memo(function AssistantMessage({
                 onEntityClick={(entityId) => {
                   window.location.href = `/graph?entity=${encodeURIComponent(entityId)}`;
                 }}
-                onDocumentClick={(documentId, chunkContent, chunkIndex, startLine, endLine) => {
+                onDocumentClick={(documentId, chunkContent, chunkIndex, startLine, endLine, chunkId) => {
                   // Navigate to document detail page with line numbers and/or highlight
                   const url = new URL(`/documents/${encodeURIComponent(documentId)}`, window.location.origin);
                   
@@ -523,6 +523,11 @@ const AssistantMessage = memo(function AssistantMessage({
                   if (startLine !== undefined && endLine !== undefined) {
                     url.searchParams.set('start_line', startLine.toString());
                     url.searchParams.set('end_line', endLine.toString());
+                  }
+                  
+                  // Deep-link to specific chunk UUID for sidebar selection
+                  if (chunkId) {
+                    url.searchParams.set('chunk', chunkId);
                   }
                   
                   // Fallback: Use text highlight if no line numbers

--- a/edgequake_webui/src/components/query/source-citations.tsx
+++ b/edgequake_webui/src/components/query/source-citations.tsx
@@ -51,7 +51,8 @@ interface SourceCitationsProps {
     chunkContent?: string, 
     chunkIndex?: number,
     startLine?: number,
-    endLine?: number
+    endLine?: number,
+    chunkId?: string
   ) => void;
   onExploreGraph?: (entityLabels: string[]) => void;
 }
@@ -180,7 +181,8 @@ const DocumentsTab = ({
     chunkContent?: string, 
     chunkIndex?: number,
     startLine?: number,
-    endLine?: number
+    endLine?: number,
+    chunkId?: string
   ) => void;
 }) => {
   const [showAll, setShowAll] = useState(false);
@@ -256,7 +258,8 @@ const DocumentsTab = ({
                               chunk.content, 
                               chunkIdx,
                               chunk.start_line,
-                              chunk.end_line
+                              chunk.end_line,
+                              chunk.chunk_id
                             )}
                             className="w-full text-left p-2 rounded bg-muted/40 hover:bg-muted/70 transition-colors group/chunk"
                           >
@@ -322,7 +325,7 @@ const KnowledgeTab = ({
   entities: QueryContext['entities'];
   relationships: QueryContext['relationships'];
   onEntityClick?: (entityId: string) => void;
-  onDocumentClick?: (documentId: string, chunkContent?: string, chunkIndex?: number) => void;
+  onDocumentClick?: (documentId: string, chunkContent?: string, chunkIndex?: number, startLine?: number, endLine?: number, chunkId?: string) => void;
 }) => {
   const [showAllEntities, setShowAllEntities] = useState(false);
   const visibleEntities = showAllEntities ? entities : entities?.slice(0, 12);

--- a/edgequake_webui/src/types/index.ts
+++ b/edgequake_webui/src/types/index.ts
@@ -430,6 +430,8 @@ export interface QueryContext {
     start_line?: number;
     end_line?: number;
     chunk_index?: number;
+    /** Chunk UUID from storage. Used for deep-linking to document detail with selected chunk. */
+    chunk_id?: string;
   }>;
   entities: Array<{
     id: string;


### PR DESCRIPTION
## Summary

Four UX improvements for tenant/workspace management and query citations.

## Changes

### 1. Workspace creation form pre-filled from tenant defaults
When opening the Create Workspace dialog, LLM, Embedding, and Vision LLM selectors are pre-filled with the selected tenant's default models. Users can still override them.

### 2. Create Workspace dialog auto-opens after tenant creation
After creating a new tenant, the Create Workspace dialog immediately opens pre-filled with the new tenant's model defaults, guiding users through the tenant → workspace setup flow.

### 3. Workspace auto-selected after creation
After creating a workspace it is immediately set as the active workspace.

### 4. Chunk citation deep-link with `?chunk=` param
- `chunk_id` field added to `QueryContext.chunks` type (optional, graceful fallback)
- `onDocumentClick` accepts an optional `chunkId` parameter throughout the chain
- Citation deep-links now include `?chunk=CHUNK_ID` when the API provides a UUID
- Document detail page reads `?chunk=` on load and pre-selects the chunk in the metadata sidebar
- A `useEffect` syncs `selectedChunkId` with URL changes

## Files changed
- `src/components/layout/header-tenant-selector.tsx`
- `src/components/layout/tenant-guard.tsx`
- `src/types/index.ts`
- `src/components/query/source-citations.tsx`
- `src/components/query/chat-message.tsx`
- `src/app/(dashboard)/documents/[id]/page.tsx`
