### PR TITLE
fix: OODA 3 — crate version, schema version, OG alt, demo query URL

### DIFF
--- a/edgequake-website/src/components/sections/Ecosystem.astro
+++ b/edgequake-website/src/components/sections/Ecosystem.astro
@@ -36,7 +36,7 @@ const crates = [
   },
   {
     name: "edgequake-llm",
-    version: "0.3.0",
+    version: "0.7.0",
     description:
       "Abstracts LLM providers so teams can move between OpenAI, Ollama, LM Studio, and mocks without rewriting the stack.",
   },

--- a/edgequake-website/src/layouts/MarketingLayout.astro
+++ b/edgequake-website/src/layouts/MarketingLayout.astro
@@ -15,7 +15,7 @@ const {
   title,
   description = "Graph-RAG framework built in Rust. Turn documents into knowledge graphs, query with 6 modes, 10x faster than Python RAG.",
   ogImage = "/og-default.png",
-  ogImageAlt = "EdgeQuake – Graph-RAG Built for Speed. Dark card showing the EdgeQuake logo, hero headline, knowledge graph visualization, and three metric badges: 10x faster, 6 query modes, PostgreSQL.",
+  ogImageAlt = "EdgeQuake – Graph-RAG Built to Ship. Dark card showing the EdgeQuake logo, hero headline, knowledge graph visualization, and three metric badges: 10x faster, 6 query modes, PostgreSQL.",
   noIndex = false,
 } = Astro.props;
 
@@ -84,7 +84,7 @@ const schema = {
         height: 630,
         caption: "EdgeQuake Graph-RAG framework social preview",
       },
-      softwareVersion: "0.4.0",
+      softwareVersion: "0.7.0",
       programmingLanguage: ["Rust", "TypeScript"],
       keywords: "graph-rag, knowledge-graph, rust, llm, postgresql, rag, ai, nlp",
       offers: {

--- a/edgequake-website/src/pages/demo.astro
+++ b/edgequake-website/src/pages/demo.astro
@@ -105,7 +105,7 @@ import MarketingLayout from "../layouts/MarketingLayout.astro";
                 </p>
                 <div class="mkt-code-surface mt-4 rounded-lg p-3">
                   <code class="text-sm mkt-text-secondary"
-                    >http://localhost:8080/health</code
+                    >http://localhost:3000</code
                   >
                 </div>
               </div>


### PR DESCRIPTION
## OODA 3 — Accuracy Fixes

### Changes
- **Ecosystem.astro**: Fix `edgequake-llm` version `0.3.0` → `0.7.0` (matches workspace and all other crates)
- **MarketingLayout.astro**: Update JSON-LD `softwareVersion` from `0.4.0` → `0.7.0` (matches VERSION file)
- **MarketingLayout.astro**: Update `ogImageAlt` from 'Built for Speed' → 'Built to Ship' (matches current H1 hero headline)
- **demo.astro**: Fix Step 3 'Query the graph' code snippet — change `http://localhost:8080/health` (health check) to `http://localhost:3000` (the actual web UI for querying)

### Why
Each of these was a factual inaccuracy that could erode trust with technical users who notice version mismatches or try the demo workflow.