### PR TITLE
fix: OODA 6 — stale version + remove in-memory storage refs

### DIFF
--- a/docs/concepts/knowledge-graph.md
+++ b/docs/concepts/knowledge-graph.md
@@ -112,12 +112,9 @@ EdgeQuake uses a hybrid storage architecture:
 
 ### Development Mode
 
-For rapid development, EdgeQuake also supports in-memory storage:
-
-```bash
-# Start with in-memory (no database required)
-cargo run -- --storage memory
-```
+> **Note:** In-memory storage was removed in v0.4.0. PostgreSQL is required
+> for all deployments, including development. See the
+> [installation guide](/docs/getting-started/installation/) for setup instructions.
 
 ---
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -233,7 +233,7 @@ Run these commands to verify your installation:
 ```bash
 # 1. Check backend health
 curl -s http://localhost:8080/health | jq
-# ✅ Expected: {"status":"ok","version":"0.1.0",...}
+# ✅ Expected: {"status":"ok","version":"0.7.0",...}
 
 # 2. Check API docs
 curl -s http://localhost:8080/api-docs/openapi.json | jq .info.title

--- a/docs/operations/deployment.md
+++ b/docs/operations/deployment.md
@@ -375,10 +375,10 @@ EdgeQuake automatically selects storage based on `DATABASE_URL`:
 │       │              • Apache AGE for graph                     │
 │       │              • Full multi-tenant support                │
 │       │                                                         │
-│       └── NO ──────▶ Memory Mode                                │
-│                      • Ephemeral (data lost on restart)         │
-│                      • For development/testing only             │
-│                      • No external dependencies                 │
+│       └── NO ──────▶ ❌ Error: DATABASE_URL required             │
+│                      • Server exits with code 1                 │
+│                      • Set DATABASE_URL to proceed              │
+│                      • In-memory mode removed in v0.4.0         │
 │                                                                 │
 └─────────────────────────────────────────────────────────────────┘
 ```


### PR DESCRIPTION
OODA 6: Fix stale version 0.1.0→0.7.0 in installation.md, remove deprecated in-memory storage from knowledge-graph.md, update deployment.md decision tree