### PR TITLE
fix(pipeline): prevent UTF-8 boundary panic in prefix hashing

### DIFF
--- a/edgequake/crates/edgequake-api/src/processor/pipeline_checkpoint.rs
+++ b/edgequake/crates/edgequake-api/src/processor/pipeline_checkpoint.rs
@@ -90,12 +90,10 @@ impl PipelineCheckpoint {
     fn compute_content_hash(text: &str) -> String {
         use sha2::{Digest, Sha256};
         let mut hasher = Sha256::new();
-        // Hash prefix to avoid hashing multi-MB documents entirely
-
+        // Hash prefix to avoid hashing multi-MB documents entirely.
         let target_len = text.len().min(65_536);
         let safe_len = text.floor_char_boundary(target_len);
         let prefix = &text[..safe_len];
-
         hasher.update(prefix.as_bytes());
         hex::encode(&hasher.finalize()[..8]) // 16-char hex = 64-bit fingerprint
     }
@@ -118,7 +116,7 @@ fn checkpoint_key(document_id: &str) -> String {
 /// * `source_text` — Original document text (for content hash)
 #[allow(clippy::too_many_arguments)]
 pub async fn save_pipeline_checkpoint(
-    kv: &Arc<dyn KVStorage>, 
+    kv: &Arc<dyn KVStorage>,
     document_id: &str,
     result: &ProcessingResult,
     workspace_id: &str,

--- a/edgequake/crates/edgequake-api/src/processor/pipeline_checkpoint.rs
+++ b/edgequake/crates/edgequake-api/src/processor/pipeline_checkpoint.rs
@@ -90,8 +90,12 @@ impl PipelineCheckpoint {
     fn compute_content_hash(text: &str) -> String {
         use sha2::{Digest, Sha256};
         let mut hasher = Sha256::new();
-        // Hash prefix to avoid hashing multi-MB documents entirely.
-        let prefix = &text[..text.len().min(65_536)];
+        // Hash prefix to avoid hashing multi-MB documents entirely
+
+        let target_len = text.len().min(65_536);
+        let safe_len = text.floor_char_boundary(target_len);
+        let prefix = &text[..safe_len];
+
         hasher.update(prefix.as_bytes());
         hex::encode(&hasher.finalize()[..8]) // 16-char hex = 64-bit fingerprint
     }
@@ -114,7 +118,7 @@ fn checkpoint_key(document_id: &str) -> String {
 /// * `source_text` — Original document text (for content hash)
 #[allow(clippy::too_many_arguments)]
 pub async fn save_pipeline_checkpoint(
-    kv: &Arc<dyn KVStorage>,
+    kv: &Arc<dyn KVStorage>, 
     document_id: &str,
     result: &ProcessingResult,
     workspace_id: &str,


### PR DESCRIPTION
## Description

This PR fixes a runtime panic that can occur when computing the document prefix hash in `PipelineCheckpoint::compute_content_hash`.

The previous implementation sliced the string using a byte index:

```
&text[..text.len().min(65_536)]
```

Since Rust `str` slicing requires valid UTF-8 boundaries, this could panic when the slice boundary fell inside a multi-byte character (for example Korean characters).

Example panic:

```
byte index 65536 is not a char boundary; it is inside '어'
```

This change ensures the prefix is sliced at a valid UTF-8 boundary using `floor_char_boundary`, preventing runtime panics while preserving the intended behavior of hashing only the document prefix to avoid hashing large documents entirely.

Fixes #93 

---

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (describe below)

---

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes

---

## Additional context

This issue occurs when processing documents containing multi-byte UTF-8 characters (such as Korean text) where the prefix boundary falls inside a character.

Using `floor_char_boundary` ensures the prefix length respects UTF-8 boundaries and prevents the panic while keeping the hashing logic efficient by only hashing the first portion of the document.