### PR TITLE
fix: OODA 4 — docs version accuracy

### DIFF
--- a/docs/api-reference/rest-api.md
+++ b/docs/api-reference/rest-api.md
@@ -4,7 +4,7 @@ title: 'EdgeQuake REST API Reference'
 
 # EdgeQuake REST API Reference
 
-> **Version**: 0.1.0  
+> **Version**: 0.7.0  
 > **Base URL**: `http://localhost:8080/api/v1`  
 > **OpenAPI**: Available at `/api-docs/openapi.json`
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 ---
 title: Documentation
-description: Complete documentation for EdgeQuake — the Graph-RAG framework built for speed.
+description: Complete documentation for EdgeQuake — the Graph-RAG framework Built to Ship.
 template: splash
 hero:
   title: EdgeQuake Documentation

--- a/docs/operations/configuration.md
+++ b/docs/operations/configuration.md
@@ -607,7 +607,7 @@ EdgeQuake validates configuration at startup:
 ```
 ╔══════════════════════════════════════════════════════════════╗
 ║                                                              ║
-║   ⚡ EdgeQuake v0.1.0                                         ║
+║   ⚡ EdgeQuake v0.7.0                                         ║
 ║                                                              ║
 ║   🐘 Storage: POSTGRESQL (persistent)
 ║   🌐 Server:  http://0.0.0.0:8080


### PR DESCRIPTION
## OODA 4 — Docs Version Accuracy

### Changes
- **docs/api-reference/rest-api.md**: Fix API version `0.1.0` → `0.7.0` (was stale since v0.1.0 release)
- **docs/operations/configuration.md**: Fix startup banner `v0.1.0` → `v0.7.0` (example output was stale)
- **docs/index.md**: Update description from 'built for speed' → 'Built to Ship' (consistency with hero headline)

### Why
Version mismatches in docs erode trust with technical users — a developer running EdgeQuake 0.7.0 who reads docs showing v0.1.0 will assume the docs are outdated.