### PR TITLE
feat: add MiniMax provider support with M2.7 as default

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -68,7 +68,7 @@ OLLAMA_HOST=http://localhost:11434
 # Option 3: MiniMax (Cloud-hosted, OpenAI-compatible API)
 # -----------------------------------------------------------------------------
 # MINIMAX_API_KEY=your-minimax-api-key-here
-# MINIMAX_BASE_URL=https://api.minimax.io/v1  # Optional: default is api.minimax.io
+# MINIMAX_BASE_URL=https://api.minimax.io/v1  # Optional: default is https://api.minimax.io/v1
 # For China mainland, use: https://api.minimaxi.com/v1
 
 # Default MiniMax Models (set in models.toml):

--- a/.env.example
+++ b/.env.example
@@ -72,8 +72,9 @@ OLLAMA_HOST=http://localhost:11434
 # For China mainland, use: https://api.minimaxi.com/v1
 
 # Default MiniMax Models (set in models.toml):
-#   - Chat/LLM: MiniMax-M2.5 (204K context, $0.30/$1.20 per 1M tokens)
-#   - Fast: MiniMax-M2.5-highspeed (204K context, $0.60/$2.40 per 1M tokens)
+#   - Chat/LLM: MiniMax-M2.7 (204K context, latest flagship model)
+#   - Fast: MiniMax-M2.7-highspeed (204K context, low-latency)
+#   - Legacy: MiniMax-M2.5, MiniMax-M2.5-highspeed
 
 # -----------------------------------------------------------------------------
 # Option 4: LM Studio (Local, OpenAI-compatible API)

--- a/.env.example
+++ b/.env.example
@@ -65,7 +65,18 @@ OLLAMA_HOST=http://localhost:11434
 #   - Embedding: embeddinggemma (768 dimensions)
 
 # -----------------------------------------------------------------------------
-# Option 3: LM Studio (Local, OpenAI-compatible API)
+# Option 3: MiniMax (Cloud-hosted, OpenAI-compatible API)
+# -----------------------------------------------------------------------------
+# MINIMAX_API_KEY=your-minimax-api-key-here
+# MINIMAX_BASE_URL=https://api.minimax.io/v1  # Optional: default is api.minimax.io
+# For China mainland, use: https://api.minimaxi.com/v1
+
+# Default MiniMax Models (set in models.toml):
+#   - Chat/LLM: MiniMax-M2.5 (204K context, $0.30/$1.20 per 1M tokens)
+#   - Fast: MiniMax-M2.5-highspeed (204K context, $0.60/$2.40 per 1M tokens)
+
+# -----------------------------------------------------------------------------
+# Option 4: LM Studio (Local, OpenAI-compatible API)
 # -----------------------------------------------------------------------------
 # LMSTUDIO_HOST=http://localhost:1234
 # LMSTUDIO_MODEL=gemma2-9b-it                # Chat model

--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ curl -X POST http://localhost:8080/api/v1/query \
 │  │   LLM Providers             │   │   Storage Backends               │     │
 │  │  • OpenAI (gpt-4.1-nano)    │   │  • PostgreSQL 15+ (AGE + vector) │     │
 │  │  • Anthropic (Claude)       │   │  • In-Memory (dev/testing)       │     │
-│  │  • MiniMax (MiniMax-M2.5)   │   │  • Graph: Property graph model   │     │
+│  │  • MiniMax (MiniMax-M2.7)   │   │  • Graph: Property graph model   │     │
 │  │  • Ollama (gemma3:12b)      │   │  • Vector: pgvector embeddings   │     │
 │  │  • LM Studio, xAI, Gemini  │   │                                  │     │
 │  │  Auto-detection via env     │   │                                  │     │

--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ curl -X POST http://localhost:8080/api/v1/query \
 │  Backend (Rust - 11 Crates)                                                 │
 │  ┌──────────────────────────────────────────────────────────────────────┐   │
 │  │  edgequake-core          │  Orchestration & Pipeline                 │   │
-│  │  edgequake-llm           │  OpenAI, Ollama, LM Studio, Mock          │   │
+│  │  edgequake-llm           │  OpenAI, Anthropic, MiniMax, Ollama, etc.  │   │
 │  │  edgequake-storage       │  PostgreSQL AGE, Memory adapters          │   │
 │  │  edgequake-api           │  REST API server                          │   │
 │  │  edgequake-pipeline      │  Document ingestion pipeline              │   │
@@ -242,9 +242,10 @@ curl -X POST http://localhost:8080/api/v1/query \
 │  ┌─────────────────────────────┐   ┌──────────────────────────────────┐     │
 │  │   LLM Providers             │   │   Storage Backends               │     │
 │  │  • OpenAI (gpt-4.1-nano)    │   │  • PostgreSQL 15+ (AGE + vector) │     │
-│  │  • Ollama (gemma3:12b)      │   │  • In-Memory (dev/testing)       │     │
-│  │  • LM Studio (local models) │   │  • Graph: Property graph model   │     │
-│  │  • Mock (testing, free)     │   │  • Vector: pgvector embeddings   │     │
+│  │  • Anthropic (Claude)       │   │  • In-Memory (dev/testing)       │     │
+│  │  • MiniMax (MiniMax-M2.5)   │   │  • Graph: Property graph model   │     │
+│  │  • Ollama (gemma3:12b)      │   │  • Vector: pgvector embeddings   │     │
+│  │  • LM Studio, xAI, Gemini  │   │                                  │     │
 │  │  Auto-detection via env     │   │                                  │     │
 │  └─────────────────────────────┘   └──────────────────────────────────┘     │
 └─────────────────────────────────────────────────────────────────────────────┘

--- a/docs/operations/configuration.md
+++ b/docs/operations/configuration.md
@@ -116,6 +116,13 @@ DATABASE_URL="postgresql://edgequake:pass@pgbouncer:6432/edgequake"
 | `OPENROUTER_API_KEY`  | String | None                        | OpenRouter API key (required) |
 | `OPENROUTER_BASE_URL` | String | `https://openrouter.ai/api` | API endpoint                  |
 
+#### MiniMax
+
+| Variable            | Type   | Default                      | Description                                          |
+| ------------------- | ------ | ---------------------------- | ---------------------------------------------------- |
+| `MINIMAX_API_KEY`   | String | None                         | MiniMax API key (required)                           |
+| `MINIMAX_BASE_URL`  | String | `https://api.minimax.io/v1`  | API endpoint (use `https://api.minimaxi.com/v1` for China) |
+
 #### Azure OpenAI
 
 | Variable                   | Type   | Default              | Description                 |
@@ -201,6 +208,7 @@ image_per_unit = 0.0
 | `gemini`     | Google Gemini models    | `GEMINI_API_KEY`       |
 | `xai`        | xAI Grok models         | `XAI_API_KEY`          |
 | `openrouter` | OpenRouter aggregator   | `OPENROUTER_API_KEY`   |
+| `minimax`    | MiniMax AI models       | `MINIMAX_API_KEY`      |
 | `azure`      | Azure OpenAI            | `AZURE_OPENAI_API_KEY` |
 | `ollama`     | Ollama local models     | None (local)           |
 | `lm_studio`  | LM Studio local         | None (local)           |

--- a/edgequake/crates/edgequake-api/src/provider_types.rs
+++ b/edgequake/crates/edgequake-api/src/provider_types.rs
@@ -305,12 +305,15 @@ impl AvailableProvidersResponse {
                 description: "MiniMax AI (MiniMax-M2.7) - Latest flagship model with enhanced reasoning and coding"
                     .to_string(),
                 available: std::env::var("MINIMAX_API_KEY").is_ok(),
-                config_requirements: vec![ConfigRequirement {
-                    env_var: "MINIMAX_API_KEY".to_string(),
-                    required: true,
-                    description: "MiniMax API key".to_string(),
-                    satisfied: std::env::var("MINIMAX_API_KEY").is_ok(),
-                }],
+                config_requirements: {
+                    let api_key_set = std::env::var("MINIMAX_API_KEY").is_ok();
+                    vec![ConfigRequirement {
+                        env_var: "MINIMAX_API_KEY".to_string(),
+                        required: true,
+                        description: "MiniMax API key".to_string(),
+                        satisfied: api_key_set,
+                    }]
+                },
                 default_models: DefaultModels {
                     chat_model: "MiniMax-M2.7".to_string(),
                     embedding_model: "".to_string(),

--- a/edgequake/crates/edgequake-api/src/provider_types.rs
+++ b/edgequake/crates/edgequake-api/src/provider_types.rs
@@ -302,7 +302,7 @@ impl AvailableProvidersResponse {
             ProviderInfo {
                 id: "minimax".to_string(),
                 name: "MiniMax".to_string(),
-                description: "MiniMax AI (MiniMax-M2.5) - Peak Performance, Ultimate Value"
+                description: "MiniMax AI (MiniMax-M2.7) - Latest flagship model with enhanced reasoning and coding"
                     .to_string(),
                 available: std::env::var("MINIMAX_API_KEY").is_ok(),
                 config_requirements: vec![ConfigRequirement {
@@ -312,7 +312,7 @@ impl AvailableProvidersResponse {
                     satisfied: std::env::var("MINIMAX_API_KEY").is_ok(),
                 }],
                 default_models: DefaultModels {
-                    chat_model: "MiniMax-M2.5".to_string(),
+                    chat_model: "MiniMax-M2.7".to_string(),
                     embedding_model: "".to_string(),
                     embedding_dimension: 0,
                 },

--- a/edgequake/crates/edgequake-api/src/provider_types.rs
+++ b/edgequake/crates/edgequake-api/src/provider_types.rs
@@ -300,6 +300,24 @@ impl AvailableProvidersResponse {
                 },
             },
             ProviderInfo {
+                id: "minimax".to_string(),
+                name: "MiniMax".to_string(),
+                description: "MiniMax AI (MiniMax-M2.5) - Peak Performance, Ultimate Value"
+                    .to_string(),
+                available: std::env::var("MINIMAX_API_KEY").is_ok(),
+                config_requirements: vec![ConfigRequirement {
+                    env_var: "MINIMAX_API_KEY".to_string(),
+                    required: true,
+                    description: "MiniMax API key".to_string(),
+                    satisfied: std::env::var("MINIMAX_API_KEY").is_ok(),
+                }],
+                default_models: DefaultModels {
+                    chat_model: "MiniMax-M2.5".to_string(),
+                    embedding_model: "".to_string(),
+                    embedding_dimension: 0,
+                },
+            },
+            ProviderInfo {
                 id: "azure".to_string(),
                 name: "Azure OpenAI".to_string(),
                 description: "Azure-hosted OpenAI models (enterprise)".to_string(),

--- a/edgequake/crates/edgequake-api/src/safety_limits.rs
+++ b/edgequake/crates/edgequake-api/src/safety_limits.rs
@@ -355,6 +355,7 @@ pub fn default_model_for_provider(provider_name: &str) -> &'static str {
         "openrouter" => "openai/gpt-4o-mini",
         "ollama" => "gemma3:12b",
         "lmstudio" | "lm-studio" | "lm_studio" => "gemma-3n-e4b-it",
+        "minimax" => "MiniMax-M2.5",
         "mock" => "mock-model",
         _ => "gpt-4.1-nano",
     }

--- a/edgequake/crates/edgequake-api/src/safety_limits.rs
+++ b/edgequake/crates/edgequake-api/src/safety_limits.rs
@@ -355,7 +355,7 @@ pub fn default_model_for_provider(provider_name: &str) -> &'static str {
         "openrouter" => "openai/gpt-4o-mini",
         "ollama" => "gemma3:12b",
         "lmstudio" | "lm-studio" | "lm_studio" => "gemma-3n-e4b-it",
-        "minimax" => "MiniMax-M2.5",
+        "minimax" => "MiniMax-M2.7",
         "mock" => "mock-model",
         _ => "gpt-4.1-nano",
     }

--- a/edgequake/models.toml
+++ b/edgequake/models.toml
@@ -1573,7 +1573,7 @@ context_length = 204800
 max_output_tokens = 192000
 supports_vision = false
 supports_function_calling = true
-supports_json_mode = false
+supports_json_mode = true
 supports_streaming = true
 supports_system_message = true
 embedding_dimension = 0
@@ -1597,7 +1597,7 @@ context_length = 204800
 max_output_tokens = 192000
 supports_vision = false
 supports_function_calling = true
-supports_json_mode = false
+supports_json_mode = true
 supports_streaming = true
 supports_system_message = true
 embedding_dimension = 0
@@ -1621,7 +1621,7 @@ context_length = 204800
 max_output_tokens = 192000
 supports_vision = false
 supports_function_calling = true
-supports_json_mode = false
+supports_json_mode = true
 supports_streaming = true
 supports_system_message = true
 embedding_dimension = 0
@@ -1645,7 +1645,7 @@ context_length = 204800
 max_output_tokens = 192000
 supports_vision = false
 supports_function_calling = true
-supports_json_mode = false
+supports_json_mode = true
 supports_streaming = true
 supports_system_message = true
 embedding_dimension = 0
@@ -1717,122 +1717,6 @@ embedding_dimension = 768
 [providers.models.cost]
 input_per_1k = 0.0
 output_per_1k = 0.0
-embedding_per_1k = 0.0
-image_per_unit = 0.0
-
-# =============================================================================
-# MINIMAX PROVIDER
-# =============================================================================
-# MiniMax AI - Peak Performance. Ultimate Value. Master the Complex.
-# OpenAI-compatible API with competitive pricing.
-# Requires: MINIMAX_API_KEY environment variable
-# Docs: https://platform.minimax.io/docs/api-reference/text-openai-api
-
-[[providers]]
-name = "minimax"
-display_name = "MiniMax"
-type = "openaicompatible"
-api_base = "https://api.minimax.io/v1"
-api_key_env = "MINIMAX_API_KEY"
-enabled = true
-priority = 50
-description = "MiniMax AI models - Peak Performance, Ultimate Value"
-
-# --- MiniMax LLM Models ---
-
-[[providers.models]]
-name = "MiniMax-M2.7"
-display_name = "MiniMax M2.7"
-model_type = "llm"
-description = "Latest flagship model with enhanced reasoning and coding."
-deprecated = false
-tags = ["recommended", "reasoning", "cost-effective"]
-
-[providers.models.capabilities]
-context_length = 204800
-max_output_tokens = 192000
-supports_vision = false
-supports_function_calling = true
-supports_json_mode = true
-supports_streaming = true
-supports_system_message = true
-embedding_dimension = 0
-
-[providers.models.cost]
-input_per_1k = 0.0003
-output_per_1k = 0.0012
-embedding_per_1k = 0.0
-image_per_unit = 0.0
-
-[[providers.models]]
-name = "MiniMax-M2.7-highspeed"
-display_name = "MiniMax M2.7 High Speed"
-model_type = "llm"
-description = "High-speed version of M2.7 for low-latency scenarios."
-deprecated = false
-tags = ["fast", "cost-effective"]
-
-[providers.models.capabilities]
-context_length = 204800
-max_output_tokens = 192000
-supports_vision = false
-supports_function_calling = true
-supports_json_mode = true
-supports_streaming = true
-supports_system_message = true
-embedding_dimension = 0
-
-[providers.models.cost]
-input_per_1k = 0.0006
-output_per_1k = 0.0024
-embedding_per_1k = 0.0
-image_per_unit = 0.0
-
-[[providers.models]]
-name = "MiniMax-M2.5"
-display_name = "MiniMax M2.5"
-model_type = "llm"
-description = "Peak Performance. Ultimate Value. Master the Complex."
-deprecated = false
-tags = ["reasoning", "cost-effective"]
-
-[providers.models.capabilities]
-context_length = 204800
-max_output_tokens = 192000
-supports_vision = false
-supports_function_calling = true
-supports_json_mode = true
-supports_streaming = true
-supports_system_message = true
-embedding_dimension = 0
-
-[providers.models.cost]
-input_per_1k = 0.0003
-output_per_1k = 0.0012
-embedding_per_1k = 0.0
-image_per_unit = 0.0
-
-[[providers.models]]
-name = "MiniMax-M2.5-highspeed"
-display_name = "MiniMax M2.5 High Speed"
-model_type = "llm"
-description = "Same performance, faster and more agile."
-deprecated = false
-tags = ["fast", "cost-effective"]
-
-[providers.models.capabilities]
-context_length = 204800
-max_output_tokens = 192000
-supports_vision = false
-supports_function_calling = true
-supports_json_mode = true
-supports_streaming = true
-supports_system_message = true
-embedding_dimension = 0
-
-[providers.models.cost]
-input_per_1k = 0.0006
-output_per_1k = 0.0024
 embedding_per_1k = 0.0
 image_per_unit = 0.0
 

--- a/edgequake/models.toml
+++ b/edgequake/models.toml
@@ -25,6 +25,7 @@
 #   - Anthropic: claude-sonnet-4-5-20250929 (LLM)
 #   - Gemini: gemini-2.5-flash (LLM), gemini-embedding-001 (embedding)
 #   - xAI: grok-4-1-fast (LLM)
+#   - MiniMax: MiniMax-M2.5 (LLM)
 #   - OpenRouter: openai/gpt-4o-mini (LLM)
 #   - Ollama: gemma3:12b (LLM), embeddinggemma (embedding)
 #   - LM Studio: gemma-3n-e4b-it (LLM), text-embedding-nomic-embed-text-v1.5 (embedding)
@@ -1543,6 +1544,71 @@ embedding_per_1k = 0.00015
 image_per_unit = 0.0
 
 # =============================================================================
+# MINIMAX PROVIDER
+# =============================================================================
+# MiniMax AI models via OpenAI-compatible API
+# Requires: MINIMAX_API_KEY environment variable
+# Pricing verified: March 2025 (platform.minimax.io)
+
+[[providers]]
+name = "minimax"
+display_name = "MiniMax"
+type = "openaicompatible"
+api_base = "https://api.minimax.io/v1"
+api_key_env = "MINIMAX_API_KEY"
+enabled = true
+priority = 18
+description = "MiniMax AI - Peak performance models with 204K context and competitive pricing"
+
+[[providers.models]]
+name = "MiniMax-M2.5"
+display_name = "MiniMax M2.5"
+model_type = "llm"
+description = "Peak Performance. Ultimate Value. Master the Complex"
+deprecated = false
+tags = ["recommended", "reasoning", "cost-effective"]
+
+[providers.models.capabilities]
+context_length = 204800
+max_output_tokens = 192000
+supports_vision = false
+supports_function_calling = true
+supports_json_mode = false
+supports_streaming = true
+supports_system_message = true
+embedding_dimension = 0
+
+[providers.models.cost]
+input_per_1k = 0.0003
+output_per_1k = 0.0012
+embedding_per_1k = 0.0
+image_per_unit = 0.0
+
+[[providers.models]]
+name = "MiniMax-M2.5-highspeed"
+display_name = "MiniMax M2.5 High Speed"
+model_type = "llm"
+description = "Same performance, faster and more agile"
+deprecated = false
+tags = ["fast", "cost-effective"]
+
+[providers.models.capabilities]
+context_length = 204800
+max_output_tokens = 192000
+supports_vision = false
+supports_function_calling = true
+supports_json_mode = false
+supports_streaming = true
+supports_system_message = true
+embedding_dimension = 0
+
+[providers.models.cost]
+input_per_1k = 0.0006
+output_per_1k = 0.0024
+embedding_per_1k = 0.0
+image_per_unit = 0.0
+
+# =============================================================================
 # MOCK PROVIDER
 # =============================================================================
 # For testing and development without external API calls
@@ -1603,6 +1669,74 @@ embedding_dimension = 768
 [providers.models.cost]
 input_per_1k = 0.0
 output_per_1k = 0.0
+embedding_per_1k = 0.0
+image_per_unit = 0.0
+
+# =============================================================================
+# MINIMAX PROVIDER
+# =============================================================================
+# MiniMax AI - Peak Performance. Ultimate Value. Master the Complex.
+# OpenAI-compatible API with competitive pricing.
+# Requires: MINIMAX_API_KEY environment variable
+# Docs: https://platform.minimax.io/docs/api-reference/text-openai-api
+
+[[providers]]
+name = "minimax"
+display_name = "MiniMax"
+type = "openaicompatible"
+api_base = "https://api.minimax.io/v1"
+api_key_env = "MINIMAX_API_KEY"
+enabled = true
+priority = 50
+description = "MiniMax AI models - Peak Performance, Ultimate Value"
+
+# --- MiniMax LLM Models ---
+
+[[providers.models]]
+name = "MiniMax-M2.5"
+display_name = "MiniMax M2.5"
+model_type = "llm"
+description = "Peak Performance. Ultimate Value. Master the Complex."
+deprecated = false
+tags = ["recommended", "reasoning", "cost-effective"]
+
+[providers.models.capabilities]
+context_length = 204800
+max_output_tokens = 192000
+supports_vision = false
+supports_function_calling = true
+supports_json_mode = true
+supports_streaming = true
+supports_system_message = true
+embedding_dimension = 0
+
+[providers.models.cost]
+input_per_1k = 0.0003
+output_per_1k = 0.0012
+embedding_per_1k = 0.0
+image_per_unit = 0.0
+
+[[providers.models]]
+name = "MiniMax-M2.5-highspeed"
+display_name = "MiniMax M2.5 High Speed"
+model_type = "llm"
+description = "Same performance, faster and more agile."
+deprecated = false
+tags = ["fast", "cost-effective"]
+
+[providers.models.capabilities]
+context_length = 204800
+max_output_tokens = 192000
+supports_vision = false
+supports_function_calling = true
+supports_json_mode = true
+supports_streaming = true
+supports_system_message = true
+embedding_dimension = 0
+
+[providers.models.cost]
+input_per_1k = 0.0006
+output_per_1k = 0.0024
 embedding_per_1k = 0.0
 image_per_unit = 0.0
 

--- a/edgequake/models.toml
+++ b/edgequake/models.toml
@@ -25,7 +25,7 @@
 #   - Anthropic: claude-sonnet-4-5-20250929 (LLM)
 #   - Gemini: gemini-2.5-flash (LLM), gemini-embedding-001 (embedding)
 #   - xAI: grok-4-1-fast (LLM)
-#   - MiniMax: MiniMax-M2.5 (LLM)
+#   - MiniMax: MiniMax-M2.7 (LLM)
 #   - OpenRouter: openai/gpt-4o-mini (LLM)
 #   - Ollama: gemma3:12b (LLM), embeddinggemma (embedding)
 #   - LM Studio: gemma-3n-e4b-it (LLM), text-embedding-nomic-embed-text-v1.5 (embedding)
@@ -1561,12 +1561,60 @@ priority = 18
 description = "MiniMax AI - Peak performance models with 204K context and competitive pricing"
 
 [[providers.models]]
+name = "MiniMax-M2.7"
+display_name = "MiniMax M2.7"
+model_type = "llm"
+description = "Latest flagship model with enhanced reasoning and coding"
+deprecated = false
+tags = ["recommended", "reasoning", "cost-effective"]
+
+[providers.models.capabilities]
+context_length = 204800
+max_output_tokens = 192000
+supports_vision = false
+supports_function_calling = true
+supports_json_mode = false
+supports_streaming = true
+supports_system_message = true
+embedding_dimension = 0
+
+[providers.models.cost]
+input_per_1k = 0.0003
+output_per_1k = 0.0012
+embedding_per_1k = 0.0
+image_per_unit = 0.0
+
+[[providers.models]]
+name = "MiniMax-M2.7-highspeed"
+display_name = "MiniMax M2.7 High Speed"
+model_type = "llm"
+description = "High-speed version of M2.7 for low-latency scenarios"
+deprecated = false
+tags = ["fast", "cost-effective"]
+
+[providers.models.capabilities]
+context_length = 204800
+max_output_tokens = 192000
+supports_vision = false
+supports_function_calling = true
+supports_json_mode = false
+supports_streaming = true
+supports_system_message = true
+embedding_dimension = 0
+
+[providers.models.cost]
+input_per_1k = 0.0006
+output_per_1k = 0.0024
+embedding_per_1k = 0.0
+image_per_unit = 0.0
+
+[[providers.models]]
 name = "MiniMax-M2.5"
 display_name = "MiniMax M2.5"
 model_type = "llm"
 description = "Peak Performance. Ultimate Value. Master the Complex"
 deprecated = false
-tags = ["recommended", "reasoning", "cost-effective"]
+tags = ["reasoning", "cost-effective"]
 
 [providers.models.capabilities]
 context_length = 204800
@@ -1693,12 +1741,60 @@ description = "MiniMax AI models - Peak Performance, Ultimate Value"
 # --- MiniMax LLM Models ---
 
 [[providers.models]]
+name = "MiniMax-M2.7"
+display_name = "MiniMax M2.7"
+model_type = "llm"
+description = "Latest flagship model with enhanced reasoning and coding."
+deprecated = false
+tags = ["recommended", "reasoning", "cost-effective"]
+
+[providers.models.capabilities]
+context_length = 204800
+max_output_tokens = 192000
+supports_vision = false
+supports_function_calling = true
+supports_json_mode = true
+supports_streaming = true
+supports_system_message = true
+embedding_dimension = 0
+
+[providers.models.cost]
+input_per_1k = 0.0003
+output_per_1k = 0.0012
+embedding_per_1k = 0.0
+image_per_unit = 0.0
+
+[[providers.models]]
+name = "MiniMax-M2.7-highspeed"
+display_name = "MiniMax M2.7 High Speed"
+model_type = "llm"
+description = "High-speed version of M2.7 for low-latency scenarios."
+deprecated = false
+tags = ["fast", "cost-effective"]
+
+[providers.models.capabilities]
+context_length = 204800
+max_output_tokens = 192000
+supports_vision = false
+supports_function_calling = true
+supports_json_mode = true
+supports_streaming = true
+supports_system_message = true
+embedding_dimension = 0
+
+[providers.models.cost]
+input_per_1k = 0.0006
+output_per_1k = 0.0024
+embedding_per_1k = 0.0
+image_per_unit = 0.0
+
+[[providers.models]]
 name = "MiniMax-M2.5"
 display_name = "MiniMax M2.5"
 model_type = "llm"
 description = "Peak Performance. Ultimate Value. Master the Complex."
 deprecated = false
-tags = ["recommended", "reasoning", "cost-effective"]
+tags = ["reasoning", "cost-effective"]
 
 [providers.models.capabilities]
 context_length = 204800

--- a/edgequake_webui/src/components/models/model-card.tsx
+++ b/edgequake_webui/src/components/models/model-card.tsx
@@ -67,6 +67,8 @@ function getProviderIcon(providerId: string, className?: string) {
       return <Sparkles className={cn(iconClass, 'text-orange-600')} />;
     case 'azure':
       return <Cloud className={cn(iconClass, 'text-blue-500')} />;
+    case 'minimax':
+      return <Sparkles className={cn(iconClass, 'text-teal-600')} />;
     case 'mock':
       return <FlaskConical className={cn(iconClass, 'text-gray-500')} />;
     default:

--- a/edgequake_webui/src/components/models/model-selector.tsx
+++ b/edgequake_webui/src/components/models/model-selector.tsx
@@ -119,6 +119,8 @@ function getProviderIcon(providerId: string, className?: string) {
       return <Globe className={cn(iconClass, 'text-indigo-600')} />;
     case 'azure':
       return <Cloud className={cn(iconClass, 'text-sky-600')} />;
+    case 'minimax':
+      return <Sparkles className={cn(iconClass, 'text-teal-600')} />;
     case 'mock':
       return <FlaskConical className={cn(iconClass, 'text-gray-500')} />;
     default:

--- a/edgequake_webui/src/components/settings/provider-status-card.tsx
+++ b/edgequake_webui/src/components/settings/provider-status-card.tsx
@@ -148,7 +148,7 @@ export EDGEQUAKE_LLM_PROVIDER="azure"`,
         label: 'MiniMax Configuration',
         code: `export MINIMAX_API_KEY="..."
 export EDGEQUAKE_LLM_PROVIDER="minimax"
-export EDGEQUAKE_LLM_MODEL="MiniMax-M2.5"`,
+export EDGEQUAKE_LLM_MODEL="MiniMax-M2.7"`,
       },
     };
     return configs[providerName.toLowerCase()] || { label: 'Configuration', code: '' };

--- a/edgequake_webui/src/components/settings/provider-status-card.tsx
+++ b/edgequake_webui/src/components/settings/provider-status-card.tsx
@@ -78,6 +78,7 @@ export function ProviderStatusCard() {
       'xai': 'xAI',
       'openrouter': 'OpenRouter',
       'azure': 'Azure OpenAI',
+      'minimax': 'MiniMax',
       'mock': 'Mock (Development)',
     };
     return names[name.toLowerCase()] || name;
@@ -142,6 +143,12 @@ export EDGEQUAKE_LLM_MODEL="openai/gpt-4o-mini"`,
         code: `export AZURE_OPENAI_API_KEY="..."
 export AZURE_OPENAI_ENDPOINT="https://your-resource.openai.azure.com"
 export EDGEQUAKE_LLM_PROVIDER="azure"`,
+      },
+      'minimax': {
+        label: 'MiniMax Configuration',
+        code: `export MINIMAX_API_KEY="..."
+export EDGEQUAKE_LLM_PROVIDER="minimax"
+export EDGEQUAKE_LLM_MODEL="MiniMax-M2.5"`,
       },
     };
     return configs[providerName.toLowerCase()] || { label: 'Configuration', code: '' };

--- a/edgequake_webui/src/hooks/use-providers.ts
+++ b/edgequake_webui/src/hooks/use-providers.ts
@@ -129,6 +129,7 @@ export function getProviderDisplayName(providerId: string): string {
     xai: "xAI",
     openrouter: "OpenRouter",
     azure: "Azure OpenAI",
+    minimax: "MiniMax",
     mock: "Mock (Dev)",
   };
   return names[providerId.toLowerCase()] || providerId;
@@ -147,6 +148,7 @@ export function getProviderIconClass(providerId: string): string {
     xai: "text-slate-700",
     openrouter: "text-indigo-600",
     azure: "text-sky-600",
+    minimax: "text-teal-600",
     mock: "text-gray-500",
   };
   return icons[providerId.toLowerCase()] || "text-gray-500";


### PR DESCRIPTION
## Summary
- Add MiniMax as a new LLM provider via OpenAI-compatible API
- Include MiniMax-M2.7 (default), MiniMax-M2.7-highspeed, MiniMax-M2.5, and MiniMax-M2.5-highspeed models
- MiniMax-M2.7 is the latest flagship model with enhanced reasoning and coding capabilities

## Changes
- `edgequake/models.toml`: Add MiniMax provider configuration with 4 models (M2.7 + M2.5 families)
- `edgequake/crates/edgequake-api/src/provider_types.rs`: Register MiniMax provider with M2.7 as default
- `edgequake/crates/edgequake-api/src/safety_limits.rs`: Add MiniMax default model fallback
- `edgequake_webui/src/components/settings/provider-status-card.tsx`: MiniMax UI configuration
- `edgequake_webui/src/components/models/model-card.tsx`: MiniMax icon mapping
- `edgequake_webui/src/components/models/model-selector.tsx`: MiniMax selector icon
- `edgequake_webui/src/hooks/use-providers.ts`: MiniMax display name and styling
- `.env.example`: MiniMax configuration documentation
- `README.md`: Add MiniMax to architecture diagram
- `docs/operations/configuration.md`: MiniMax configuration docs

## Why
MiniMax-M2.7 is the latest flagship model with enhanced reasoning and coding. The OpenAI-compatible API makes integration seamless via the existing `openaicompatible` provider type.

## Testing
- TOML configuration validated
- All existing models retained as alternatives