### PR TITLE
fix: OODA 9 — update gpt-4o-mini to gpt-5-nano in operations docs

### DIFF
--- a/docs/operations/configuration.md
+++ b/docs/operations/configuration.md
@@ -179,7 +179,7 @@ description = "OpenAI GPT models"
 
 # Model definitions within provider
 [[providers.models]]
-name = "gpt-4o-mini"
+name = "gpt-5-nano"
 display_name = "GPT-4o Mini"
 model_type = "llm"                   # or "embedding"
 description = "Cost-effective model"
@@ -242,7 +242,7 @@ enabled = true
 priority = 10
 
 [[providers.models]]
-name = "gpt-4o-mini"
+name = "gpt-5-nano"
 display_name = "GPT-4o Mini"
 model_type = "llm"
 tags = ["recommended"]
@@ -312,7 +312,7 @@ enabled = true
 priority = 5
 
 [[providers.models]]
-name = "gpt-4o-mini"  # Your deployment name
+name = "gpt-5-nano"  # Your deployment name
 display_name = "Azure GPT-4o Mini"
 model_type = "llm"
 
@@ -437,7 +437,7 @@ enabled = true
 priority = 6
 
 [[providers.models]]
-name = "openai/gpt-4o-mini"
+name = "openai/gpt-5-nano"
 display_name = "OpenRouter GPT-4o Mini"
 model_type = "llm"
 tags = ["recommended"]
@@ -473,7 +473,7 @@ curl -X POST http://localhost:8080/api/v1/query \
     "query": "What is quantum computing?",
     "mode": "hybrid",
     "llm_provider": "openai",
-    "llm_model": "gpt-4o-mini"
+    "llm_model": "gpt-5-nano"
   }'
 ```
 

--- a/docs/operations/performance-tuning.md
+++ b/docs/operations/performance-tuning.md
@@ -45,14 +45,14 @@ This guide covers performance tuning strategies for EdgeQuake deployments.
 | Model                | Latency (TTFT) | Cost | Quality   |
 | -------------------- | -------------- | ---- | --------- |
 | gpt-4o               | 500ms          | $$$$ | Excellent |
-| gpt-4o-mini          | 200ms          | $    | Very Good |
+| gpt-5-nano          | 200ms          | $    | Very Good |
 | gemma3:12b (Ollama)  | 100ms          | Free | Good      |
 | llama3.2:3b (Ollama) | 50ms           | Free | Moderate  |
 
-**Recommendation**: Use `gpt-4o-mini` for production (best latency/quality ratio)
+**Recommendation**: Use `gpt-5-nano` for production (best latency/quality ratio)
 
 ```bash
-export EDGEQUAKE_LLM_MODEL=gpt-4o-mini
+export EDGEQUAKE_LLM_MODEL=gpt-5-nano
 ```
 
 ### 2. Reduce Context Size
@@ -347,7 +347,7 @@ ollama pull gemma3:12b-q4_K_M
 │  │ Total (500 tokens): 5.05s                                │   │
 │  └──────────────────────────────────────────────────────────┘   │
 │                                                                 │
-│  OpenAI gpt-4o-mini:                                            │
+│  OpenAI gpt-5-nano:                                            │
 │  ┌──────────────────────────────────────────────────────────┐   │
 │  │ Time to First Token: 200ms                               │   │
 │  │ Token Generation: 80 tokens/sec                          │   │
@@ -479,7 +479,7 @@ cargo bench
 
 ### Quick Wins
 
-- [ ] Using gpt-4o-mini (or faster model)
+- [ ] Using gpt-5-nano (or faster model)
 - [ ] Context size reduced (max_chunks ≤ 10)
 - [ ] Appropriate query mode selected
 - [ ] Streaming enabled for chat


### PR DESCRIPTION
OODA 9: Replace gpt-4o-mini with gpt-5-nano in performance-tuning.md and configuration.md