### PR TITLE
fix: OODA 5 doc API examples v0.1.0 to v0.7.0

### DIFF
--- a/docs/api-reference/extended-api.md
+++ b/docs/api-reference/extended-api.md
@@ -40,7 +40,7 @@ curl http://localhost:8080/api/version
 
 ```json
 {
-  "version": "0.1.0"
+  "version": "0.7.0"
 }
 ```
 

--- a/docs/api-reference/rest-api.md
+++ b/docs/api-reference/rest-api.md
@@ -87,7 +87,7 @@ Deep health check with component status for monitoring dashboards.
 ```json
 {
   "status": "healthy",
-  "version": "0.1.0",
+  "version": "0.7.0",
   "storage_mode": "postgres",
   "workspace_id": "default",
   "components": {

--- a/docs/operations/monitoring.md
+++ b/docs/operations/monitoring.md
@@ -52,7 +52,7 @@ curl http://localhost:8080/health
 ```json
 {
   "status": "ok",
-  "version": "0.1.0",
+  "version": "0.7.0",
   "storage_mode": "postgresql"
 }
 ```

--- a/docs/tutorials/first-rag-app.md
+++ b/docs/tutorials/first-rag-app.md
@@ -59,7 +59,7 @@ curl http://localhost:8080/health
 Expected response:
 
 ```json
-{ "status": "ok", "version": "0.1.0", "storage_mode": "postgresql" }
+{ "status": "ok", "version": "0.7.0", "storage_mode": "postgresql" }
 ```
 
 ---


### PR DESCRIPTION
OODA 5: Update API response examples to v0.7.0 in rest-api.md, extended-api.md, monitoring.md, first-rag-app.md