### PR TITLE
fix: OODA 13 — normalize YAML frontmatter quotes and table formatting in docs

### DIFF
--- a/docs/api-reference/rest-api.md
+++ b/docs/api-reference/rest-api.md
@@ -1,5 +1,5 @@
 ---
-title: 'EdgeQuake REST API Reference'
+title: "EdgeQuake REST API Reference"
 ---
 
 # EdgeQuake REST API Reference
@@ -202,14 +202,14 @@ List all documents in the workspace.
 
 **Query Parameters**:
 
-| Parameter          | Type    | Default | Description                                      |
-| ------------------ | ------- | ------- | ------------------------------------------------ |
-| `limit`            | integer | 50      | Max documents to return                          |
-| `offset`           | integer | 0       | Pagination offset                                |
-| `status`           | string  | all     | Filter by status (processing, completed, failed) |
-| `date_from`        | string  | null    | ISO 8601 date. Only include documents created on or after this date |
+| Parameter          | Type    | Default | Description                                                          |
+| ------------------ | ------- | ------- | -------------------------------------------------------------------- |
+| `limit`            | integer | 50      | Max documents to return                                              |
+| `offset`           | integer | 0       | Pagination offset                                                    |
+| `status`           | string  | all     | Filter by status (processing, completed, failed)                     |
+| `date_from`        | string  | null    | ISO 8601 date. Only include documents created on or after this date  |
 | `date_to`          | string  | null    | ISO 8601 date. Only include documents created on or before this date |
-| `document_pattern` | string  | null    | Comma-separated title search terms (case-insensitive, OR logic) |
+| `document_pattern` | string  | null    | Comma-separated title search terms (case-insensitive, OR logic)      |
 
 ```bash
 curl http://localhost:8080/api/v1/documents?limit=10&status=completed \
@@ -299,24 +299,24 @@ curl -X POST http://localhost:8080/api/v1/query \
 
 **Request Body**:
 
-| Field                  | Type    | Default  | Description                                  |
-| ---------------------- | ------- | -------- | -------------------------------------------- |
-| `query`                | string  | required | The question to answer                       |
-| `mode`                 | string  | "hybrid" | Query mode (see below)                       |
-| `context_only`         | boolean | false    | Return only retrieved context, no LLM answer |
-| `prompt_only`          | boolean | false    | Return formatted prompt for debugging        |
-| `enable_rerank`        | boolean | true     | Apply reranking to improve relevance         |
-| `rerank_top_k`         | integer | 5        | Number of top chunks after reranking         |
-| `conversation_history` | array   | null     | Previous messages for multi-turn context     |
-| `system_prompt`        | string  | null     | Custom instructions prepended to LLM context |
+| Field                  | Type    | Default  | Description                                         |
+| ---------------------- | ------- | -------- | --------------------------------------------------- |
+| `query`                | string  | required | The question to answer                              |
+| `mode`                 | string  | "hybrid" | Query mode (see below)                              |
+| `context_only`         | boolean | false    | Return only retrieved context, no LLM answer        |
+| `prompt_only`          | boolean | false    | Return formatted prompt for debugging               |
+| `enable_rerank`        | boolean | true     | Apply reranking to improve relevance                |
+| `rerank_top_k`         | integer | 5        | Number of top chunks after reranking                |
+| `conversation_history` | array   | null     | Previous messages for multi-turn context            |
+| `system_prompt`        | string  | null     | Custom instructions prepended to LLM context        |
 | `document_filter`      | object  | null     | Optional filter to restrict RAG context (see below) |
 
 **Document Filter Object**:
 
-| Field              | Type   | Description                                          |
-| ------------------ | ------ | ---------------------------------------------------- |
-| `date_from`        | string | ISO 8601 date. Only include documents created on or after this date |
-| `date_to`          | string | ISO 8601 date. Only include documents created on or before this date |
+| Field              | Type   | Description                                                                  |
+| ------------------ | ------ | ---------------------------------------------------------------------------- |
+| `date_from`        | string | ISO 8601 date. Only include documents created on or after this date          |
+| `date_to`          | string | ISO 8601 date. Only include documents created on or before this date         |
 | `document_pattern` | string | Comma-separated terms. Matches document titles case-insensitively (OR logic) |
 
 All filter fields are optional and AND-ed together. Omit `document_filter` entirely to query all documents.
@@ -392,15 +392,15 @@ curl -X POST http://localhost:8080/api/v1/query/stream \
 
 **Request Parameters**:
 
-| Field             | Type   | Required | Description                                                |
-|-------------------|--------|----------|------------------------------------------------------------|
-| `query`           | string | yes      | Natural language query                                     |
-| `mode`            | string | no       | Query mode: `hybrid`, `local`, `global`, `naive`, `mix`    |
-| `system_prompt`   | string | no       | System prompt extension                                    |
-| `document_filter` | object | no       | Document filter to scope RAG context (SPEC-005)            |
-| `llm_provider`    | string | no       | LLM provider override (e.g., `openai`, `ollama`)           |
-| `llm_model`       | string | no       | LLM model override (e.g., `gpt-5-nano`)                   |
-| `stream_format`   | string | no       | `v1` for raw text (backward compat), `v2` for structured   |
+| Field             | Type   | Required | Description                                              |
+| ----------------- | ------ | -------- | -------------------------------------------------------- |
+| `query`           | string | yes      | Natural language query                                   |
+| `mode`            | string | no       | Query mode: `hybrid`, `local`, `global`, `naive`, `mix`  |
+| `system_prompt`   | string | no       | System prompt extension                                  |
+| `document_filter` | object | no       | Document filter to scope RAG context (SPEC-005)          |
+| `llm_provider`    | string | no       | LLM provider override (e.g., `openai`, `ollama`)         |
+| `llm_model`       | string | no       | LLM model override (e.g., `gpt-5-nano`)                  |
+| `stream_format`   | string | no       | `v1` for raw text (backward compat), `v2` for structured |
 
 **SSE Events (v2 format — default)**:
 
@@ -452,13 +452,13 @@ curl -X POST http://localhost:8080/api/v1/chat/completions \
 
 **Request Body**:
 
-| Field             | Type    | Default  | Description                                    |
-| ----------------- | ------- | -------- | ---------------------------------------------- |
-| `message`         | string  | required | User message                                   |
-| `conversation_id` | string  | null     | Existing conversation ID (creates new if null) |
-| `mode`            | string  | "hybrid" | Query mode                                     |
-| `stream`          | boolean | false    | Enable SSE streaming                           |
-| `system_prompt`   | string  | null     | Custom instructions prepended to LLM context   |
+| Field             | Type    | Default  | Description                                                        |
+| ----------------- | ------- | -------- | ------------------------------------------------------------------ |
+| `message`         | string  | required | User message                                                       |
+| `conversation_id` | string  | null     | Existing conversation ID (creates new if null)                     |
+| `mode`            | string  | "hybrid" | Query mode                                                         |
+| `stream`          | boolean | false    | Enable SSE streaming                                               |
+| `system_prompt`   | string  | null     | Custom instructions prepended to LLM context                       |
 | `document_filter` | object  | null     | Optional filter to restrict RAG context (same schema as Query API) |
 
 **Response** (Non-streaming):

--- a/docs/architecture/crates/README.md
+++ b/docs/architecture/crates/README.md
@@ -1,5 +1,5 @@
 ---
-title: 'Architecture: Crate Reference'
+title: "Architecture: Crate Reference"
 sidebar:
   hidden: true
 ---

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,5 +1,5 @@
 ---
-title: 'Frequently Asked Questions'
+title: "Frequently Asked Questions"
 ---
 
 # Frequently Asked Questions
@@ -254,14 +254,14 @@ EdgeQuake doesn't include built-in authentication. Secure with:
 
 ### What query modes are available?
 
-| Mode     | Use Case                          |
-| -------- | --------------------------------- |
-| `naive`  | Simple vector search              |
-| `local`  | Entity-focused queries            |
-| `global` | High-level summaries              |
-| `hybrid` | Best of all modes (DEFAULT)       |
-| `mix`    | Custom weighted blend             |
-| `bypass` | Direct LLM, no retrieval (debug)  |
+| Mode     | Use Case                         |
+| -------- | -------------------------------- |
+| `naive`  | Simple vector search             |
+| `local`  | Entity-focused queries           |
+| `global` | High-level summaries             |
+| `hybrid` | Best of all modes (DEFAULT)      |
+| `mix`    | Custom weighted blend            |
+| `bypass` | Direct LLM, no retrieval (debug) |
 
 ---
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -1,5 +1,5 @@
 ---
-title: 'Installation Guide'
+title: "Installation Guide"
 ---
 
 # Installation Guide
@@ -201,7 +201,7 @@ EdgeQuake uses PostgreSQL as its storage backend for all modes (since v0.4.0):
 │         │                                     │            │
 │         └─────────────────────────────────────┘            │
 │                                                             │
-│  DATABASE_URL required for all server modes.               │ 
+│  DATABASE_URL required for all server modes.               │
 │  Use Docker for the easiest PostgreSQL setup.              │
 └─────────────────────────────────────────────────────────────┘
 ```

--- a/docs/operations/configuration.md
+++ b/docs/operations/configuration.md
@@ -1,5 +1,5 @@
 ---
-title: 'Configuration Reference'
+title: "Configuration Reference"
 ---
 
 # Configuration Reference
@@ -122,10 +122,10 @@ DATABASE_URL="postgresql://edgequake:pass@pgbouncer:6432/edgequake"
 
 #### MiniMax
 
-| Variable            | Type   | Default                      | Description                                          |
-| ------------------- | ------ | ---------------------------- | ---------------------------------------------------- |
-| `MINIMAX_API_KEY`   | String | None                         | MiniMax API key (required)                           |
-| `MINIMAX_BASE_URL`  | String | `https://api.minimax.io/v1`  | API endpoint (use `https://api.minimaxi.com/v1` for China) |
+| Variable           | Type   | Default                     | Description                                                |
+| ------------------ | ------ | --------------------------- | ---------------------------------------------------------- |
+| `MINIMAX_API_KEY`  | String | None                        | MiniMax API key (required)                                 |
+| `MINIMAX_BASE_URL` | String | `https://api.minimax.io/v1` | API endpoint (use `https://api.minimaxi.com/v1` for China) |
 
 #### Azure OpenAI
 

--- a/docs/tutorials/document-ingestion.md
+++ b/docs/tutorials/document-ingestion.md
@@ -1,5 +1,5 @@
 ---
-title: 'Tutorial: Document Ingestion Deep-Dive'
+title: "Tutorial: Document Ingestion Deep-Dive"
 ---
 
 # Tutorial: Document Ingestion Deep-Dive
@@ -21,7 +21,7 @@ This tutorial explores EdgeQuake's document processing pipeline in depth, coveri
 │                   DOCUMENT INGESTION PIPELINE                   │
 ├─────────────────────────────────────────────────────────────────┤
 │                                                                 │
-│  Document ─────────────────────────────────────────────────────▶ 
+│  Document ─────────────────────────────────────────────────────▶
 │      │                                                          │
 │      ▼                                                          │
 │  ┌─────────────┐                                                │
@@ -405,12 +405,12 @@ Different document types benefit from different chunking approaches:
 
 ### Strategy Comparison
 
-| Strategy      | Best For             | Chunk Size    |
-| ------------- | -------------------- | ------------- |
+| Strategy      | Best For             | Chunk Size            |
+| ------------- | -------------------- | --------------------- |
 | **Fixed**     | General text         | 1200 tokens (default) |
-| **Semantic**  | Well-structured docs | Variable      |
-| **Paragraph** | Articles, blogs      | 1 paragraph   |
-| **Sentence**  | Q&A, definitions     | 1-3 sentences |
+| **Semantic**  | Well-structured docs | Variable              |
+| **Paragraph** | Articles, blogs      | 1 paragraph           |
+| **Sentence**  | Q&A, definitions     | 1-3 sentences         |
 
 ### Using Custom Chunk Size
 
@@ -737,12 +737,12 @@ curl "http://localhost:8080/api/v1/workspaces/$WORKSPACE_ID/metrics"
 
 ### Chunk Size Guidelines
 
-| Document Type    | Recommended Size |
-| ---------------- | ---------------- |
+| Document Type    | Recommended Size      |
+| ---------------- | --------------------- |
 | General articles | 1200 tokens (default) |
-| Technical docs   | 1200 tokens      |
-| Short Q&A        | 512 tokens       |
-| Legal contracts  | Paragraph-based  |
+| Technical docs   | 1200 tokens           |
+| Short Q&A        | 512 tokens            |
+| Legal contracts  | Paragraph-based       |
 
 ### Entity Extraction Tips
 
@@ -802,11 +802,11 @@ curl "http://localhost:8080/api/v1/workspaces/$WORKSPACE_ID/metrics"
 
 ## Next Steps
 
-| Tutorial                                    | Description                     |
-| ------------------------------------------- | ------------------------------- |
+| Tutorial                                                  | Description                     |
+| --------------------------------------------------------- | ------------------------------- |
 | [Query Optimization](/docs/tutorials/query-optimization/) | Choosing and tuning query modes |
 | [Multi-Tenant Setup](/docs/tutorials/multi-tenant/)       | Building a SaaS application     |
-| [Custom Entity Types](/docs/concepts/entity-extraction/)   | Domain-specific extraction      |
+| [Custom Entity Types](/docs/concepts/entity-extraction/)  | Domain-specific extraction      |
 
 ---
 

--- a/docs/tutorials/first-rag-app.md
+++ b/docs/tutorials/first-rag-app.md
@@ -1,5 +1,5 @@
 ---
-title: 'Tutorial: Building Your First RAG App'
+title: "Tutorial: Building Your First RAG App"
 ---
 
 # Tutorial: Building Your First RAG App
@@ -462,12 +462,12 @@ curl -X DELETE "http://localhost:8080/api/v1/workspaces/$WORKSPACE_ID"
 
 ## Next Steps
 
-| Tutorial                                              | Description                    |
-| ----------------------------------------------------- | ------------------------------ |
+| Tutorial                                                            | Description                    |
+| ------------------------------------------------------------------- | ------------------------------ |
 | [Document Ingestion Deep-Dive](/docs/tutorials/document-ingestion/) | Custom chunking and processing |
 | [Query Optimization](/docs/tutorials/query-optimization/)           | Choosing the right mode        |
 | [Multi-Tenant Setup](/docs/tutorials/multi-tenant/)                 | Building a SaaS app            |
-| [Custom Entity Types](/docs/concepts/entity-extraction/)             | Domain-specific extraction     |
+| [Custom Entity Types](/docs/concepts/entity-extraction/)            | Domain-specific extraction     |
 
 ---
 

--- a/docs/tutorials/multi-tenant.md
+++ b/docs/tutorials/multi-tenant.md
@@ -1,5 +1,5 @@
 ---
-title: 'Tutorial: Multi-Tenant Setup'
+title: "Tutorial: Multi-Tenant Setup"
 ---
 
 # Tutorial: Multi-Tenant Setup
@@ -170,7 +170,7 @@ Server Defaults (models.toml)
 
 | Scenario               | Configuration                              |
 | ---------------------- | ------------------------------------------ |
-| Cost-conscious tenant  | Use `ollama` or `gpt-5-nano`              |
+| Cost-conscious tenant  | Use `ollama` or `gpt-5-nano`               |
 | Premium tenant         | Use `gpt-4o` with `text-embedding-3-large` |
 | Compliance requirement | Use self-hosted Ollama                     |
 | Testing                | Use mock provider                          |
@@ -610,11 +610,11 @@ Increase quotas or upgrade tier.
 
 ## Next Steps
 
-| Tutorial                                  | Description                |
-| ----------------------------------------- | -------------------------- |
+| Tutorial                                                 | Description                |
+| -------------------------------------------------------- | -------------------------- |
 | [Custom Entity Types](/docs/concepts/entity-extraction/) | Domain-specific extraction |
-| [API Integration](/docs/integrations/custom-clients/)     | Building on EdgeQuake      |
-| [Scaling Guide](/docs/operations/deployment/)             | Growing your deployment    |
+| [API Integration](/docs/integrations/custom-clients/)    | Building on EdgeQuake      |
+| [Scaling Guide](/docs/operations/deployment/)            | Growing your deployment    |
 
 ---
 


### PR DESCRIPTION
Formatting changes applied by VS Code formatter to 8 doc files:
- YAML frontmatter: single quotes → double quotes (standard YAML style)
- Table column widths realigned for consistency
- Trailing whitespace removed

Files: rest-api.md, README.md (crates), faq.md, installation.md, configuration.md, document-ingestion.md, first-rag-app.md, multi-tenant.md