### PR TITLE
fix: OODA 10 — update remaining gpt-4o-mini to gpt-5-nano

### DIFF
--- a/docs/api-reference/extended-api.md
+++ b/docs/api-reference/extended-api.md
@@ -394,7 +394,7 @@ curl http://localhost:8080/api/v1/pipeline/costs/pricing
 {
   "models": [
     {
-      "id": "gpt-4o-mini",
+      "id": "gpt-5-nano",
       "provider": "openai",
       "input_cost_per_1k_tokens": 0.00015,
       "output_cost_per_1k_tokens": 0.0006
@@ -423,7 +423,7 @@ curl -X POST http://localhost:8080/api/v1/pipeline/costs/estimate \
   -H "Content-Type: application/json" \
   -d '{
     "content_length": 50000,
-    "llm_model": "gpt-4o-mini",
+    "llm_model": "gpt-5-nano",
     "embedding_model": "text-embedding-3-small"
   }'
 ```
@@ -669,7 +669,7 @@ curl -X POST http://localhost:8080/api/v1/tenants/tenant-uuid/workspaces \
     "name": "Research Project",
     "slug": "research",
     "llm_provider": "openai",
-    "llm_model": "gpt-4o-mini"
+    "llm_model": "gpt-5-nano"
   }'
 ```
 

--- a/docs/api-reference/rest-api.md
+++ b/docs/api-reference/rest-api.md
@@ -635,7 +635,7 @@ curl -X POST http://localhost:8080/api/v1/workspaces \
     "description": "Workspace for research documents",
     "embedding_model": "text-embedding-3-small",
     "embedding_dimension": 1536,
-    "llm_model": "gpt-4o-mini"
+    "llm_model": "gpt-5-nano"
   }'
 ```
 
@@ -699,7 +699,7 @@ curl http://localhost:8080/api/v1/models
 {
   "models": [
     {
-      "id": "gpt-4o-mini",
+      "id": "gpt-5-nano",
       "name": "GPT-4o Mini",
       "provider": "openai",
       "context_length": 128000,

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -115,8 +115,8 @@ EdgeQuake itself is **free and open source**. Costs come from:
 1. **Use cheaper models**:
 
    ```bash
-   # gpt-4o-mini is 10x cheaper than gpt-4o
-   EDGEQUAKE_LLM_MODEL=gpt-4o-mini
+   # gpt-5-nano is 10x cheaper than gpt-4o
+   EDGEQUAKE_LLM_MODEL=gpt-5-nano
    ```
 
 2. **Use local LLM** (Ollama):
@@ -133,7 +133,7 @@ EdgeQuake itself is **free and open source**. Costs come from:
 
 OpenAI offers free credits for new accounts ($5-$18 depending on promotion). After that:
 
-- gpt-4o-mini: ~$0.00015/1K input tokens
+- gpt-5-nano: ~$0.00015/1K input tokens
 - text-embedding-3-small: ~$0.00002/1K tokens
 
 ---
@@ -163,7 +163,7 @@ EdgeQuake handles:
 
 1. **Use `naive` mode** for simple queries (vector-only, no graph)
 2. **Reduce `max_chunks`** from 20 to 5-10
-3. **Use faster LLM** (gpt-4o-mini vs gpt-4o)
+3. **Use faster LLM** (gpt-5-nano vs gpt-4o)
 4. **Pre-warm embeddings** with test query
 5. **Use GPU** for Ollama embedding
 

--- a/docs/integrations/langchain.md
+++ b/docs/integrations/langchain.md
@@ -267,7 +267,7 @@ retriever = EdgeQuakeRetriever(
     query_mode="hybrid",
 )
 
-llm = ChatOpenAI(model="gpt-4o-mini", temperature=0)
+llm = ChatOpenAI(model="gpt-5-nano", temperature=0)
 
 # Prompt template
 template = """Answer the question based on the following context:
@@ -367,7 +367,7 @@ knowledge_tool = Tool(
 )
 
 # Create agent
-llm = ChatOpenAI(model="gpt-4o-mini", temperature=0)
+llm = ChatOpenAI(model="gpt-5-nano", temperature=0)
 
 prompt = ChatPromptTemplate.from_messages([
     ("system", "You are a helpful assistant with access to a knowledge base."),
@@ -419,7 +419,7 @@ def generate(state: GraphState) -> GraphState:
     """Generate response using context."""
     from langchain_openai import ChatOpenAI
 
-    llm = ChatOpenAI(model="gpt-4o-mini")
+    llm = ChatOpenAI(model="gpt-5-nano")
 
     prompt = f"""Based on the following context, answer the question.
 

--- a/docs/troubleshooting/common-issues.md
+++ b/docs/troubleshooting/common-issues.md
@@ -826,7 +826,7 @@ RUST_LOG="edgequake=debug" cargo run
 ```bash
 # Use faster model
 curl -X POST "http://localhost:8080/api/v1/query" \
-  -d '{"query": "test", "llm_model": "gpt-4o-mini"}'
+  -d '{"query": "test", "llm_model": "gpt-5-nano"}'
 
 # Reduce context size
 curl -X POST "http://localhost:8080/api/v1/query" \


### PR DESCRIPTION
OODA 10: Replace gpt-4o-mini with gpt-5-nano in API refs, FAQ, troubleshooting, LangChain integration docs