### PR TITLE
fix: OODA 12 — add robots.txt + fix Starlight description

### DIFF
--- a/edgequake-website/astro.config.mjs
+++ b/edgequake-website/astro.config.mjs
@@ -13,7 +13,7 @@ export default defineConfig({
     starlight({
       title: "EdgeQuake",
       description:
-        "Graph-RAG framework built for speed. Knowledge graph engine powered by Rust.",
+        "Graph-RAG framework — Built to Ship. Knowledge graph engine powered by Rust.",
       head: [
         // Default OG image for all docs pages (PNG required for Twitter/LinkedIn/Facebook)
         {

--- a/edgequake-website/public/robots.txt
+++ b/edgequake-website/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://edgequake.com/sitemap-index.xml


### PR DESCRIPTION
- Force-add robots.txt to git (was gitignored by root .gitignore line 125)
- Fix Starlight description: 'built for speed' → 'Built to Ship' (consistent branding)
- robots.txt references sitemap-index.xml for search engine discovery