### PR TITLE
fix(website): perfect responsiveness across mobile, tablet, and desktop

### DIFF
--- a/edgequake-website/src/components/sections/Architecture.astro
+++ b/edgequake-website/src/components/sections/Architecture.astro
@@ -18,10 +18,58 @@
     </div>
 
     <div class="mt-12 flex justify-center">
-      <div class="mkt-card w-full max-w-4xl overflow-x-auto rounded-xl p-8">
+      <div class="mkt-card w-full max-w-4xl rounded-xl p-4 sm:p-8">
+
+        <!-- Mobile pipeline: vertical steps (visible on xs/sm only) -->
+        <div class="sm:hidden">
+          <ol class="flex flex-col items-center gap-1">
+            {[
+              "Documents",
+              "Ingestion Pipeline",
+              "PostgreSQL Storage",
+              "Query Engine",
+              "REST API",
+            ].map((stage, i) => (
+              <li class="flex w-full flex-col items-center">
+                <div class="w-full rounded-lg border border-blue-500/70 bg-[#1e3a5f] px-4 py-3 text-center">
+                  <span class="text-sm font-semibold text-blue-300">{stage}</span>
+                </div>
+                {i < 4 && (
+                  <svg
+                    width="16"
+                    height="20"
+                    viewBox="0 0 16 20"
+                    aria-hidden="true"
+                  >
+                    <line
+                      x1="8"
+                      y1="0"
+                      x2="8"
+                      y2="14"
+                      stroke="#3b82f6"
+                      stroke-width="1.5"
+                    />
+                    <polygon points="2,12 8,20 14,12" fill="#3b82f6" />
+                  </svg>
+                )}
+              </li>
+            ))}
+          </ol>
+          <div class="mt-4 flex justify-center gap-4">
+            <span class="rounded-md border border-dashed border-zinc-500/60 px-3 py-1.5 text-xs text-zinc-400">
+              LLM Provider
+            </span>
+            <span class="rounded-md border border-dashed border-zinc-500/60 px-3 py-1.5 text-xs text-zinc-400">
+              Clients
+            </span>
+          </div>
+        </div>
+
+        <!-- Desktop/tablet pipeline: horizontal SVG (hidden on xs) -->
+        <div class="hidden sm:block overflow-x-auto">
         <svg
           viewBox="0 0 800 340"
-          class="w-full"
+          class="w-full min-w-[640px]"
           xmlns="http://www.w3.org/2000/svg"
         >
           <!-- Boxes -->
@@ -185,6 +233,7 @@
             </marker>
           </defs>
         </svg>
+        </div><!-- end hidden sm:block -->
 
         <p class="mt-6 text-sm leading-relaxed mkt-text-muted">
           The key idea is simple: ingest source material once, preserve

--- a/edgequake-website/src/components/sections/Hero.astro
+++ b/edgequake-website/src/components/sections/Hero.astro
@@ -27,11 +27,11 @@ const badges = [
   </div>
 
   <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
-    <div class="grid items-center gap-12 lg:grid-cols-2">
+    <div class="grid items-center gap-8 md:grid-cols-2 md:gap-12">
       <!-- Text -->
-      <div class="text-center lg:text-left">
+      <div class="text-center md:text-left">
         <div
-          class="flex flex-wrap items-center justify-center gap-2 lg:justify-start"
+          class="flex flex-wrap items-center justify-center gap-2 md:justify-start"
         >
           {
             badges.map((b) => (
@@ -43,25 +43,25 @@ const badges = [
         </div>
 
         <h1
-          class="mt-6 text-4xl font-extrabold tracking-tight mkt-text sm:text-5xl lg:text-6xl"
+          class="mt-6 text-4xl font-extrabold tracking-tight mkt-text sm:text-5xl md:text-5xl lg:text-6xl"
         >
           Graph-RAG.{" "}
           <span class="mkt-accent-text">Built to Ship.</span>
         </h1>
 
-        <p class="mt-6 max-w-xl text-lg mkt-text-muted mx-auto lg:mx-0">
+        <p class="mt-6 max-w-xl text-lg mkt-text-muted mx-auto md:mx-0">
           Turn PDFs, markdown, and raw text into lineage-aware knowledge graphs.
           Query with local, global, hybrid, naive, mix, and graph-aware
           retrieval. Run the full stack in Rust on PostgreSQL.
         </p>
 
-        <p class="mt-4 max-w-xl text-sm mkt-text-dim mx-auto lg:mx-0">
+        <p class="mt-4 max-w-xl text-sm mkt-text-dim mx-auto md:mx-0">
           Built for teams that want Graph-RAG quality without Python pipeline
           fragility, cloud lock-in, or opaque retrieval behavior.
         </p>
 
         <div
-          class="mt-8 flex flex-wrap items-center justify-center gap-4 lg:justify-start"
+          class="mt-8 flex flex-wrap items-center justify-center gap-4 md:justify-start"
         >
           <a
             href="/docs/getting-started/"
@@ -103,7 +103,7 @@ const badges = [
         </div>
 
         <div
-          class="mt-6 flex flex-wrap items-center justify-center gap-x-6 gap-y-2 text-sm lg:justify-start"
+          class="mt-6 flex flex-wrap items-center justify-center gap-x-6 gap-y-2 text-sm md:justify-start"
         >
           <a
             href="/docs/getting-started/"
@@ -126,9 +126,9 @@ const badges = [
         </div>
       </div>
 
-      <!-- Graph Animation -->
-      <div class="relative hidden lg:block">
-        <div class="aspect-square w-full max-w-lg mx-auto">
+      <!-- Graph Animation (tablet + desktop) -->
+      <div class="relative hidden md:block">
+        <div class="aspect-square w-full max-w-sm mx-auto lg:max-w-lg">
           <GraphAnimation />
         </div>
       </div>

--- a/edgequake-website/src/components/sections/QuickStart.astro
+++ b/edgequake-website/src/components/sections/QuickStart.astro
@@ -114,7 +114,7 @@ curl -X POST http://localhost:8080/query \\
             tabindex="0"
             class={`relative ${i === 0 ? "" : "hidden"}`}
           >
-            <div class="mkt-code-showcase rounded-b-2xl border border-t-0 p-5 sm:p-6">
+            <div class="mkt-code-showcase rounded-b-2xl border border-t-0 p-4 sm:p-6 overflow-x-auto">
               <div class="mb-4 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
                 <p class="text-sm mkt-text-secondary">{tab.summary}</p>
                 <span class="mkt-badge inline-flex w-fit items-center rounded-full px-3 py-1 text-xs font-semibold uppercase tracking-[0.18em]">

--- a/edgequake-website/src/styles/global.css
+++ b/edgequake-website/src/styles/global.css
@@ -301,6 +301,12 @@
     margin: 0;
   }
 
+  /* Ensure code blocks scroll horizontally on narrow screens */
+  .mkt-code-showcase pre {
+    overflow-x: auto;
+    max-width: 100%;
+  }
+
   .mkt-form-field {
     width: 100%;
     border-radius: 0.875rem;


### PR DESCRIPTION
## Summary

Full responsiveness audit & fixes for the EdgeQuake marketing website across three viewport sizes (375px mobile, 768px tablet, 1440px desktop).

## Issues Fixed

### 🔴 Critical — Architecture diagram clipped on mobile
- Added a mobile-first vertical pipeline list (`sm:hidden`) for xs screens (<640px)
- Preserves the horizontal SVG diagram for sm+ screens inside `hidden sm:block overflow-x-auto`
- Users on mobile now see: Documents → Ingestion Pipeline → PostgreSQL Storage → Query Engine → REST API as a readable vertical flow

### 🟡 Moderate — Hero section empty whitespace on tablet  
- Graph animation was `hidden lg:block` (invisible on 768-1023px tablet)
- Changed grid to `md:grid-cols-2` so hero has 2-column layout from 768px+
- Graph animation now visible at `md:block` (768px+) with `max-w-sm` on tablet, `lg:max-w-lg` on desktop
- Updated all hero text alignment classes from `lg:text-left` → `md:text-left` to match the grid change

### 🟢 Minor — QuickStart code block overflow on mobile
- Added `overflow-x-auto` to the code panel container in `QuickStart.astro`  
- Added `overflow-x: auto; max-width: 100%` to `.mkt-code-showcase pre` in `global.css`

## Files Changed

- `src/components/sections/Architecture.astro` — mobile vertical pipeline list
- `src/components/sections/Hero.astro` — tablet 2-col grid, md breakpoints
- `src/components/sections/QuickStart.astro` — overflow-x-auto on code container
- `src/styles/global.css` — pre overflow fix

## Verification

All pages verified with Playwright at 3 viewports:
- ✅ Home (375px mobile) — vertical pipeline visible, no clipping
- ✅ Home (768px tablet) — hero shows graph animation in 2-col, architecture shows SVG
- ✅ Home (1440px desktop) — unchanged look and feel
- ✅ Demo, Enterprise, Ecosystem, Contact — single-col grids on mobile ✓