### PR TITLE
fix: OODA 7 — update deprecated gpt-4o-mini to gpt-5-nano in tutorials

### DIFF
--- a/docs/tutorials/document-ingestion.md
+++ b/docs/tutorials/document-ingestion.md
@@ -781,7 +781,7 @@ curl "http://localhost:8080/api/v1/workspaces/$WORKSPACE_ID/metrics"
 **Solutions**:
 
 1. Increase worker threads: `WORKER_THREADS=8`
-2. Use faster LLM model (gpt-4o-mini)
+2. Use faster LLM model (gpt-5-nano)
 3. Reduce gleaning iterations
 4. Batch documents instead of sequential
 

--- a/docs/tutorials/migration-from-lightrag.md
+++ b/docs/tutorials/migration-from-lightrag.md
@@ -115,7 +115,7 @@ curl -X POST http://localhost:8080/api/v1/tenants/default/workspaces \
     "name": "my-project",
     "slug": "my-project",
     "llm_provider": "openai",
-    "llm_model": "gpt-4o-mini"
+    "llm_model": "gpt-5-nano"
   }'
 
 # Returns workspace_id to use in subsequent requests
@@ -266,7 +266,7 @@ lightrag = LightRAG(
 # Environment variables
 export OPENAI_API_KEY="sk-..."
 export EDGEQUAKE_LLM_PROVIDER="openai"
-export EDGEQUAKE_LLM_MODEL="gpt-4o-mini"
+export EDGEQUAKE_LLM_MODEL="gpt-5-nano"
 export EDGEQUAKE_EMBEDDING_MODEL="text-embedding-3-small"
 
 # Or per-workspace via API
@@ -274,7 +274,7 @@ curl -X PUT http://localhost:8080/api/v1/workspaces/$WORKSPACE_ID \
   -H "Content-Type: application/json" \
   -d '{
     "llm_provider": "openai",
-    "llm_model": "gpt-4o-mini",
+    "llm_model": "gpt-5-nano",
     "embedding_model": "text-embedding-3-small"
   }'
 ```

--- a/docs/tutorials/multi-tenant.md
+++ b/docs/tutorials/multi-tenant.md
@@ -170,7 +170,7 @@ Server Defaults (models.toml)
 
 | Scenario               | Configuration                              |
 | ---------------------- | ------------------------------------------ |
-| Cost-conscious tenant  | Use `ollama` or `gpt-4o-mini`              |
+| Cost-conscious tenant  | Use `ollama` or `gpt-5-nano`              |
 | Premium tenant         | Use `gpt-4o` with `text-embedding-3-large` |
 | Compliance requirement | Use self-hosted Ollama                     |
 | Testing                | Use mock provider                          |
@@ -477,7 +477,7 @@ Examples:
 | Tier    | LLM          | Embedding              | Cost |
 | ------- | ------------ | ---------------------- | ---- |
 | Free    | Ollama local | Ollama local           | $0   |
-| Basic   | gpt-4o-mini  | text-embedding-3-small | $    |
+| Basic   | gpt-5-nano   | text-embedding-3-small | $    |
 | Premium | gpt-4o       | text-embedding-3-large | $$$  |
 
 ### 3. Quota Management


### PR DESCRIPTION
OODA 7: Replace deprecated gpt-4o-mini model references with gpt-5-nano in document-ingestion.md, multi-tenant.md, migration-from-lightrag.md