### PR TITLE
fix: stabilize PDF ingestion with writable PDFium cache

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -100,15 +100,10 @@ PORT=8080
 # =============================================================================
 # PDF Extraction Configuration (OODA-E2E-01)
 # =============================================================================
-# Path to libpdfium shared library for PDF text extraction.
-# Required for PDF upload processing. Without this, PDF extraction
-# falls back to MockBackend (returns empty content).
-#
-# Download from: https://github.com/bblanchon/pdfium-binaries/releases
-# Bundled with project at: edgequake/crates/edgequake-pdf/lib/lib/libpdfium.dylib
-#
-# The server will auto-discover the bundled library, but you can override:
-# PDFIUM_DYNAMIC_LIB_PATH=/path/to/libpdfium.dylib
+# Writable base directory for the bundled pdfium cache used by edgequake-pdf2md.
+# The runtime appends a versioned subdirectory under this base path.
+# Keep this on a filesystem the runtime user can write to.
+# PDFIUM_AUTO_CACHE_DIR=/tmp/edgequake-pdfium-cache
 
 # =============================================================================
 # Worker Configuration

--- a/edgequake/crates/edgequake-api/src/processor/mod.rs
+++ b/edgequake/crates/edgequake-api/src/processor/mod.rs
@@ -160,6 +160,14 @@ pub struct DocumentTaskProcessor {
 }
 
 impl DocumentTaskProcessor {
+    #[cfg(not(test))]
+    fn initialize_pdfium_auto_cache_dir() {
+        let _ = pdf_processing::ensure_pdfium_auto_cache_dir();
+    }
+
+    #[cfg(test)]
+    fn initialize_pdfium_auto_cache_dir() {}
+
     /// Create a new document task processor (legacy, without workspace support).
     /// OODA-223: Uses non-strict mode (allows fallback) for backward compatibility.
     pub fn new(
@@ -171,6 +179,8 @@ impl DocumentTaskProcessor {
         graph_storage: Arc<dyn GraphStorage>,
         pipeline_state: PipelineState,
     ) -> Self {
+        Self::initialize_pdfium_auto_cache_dir();
+
         Self {
             pipeline,
             llm_provider,
@@ -208,6 +218,8 @@ impl DocumentTaskProcessor {
         workspace_service: SharedWorkspaceService,
         models_config: Arc<ModelsConfig>,
     ) -> Self {
+        Self::initialize_pdfium_auto_cache_dir();
+
         Self {
             pipeline,
             llm_provider,
@@ -242,6 +254,8 @@ impl DocumentTaskProcessor {
         workspace_service: SharedWorkspaceService,
         models_config: Arc<ModelsConfig>,
     ) -> Self {
+        Self::initialize_pdfium_auto_cache_dir();
+
         Self {
             pipeline,
             llm_provider,

--- a/edgequake/crates/edgequake-api/src/processor/pdf_processing.rs
+++ b/edgequake/crates/edgequake-api/src/processor/pdf_processing.rs
@@ -77,7 +77,8 @@ fn resolve_pdfium_auto_cache_dir() -> std::path::PathBuf {
     select_pdfium_auto_cache_dir(preferred)
 }
 
-fn ensure_pdfium_auto_cache_dir() -> std::path::PathBuf {
+#[cfg(not(test))]
+pub(super) fn ensure_pdfium_auto_cache_dir() -> std::path::PathBuf {
     static CACHE_DIR: std::sync::OnceLock<std::path::PathBuf> = std::sync::OnceLock::new();
 
     CACHE_DIR
@@ -398,11 +399,6 @@ impl DocumentTaskProcessor {
                     "Vision extraction timeout set (adaptive for {} pages)",
                     page_count
                 );
-
-                // pdfium-auto extracts the bundled library into a writable cache base.
-                // The default cache location may be unwritable for the non-root runtime
-                // user, so we pin it to a temp-backed path before the first use.
-                let _ = ensure_pdfium_auto_cache_dir();
 
                 let spawn_result = tokio::time::timeout(
                     vision_timeout,

--- a/edgequake/crates/edgequake-api/src/processor/pdf_processing.rs
+++ b/edgequake/crates/edgequake-api/src/processor/pdf_processing.rs
@@ -1,6 +1,98 @@
 use super::*;
 use tokio_util::sync::CancellationToken;
 
+const PDFIUM_CACHE_DIR_NAME: &str = "edgequake-pdfium-cache";
+const PDFIUM_CACHE_DIR_FALLBACK: &str = "/tmp/edgequake-pdfium-cache";
+
+fn default_pdfium_auto_cache_dir() -> std::path::PathBuf {
+    std::env::temp_dir().join(PDFIUM_CACHE_DIR_NAME)
+}
+
+fn cache_dir_is_writable(cache_dir: &std::path::Path) -> bool {
+    if let Err(error) = std::fs::create_dir_all(cache_dir) {
+        tracing::debug!(
+            cache_dir = %cache_dir.display(),
+            error = %error,
+            "PDFium cache directory could not be created"
+        );
+        return false;
+    }
+
+    let probe_path = cache_dir.join(format!(
+        ".edgequake-pdfium-probe-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|duration| duration.as_nanos())
+            .unwrap_or_default()
+    ));
+
+    match std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&probe_path)
+    {
+        Ok(_) => {
+            let _ = std::fs::remove_file(&probe_path);
+            true
+        }
+        Err(error) => {
+            tracing::debug!(
+                cache_dir = %cache_dir.display(),
+                error = %error,
+                "PDFium cache directory is not writable"
+            );
+            false
+        }
+    }
+}
+
+fn select_pdfium_auto_cache_dir(preferred: std::path::PathBuf) -> std::path::PathBuf {
+    if cache_dir_is_writable(&preferred) {
+        return preferred;
+    }
+
+    let fallback = std::path::PathBuf::from(PDFIUM_CACHE_DIR_FALLBACK);
+    if cache_dir_is_writable(&fallback) {
+        warn!(
+            preferred_cache_dir = %preferred.display(),
+            fallback_cache_dir = %fallback.display(),
+            "PDFium cache directory was not writable; using fallback"
+        );
+        return fallback;
+    }
+
+    warn!(
+        preferred_cache_dir = %preferred.display(),
+        fallback_cache_dir = %fallback.display(),
+        "PDFium cache directories were not writable; continuing with the preferred path"
+    );
+    preferred
+}
+
+fn resolve_pdfium_auto_cache_dir() -> std::path::PathBuf {
+    let preferred = std::env::var_os("PDFIUM_AUTO_CACHE_DIR")
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(default_pdfium_auto_cache_dir);
+    select_pdfium_auto_cache_dir(preferred)
+}
+
+fn ensure_pdfium_auto_cache_dir() -> std::path::PathBuf {
+    static CACHE_DIR: std::sync::OnceLock<std::path::PathBuf> = std::sync::OnceLock::new();
+
+    CACHE_DIR
+        .get_or_init(|| {
+            let cache_dir = resolve_pdfium_auto_cache_dir();
+            std::env::set_var("PDFIUM_AUTO_CACHE_DIR", &cache_dir);
+            tracing::debug!(
+                cache_dir = %cache_dir.display(),
+                "Using PDFium cache directory"
+            );
+            cache_dir
+        })
+        .clone()
+}
+
 impl DocumentTaskProcessor {
     /// Process PDF processing task (SPEC-007).
     ///
@@ -307,6 +399,11 @@ impl DocumentTaskProcessor {
                     page_count
                 );
 
+                // pdfium-auto extracts the bundled library into a writable cache base.
+                // The default cache location may be unwritable for the non-root runtime
+                // user, so we pin it to a temp-backed path before the first use.
+                let _ = ensure_pdfium_auto_cache_dir();
+
                 let spawn_result = tokio::time::timeout(
                     vision_timeout,
                     tokio::task::spawn_blocking(move || {
@@ -572,5 +669,60 @@ impl DocumentTaskProcessor {
         Err(edgequake_tasks::TaskError::UnsupportedOperation(
             "PDF processing requires postgres feature".to_string(),
         ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use serial_test::serial;
+    use tempfile::tempdir;
+
+    #[test]
+    fn default_pdfium_cache_dir_uses_temp_dir() {
+        let cache_dir = default_pdfium_auto_cache_dir();
+
+        assert!(cache_dir.ends_with(PDFIUM_CACHE_DIR_NAME));
+    }
+
+    #[test]
+    fn writable_cache_dir_is_selected() {
+        let temp_dir = tempdir().expect("temp dir");
+        let candidate = temp_dir.path().join(PDFIUM_CACHE_DIR_NAME);
+
+        let resolved = select_pdfium_auto_cache_dir(candidate.clone());
+
+        assert_eq!(resolved, candidate);
+        assert!(resolved.exists());
+    }
+
+    #[test]
+    fn unwritable_cache_dir_falls_back_to_tmp() {
+        let temp_dir = tempdir().expect("temp dir");
+        let candidate = temp_dir.path().join("blocked-cache-dir");
+        std::fs::write(&candidate, b"not a directory").expect("create blocking file");
+
+        let resolved = select_pdfium_auto_cache_dir(candidate);
+
+        assert_eq!(
+            resolved,
+            std::path::PathBuf::from(PDFIUM_CACHE_DIR_FALLBACK)
+        );
+        assert!(resolved.exists());
+    }
+
+    #[test]
+    #[serial]
+    fn explicit_pdfium_cache_dir_is_respected_when_writable() {
+        let temp_dir = tempdir().expect("temp dir");
+        let custom_cache_dir = temp_dir.path().join("custom-pdfium-cache");
+
+        std::env::set_var("PDFIUM_AUTO_CACHE_DIR", &custom_cache_dir);
+        let resolved = resolve_pdfium_auto_cache_dir();
+        std::env::remove_var("PDFIUM_AUTO_CACHE_DIR");
+
+        assert_eq!(resolved, custom_cache_dir);
+        assert!(resolved.exists());
     }
 }

--- a/edgequake/docker/Dockerfile
+++ b/edgequake/docker/Dockerfile
@@ -54,6 +54,9 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/* \
     && useradd -r -s /bin/false edgequake
 
+# pdfium-auto extracts the bundled shared library into this writable cache base.
+ENV PDFIUM_AUTO_CACHE_DIR=/tmp/edgequake-pdfium-cache
+
 # Copy binary from builder
 COPY --from=builder /app/target/release/edgequake /usr/local/bin/
 

--- a/edgequake/docker/docker-compose-cpu-build.yml
+++ b/edgequake/docker/docker-compose-cpu-build.yml
@@ -1,0 +1,54 @@
+services:
+  edgequake:
+    image: docker-edgequake:latest
+    container_name: edgequake-backend
+    restart: unless-stopped
+    ports:
+      - "11432:8080"
+    environment:
+      - HOST=0.0.0.0
+      - PORT=8080
+      - DATABASE_URL=${DATABASE_URL:-postgresql://edgequake:${POSTGRES_PASSWORD:-edgequake_pass}@host.docker.internal:5432/edgequake_db}
+      - EDGEQUAKE_MODELS_CONFIG=/app/models.toml
+      - OPENAI_API_KEY=${OPENAI_API_KEY:-}
+      - OPENAI_COMPATIBLE_API_KEY=${OPENAI_COMPATIBLE_API_KEY:-}
+      - OPENAI_BASE_URL=${OPENAI_BASE_URL:-http://host.docker.internal:4000/v1}
+      - EDGEQUAKE_LLM_PROVIDER=${EDGEQUAKE_LLM_PROVIDER:-openai}
+      - EDGEQUAKE_LLM_MODEL=${EDGEQUAKE_LLM_MODEL:-qwen3.5-35b-a3b}
+      - EDGEQUAKE_EMBEDDING_PROVIDER=${EDGEQUAKE_EMBEDDING_PROVIDER:-openai}
+      - EDGEQUAKE_EMBEDDING_MODEL=${EDGEQUAKE_EMBEDDING_MODEL:-qwen3-embedding-0.6b}
+      - EDGEQUAKE_EMBEDDING_DIMENSION=${EDGEQUAKE_EMBEDDING_DIMENSION:-1024}
+      - EDGEQUAKE_DEFAULT_LLM_PROVIDER=litellm-local
+      - EDGEQUAKE_DEFAULT_LLM_MODEL=qwen3.5-35b-a3b
+      - EDGEQUAKE_DEFAULT_EMBEDDING_PROVIDER=litellm-local
+      - EDGEQUAKE_DEFAULT_EMBEDDING_MODEL=qwen3-embedding-0.6b
+      - EDGEQUAKE_DEFAULT_EMBEDDING_DIMENSION=1024
+      - EDGEQUAKE_VISION_PROVIDER=${EDGEQUAKE_VISION_PROVIDER:-openai}
+      - EDGEQUAKE_VISION_MODEL=${EDGEQUAKE_VISION_MODEL:-qwen3.5-35b-a3b}
+      - PDFIUM_AUTO_CACHE_DIR=${PDFIUM_AUTO_CACHE_DIR:-/tmp/edgequake-pdfium-cache}
+      - WORKER_THREADS=2
+      - RUST_LOG=debug,edgequake=debug,tower_http=warn,axum=warn
+      - RUST_BACKTRACE=1
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    volumes:
+      - type: bind
+        source: /root/edgequake/config/models.toml
+        target: /app/models.toml
+        read_only: true
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
+
+  frontend:
+    image: docker-frontend:latest
+    container_name: edgequake-frontend
+    restart: unless-stopped
+    ports:
+      - "3000:3000"
+    environment:
+      EDGEQUAKE_API_URL: ${EDGEQUAKE_API_URL:-http://localhost:11432}
+      NODE_ENV: production

--- a/edgequake/docker/docker-compose-cpu-build.yml
+++ b/edgequake/docker/docker-compose-cpu-build.yml
@@ -8,7 +8,7 @@ services:
     environment:
       - HOST=0.0.0.0
       - PORT=8080
-      - DATABASE_URL=${DATABASE_URL:-postgresql://edgequake:${POSTGRES_PASSWORD:-edgequake_pass}@host.docker.internal:5432/edgequake_db}
+      - DATABASE_URL=${DATABASE_URL:-postgresql://edgequake:edgequake_pass@host.docker.internal:5432/edgequake_db}
       - EDGEQUAKE_MODELS_CONFIG=/app/models.toml
       - OPENAI_API_KEY=${OPENAI_API_KEY:-}
       - OPENAI_COMPATIBLE_API_KEY=${OPENAI_COMPATIBLE_API_KEY:-}

--- a/edgequake/docker/docker-compose.yml
+++ b/edgequake/docker/docker-compose.yml
@@ -30,6 +30,8 @@ services:
       - EDGEQUAKE_EMBEDDING_PROVIDER=${EDGEQUAKE_EMBEDDING_PROVIDER:-}
       # Vision extraction timeout (seconds). Default 600s (10 min).
       - EDGEQUAKE_VISION_TIMEOUT_SECS=${EDGEQUAKE_VISION_TIMEOUT_SECS:-600}
+      # Writable cache base for the bundled pdfium library used by pdfium-auto.
+      - PDFIUM_AUTO_CACHE_DIR=${PDFIUM_AUTO_CACHE_DIR:-/tmp/edgequake-pdfium-cache}
       - RUST_LOG=info,edgequake=debug
     # Linux only: enable host.docker.internal resolution
     extra_hosts:


### PR DESCRIPTION
## Summary
Cherry-picks the PDFium cache fix so PDF ingestion works reliably in non-root container environments.

## Why
`pdfium-auto` needs a writable cache directory. In Docker and Portainer containers, the default cache path can fail, which can leave PDF ingest stuck or broken.

## Changes
- Probe the preferred PDFium cache directory and fall back to `/tmp/edgequake-pdfium-cache` when needed
- Set a writable cache base in the Docker runtime image
- Add the Docker and compose defaults needed for containerized PDF ingest
- Keep the build helper compose file aligned with the PDF ingest fix

## Validation
- Branch was cherry-picked from the existing validated work
- Unit tests for cache selection are included in the branch history
