### PR TITLE
fix: OODA 11 — remove remaining in-memory storage references

### DIFF
--- a/docs/architecture/crates/README.md
+++ b/docs/architecture/crates/README.md
@@ -519,7 +519,6 @@ Key feature flags across crates:
 | Flag       | Crate    | Description               |
 | ---------- | -------- | ------------------------- |
 | `postgres` | storage  | Enable PostgreSQL backend |
-| `memory`   | storage  | Enable in-memory backend  |
 | `openai`   | llm      | Enable OpenAI provider    |
 | `ollama`   | llm      | Enable Ollama provider    |
 | `pdf`      | pipeline | Enable PDF processing     |

--- a/docs/operations/configuration.md
+++ b/docs/operations/configuration.md
@@ -566,7 +566,8 @@ DATABASE_URL="postgresql://user:pass@pgbouncer:6432/edgequake?application_name=e
 ### Development (Minimal)
 
 ```bash
-# Just run with defaults (in-memory, mock LLM if no key)
+# Requires DATABASE_URL — set via .env or environment
+# Mock LLM if no OPENAI_API_KEY is set
 cargo run
 ```
 

--- a/docs/troubleshooting/common-issues.md
+++ b/docs/troubleshooting/common-issues.md
@@ -1041,7 +1041,7 @@ curl -I http://localhost:8080/health
 1. Check this troubleshooting guide
 2. Check logs for specific error messages
 3. Verify environment variables are set
-4. Try with minimal configuration (in-memory, mock LLM)
+4. Try with minimal configuration (PostgreSQL + mock LLM)
 
 ### Debug Mode
 


### PR DESCRIPTION
OODA 11: Remove deprecated in-memory storage refs from configuration.md, common-issues.md, architecture/crates/README.md