### PR TITLE
docs: add Portainer stack defaults and deployment guide

### DIFF
--- a/docs/portainer-stack-deployment.md
+++ b/docs/portainer-stack-deployment.md
@@ -1,468 +1,227 @@
 # EdgeQuake → Portainer Stack 배포 가이드
 
-**목표**: Docker Compe 파일을 Portainer 의 Stack 으로 완벽하게 변환하여 관리하는 방법
+Portainer에서 EdgeQuake를 배포할 때는 `edgequake/docker/portainer-compose.yml`을 기준으로 잡는 것이 가장 안전합니다.
+
+핵심 원칙은 세 가지입니다.
+
+- `container_name`은 쓰지 않습니다. Portainer가 stack 이름을 자동으로 붙이므로, 고정 이름은 충돌을 만들기 쉽습니다.
+- `NEXT_PUBLIC_API_URL`은 런타임 env가 아니라 `build.args`로 넘깁니다. Next.js public env는 빌드 시점에 번들에 박히기 때문입니다.
+- PostgreSQL은 stack 안에 포함합니다. 외부 DB에 의존하지 않도록 `postgres` 서비스와 volume을 함께 둡니다.
 
 ---
 
-## 1️⃣ 현재 구조 분석
+## 추천 파일
 
-최적의 Portainer Stack 배포를 위해 `docker/docker-compose.yml` 을 검토합니다.
+- `edgequake/docker/portainer-compose.yml`
+- `edgequake/docker/docker-compose.yml` 1차 로컬 개발용
+- `edgequake/docker/docker-compose-cpu-build.yml` CPU 빌드 변형
 
-### 주요 서비스 구성
-| Service | 포트 | 용도 | 비고 |
-|---------|------|------|------|
-| `edgequake` | 8080 | Backend API (Rust/Axum) | PostgreSQL 의존성 있음 |
-| `frontend` | 3000 | Frontend UI (Next.js/React 19) | Backend 의존성 있음 |
-| `postgres` | 5432 | Database (PostgreSQL + pgvector + AGE) | 볼륨 persists 데이터 |
-
-### 환경 변수 구성
-- **Required**: `DATABASE_URL`, POSTGRES 설정
-- **Optional**: `OPENAI_API_KEY`, `OLLAMA_HOST` 등 LLM Provider 관련
+Portainer 가이드는 `portainer-compose.yml` 기준으로 읽으면 됩니다.
 
 ---
 
-## 2️⃣ Portainer Stack 변환 전략
+## 환경 변수
 
-### 접근 방식 1: 파일 업로드 (가장 간단)
-Portainer 웹 UI 에서 compose 파일을 직접 업로드합니다.
+`edgequake/docker/.env.portainer.example`을 복사해서 사용합니다.
 
-
-**장점**:
-- 빠른 배포 (5 분 이내)
-- 로컬/테스트 환경에 최적
-- Docker Compose 와 동일한 구조 유지
-
-**단점**:
-- 수동 업데이트 필요
-- 버전 관리 어려움
-
-### 접근 방식 2: Git Repository 연동 (권장 - 프로덕션)
-Git repo URL 을 Portainer 에 등록하여 자동 동기화합니다.
-
-
-**파일 위치**: `edgequake/docker/portainer-compose.yml` 으로 별도 분리 추천
-
----
-
-## 3️⃣ 변환된 Compose 파일
-
-기존 `docker-compose.yml` 과의 주요 차이점:
-
-### A. Container Name 제거
-Portainer 가 자동으로 이름에 Stack 이름을 접두사로 붙이므로 중괄호로 사용합니다.
-
-```yaml
-services:
-  edgequake:
-    # container_name: edgequake (제거하거나 주석 처리)
-    container_name: ${STACK_NAME:-edgequake}-backend  # 동적 네임스페이스
-```
-
-### B. Build vs Image 모드 선택
-
-**Option 1 - Push to Registry (권장)**  
-1. `docker build` 로 이미지 빌드 & 태그
-2. Docker Hub / GitHub Container Registry 에 push
-3. Portainer 에서 `image:` 참조
-
-
-**옵션 코드**:
-
-```yaml
-edgequake:
-  image: ghcr.io/raphaelmansuy/edgequake:${TAG:-latest}
-  # build 제거 (이미지 풀)
-```
-
-
-**Option 2 - Local Build (개발용)**  
-Portainer 가 Docker Host 에서 직접 빌드합니다. `build:` 섹션 유지합니다.
-
-### C. Frontend API URL 수정
-
-Docker 내부 네트워크에서 Backend 를 접근하므로 localhost 대신 서비스 이름을 사용합니다:
-
-```yaml
-frontend:
-  build:
-    args:
-      NEXT_PUBLIC_API_URL: http://edgequake:8080  # 변경점!
-  environment:
-    - NEXT_PUBLIC_API_URL=http://edgequake:8080  # Docker 내부에서 사용
-```
-
-**Why?**  
-- Portainer Stack 내부에서는 `localhost` 가 아닌 서비스 이름 (`edgequake`) 으로 접근해야 합니다.
-- HTTP 요청이 외부 호스트 (`host.docker.internal`) 로 향하면 Connection refused 에러가 발생합니다.
-
-
----
-
-## 4️⃣ 배포 단계별 가이드
-
-### 단계 1: Portainer 설정 (초기화)
-
-**Prerequisites**:
-```bash
-# 1. Docker Host 가 Portainer 과 통신 가능한지 확인
-docker context ls
-
-# 2. Portainer Stack 이 이미 설치되어 있는지 확인
-# (만약 없음, https://www.portainer.io/install/docker-engine 참조)
-docker run -d -p 8000:8000 -p 9000:9000 --name portainer \
-  --restart=always \
-  -v /var/run/docker.sock:/var/run/docker.sock \
-  -v portainer_data:/data \
-  portainer/portainer-ce:latest
-```
-
-### 단계 2: 환경 변수 설정
-
-**`.env` 파일 생성** (`docker/` 디렉토리 하위):
-
-
-```bash
-# Required
-POSTGRES_DB=edgequake
+```env
 POSTGRES_USER=edgequake
-POSTGRES_PASSWORD=SuperSecret123!
+POSTGRES_PASSWORD=CHANGE_ME
+POSTGRES_DB=edgequake
 
-# Optional - LLM Provider 선택
-OPENAI_API_KEY=sk-proj-your-openai-key  # OpenAI 모드
-# EDGEQUAKE_LLM_PROVIDER=openai         # 또는 ollama
+NEXT_PUBLIC_API_URL=http://localhost:11432
 
-# Optional - Networking
-STACK_NAME=edgequake-app  # Portainer Stack 네임스페이스
+OPENAI_API_KEY=
+OPENAI_COMPATIBLE_API_KEY=sk-your-compatible-key
+OPENAI_BASE_URL=http://host.docker.internal:4000/v1
+
+EDGEQUAKE_LLM_PROVIDER=openai
+EDGEQUAKE_LLM_MODEL=qwen3.5-35b-a3b
+EDGEQUAKE_EMBEDDING_PROVIDER=openai
+EDGEQUAKE_EMBEDDING_MODEL=qwen3-embedding-0.6b
+EDGEQUAKE_EMBEDDING_DIMENSION=1024
+
+EDGEQUAKE_DEFAULT_LLM_PROVIDER=litellm-local
+EDGEQUAKE_DEFAULT_LLM_MODEL=qwen3.5-35b-a3b
+EDGEQUAKE_DEFAULT_EMBEDDING_PROVIDER=litellm-local
+EDGEQUAKE_DEFAULT_EMBEDDING_MODEL=qwen3-embedding-0.6b
+EDGEQUAKE_DEFAULT_EMBEDDING_DIMENSION=1024
+
+EDGEQUAKE_VISION_PROVIDER=openai
+EDGEQUAKE_VISION_MODEL=qwen3.5-35b-a3b
+EDGEQUAKE_MODELS_CONFIG=/app/models.toml
+
+EDGEQUAKE_VISION_TIMEOUT_SECS=600
+PDFIUM_AUTO_CACHE_DIR=/tmp/edgequake-pdfium-cache
+
+RUST_LOG=debug,edgequake=debug
+RUST_BACKTRACE=1
 ```
 
-### 단계 3: Compose 파일 수정 (최종본)
+`NEXT_PUBLIC_API_URL`은 브라우저가 실제로 접근할 수 있는 backend URL이어야 합니다.
 
-`docker/portainer-compose.yml` 생성:
+- 같은 Docker host에서 접속한다면 `http://localhost:11432`
+- 다른 머신에서 접속한다면 해당 host의 IP나 도메인으로 바꾸세요
 
+`POSTGRES_PASSWORD`는 예시값이므로 실제 배포 전에 반드시 바꾸세요.
+
+---
+
+## Portainer Compose
+
+`edgequake/docker/portainer-compose.yml`의 권장 형태는 아래와 같습니다.
 
 ```yaml
-version: '3.8'
-
 services:
   edgequake:
-    image: ghcr.io/raphaelmansuy/edgequake:${TAG:-latest}
-    # 만약 빌드를直接使用하려면 `build:` 섹션 유지 (dev mode)
-    
-    restart: unless-stopped
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile
+    image: docker-edgequake:latest
+    ports:
+      - "11432:8080"
     environment:
-      - EDGEQUAKE_HOST=0.0.0.0
-      - EDGEQUAKE_PORT=8080
-      - DATABASE_URL=postgres://edgequake:${POSTGRES_PASSWORD}@postgres:5432/edgequake
+      - HOST=0.0.0.0
+      - PORT=8080
+      - DATABASE_URL=postgresql://${POSTGRES_USER:-edgequake}:${POSTGRES_PASSWORD:-CHANGE_ME}@postgres:5432/${POSTGRES_DB:-edgequake}
+      - EDGEQUAKE_MODELS_CONFIG=/app/models.toml
       - OPENAI_API_KEY=${OPENAI_API_KEY:-}
-      - OLLAMA_HOST=http://${OLLAMA_HOSTNAME:-host.docker.internal}:11434
-      - EDGEQUAKE_LLM_PROVIDER=${EDGEQUAKE_LLM_PROVIDER:-ollama}
-      - RUST_LOG=info,edgequake=debug
-    
+      - OPENAI_COMPATIBLE_API_KEY=${OPENAI_COMPATIBLE_API_KEY:-sk-0000}
+      - OPENAI_BASE_URL=${OPENAI_BASE_URL:-http://host.docker.internal:4000/v1}
+      - EDGEQUAKE_LLM_PROVIDER=${EDGEQUAKE_LLM_PROVIDER:-openai}
+      - EDGEQUAKE_LLM_MODEL=${EDGEQUAKE_LLM_MODEL:-qwen3.5-35b-a3b}
+      - EDGEQUAKE_EMBEDDING_PROVIDER=${EDGEQUAKE_EMBEDDING_PROVIDER:-openai}
+      - EDGEQUAKE_EMBEDDING_MODEL=${EDGEQUAKE_EMBEDDING_MODEL:-qwen3-embedding-0.6b}
+      - EDGEQUAKE_EMBEDDING_DIMENSION=${EDGEQUAKE_EMBEDDING_DIMENSION:-1024}
+      - EDGEQUAKE_DEFAULT_LLM_PROVIDER=litellm-local
+      - EDGEQUAKE_DEFAULT_LLM_MODEL=qwen3.5-35b-a3b
+      - EDGEQUAKE_DEFAULT_EMBEDDING_PROVIDER=litellm-local
+      - EDGEQUAKE_DEFAULT_EMBEDDING_MODEL=qwen3-embedding-0.6b
+      - EDGEQUAKE_DEFAULT_EMBEDDING_DIMENSION=1024
+      - EDGEQUAKE_VISION_PROVIDER=${EDGEQUAKE_VISION_PROVIDER:-openai}
+      - EDGEQUAKE_VISION_MODEL=${EDGEQUAKE_VISION_MODEL:-qwen3.5-35b-a3b}
+      - EDGEQUAKE_VISION_TIMEOUT_SECS=${EDGEQUAKE_VISION_TIMEOUT_SECS:-600}
+      - PDFIUM_AUTO_CACHE_DIR=${PDFIUM_AUTO_CACHE_DIR:-/tmp/edgequake-pdfium-cache}
+      - WORKER_THREADS=2
+      - RUST_LOG=debug,edgequake=debug,tower_http=warn,axum=warn
+      - RUST_BACKTRACE=1
     depends_on:
       postgres:
         condition: service_healthy
-    
-    networks:
-      - edgequake-network
-    
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8080/health"]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-      start_period: 10s
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    volumes:
+      - type: bind
+        source: /root/edgequake/config/models.toml
+        target: /app/models.toml
+        read_only: true
 
   frontend:
-    image: ghcr.io/raphaelmansuy/edgequake-webui:${TAG:-latest}
-    
-    restart: unless-stopped
+    build:
+      context: ../../
+      dockerfile: edgequake_webui/Dockerfile
+      args:
+        NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL:-http://localhost:11432}
+    image: docker-frontend:latest
+    ports:
+      - "3000:3000"
     environment:
-      - NEXT_PUBLIC_API_URL=http://edgequake:8080
       - NODE_ENV=production
-    
     depends_on:
       - edgequake
-    
-    networks:
-      - edgequake-network
 
   postgres:
-    image: portainer/edgequake-postgres:${TAG:-latest}  
-    # 또는 공식 Postgres + Custom init 스크립트 사용
-    
-    restart: unless-stopped
+    build:
+      context: .
+      dockerfile: Dockerfile.postgres
+    image: docker-postgres:latest
+    ports:
+      - "${POSTGRES_PORT:-5432}:5432"
     environment:
-      - POSTGRES_USER=edgequake
-      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
-      - POSTGRES_DB=edgequake
-    
+      - POSTGRES_USER=${POSTGRES_USER:-edgequake}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-CHANGE_ME}
+      - POSTGRES_DB=${POSTGRES_DB:-edgequake}
     volumes:
       - postgres-data:/var/lib/postgresql/data
-      # ./init-extensions.sql 볼륨 마운트 필요 (pgvector + AGE)
-    
-    networks:
-      - edgequake-network
-    
-    healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U edgequake -d edgequake"]
-      interval: 10s
-      timeout: 5s
-      retries: 5
+      - ./init-extensions.sql:/docker-entrypoint-initdb.d/init.sql:ro
 
 volumes:
   postgres-data:
     driver: local
-
-networks:
-  edgequake-network:
-    driver: bridge
 ```
 
-### 단계 4: Portainer Web UI 에서 Stack 생성
+포인트는 다음입니다.
 
-1. **Portainer 로 접속**: `http://<portainer-host>:9000`
-2. **Left Sidebar → Stacks** 클릭
-3. **Add stack** 버튼 클릭
-4. **Name**: `edgequake-app` (또는 원하는 이름)
-5. **Navigation method 선택**:
-   - **File browser**: 로컬에서 파일을 업로드
-     - `docker/portainer-compose.yml` 드래그&드롭
-   - **Web repository **(추천): Git URL 입력
-     - Repository URL: `https://github.com/raphaelmansuy/edgequake.git`
-     - Branch: `main` (또고 사용하려는 브랜치)
-     - Path in repository: `docker/portainer-compose.yml`
-6. **Environment Variables 설정** (필요한 경우):
-   - Git 기반일 때 `.env` 파일도 함께 업로드되거나, 
-   - UI 에서 직접 입력 가능 (예: `POSTGRES_PASSWORD=...`)
-7. **Create the stack** 클릭
+- frontend는 `build.args.NEXT_PUBLIC_API_URL`로 빌드합니다.
+- `NEXT_PUBLIC_API_URL`은 `environment`가 아니라 `build.args`에서 관리합니다.
+- postgres는 stack 내부에 두고 `DATABASE_URL`을 그 서비스명(`postgres`)으로 연결합니다.
+- `container_name`은 쓰지 않습니다.
 
-### 단계 5: 이미지 퍼블리시 선택 (프로덕션 모드)
+---
 
+## Portainer에서 배포하기
 
-**Option A - Multi-Arch Image Build**:
+### 1. Stack 생성
+
+1. Portainer에 로그인합니다.
+2. `Stacks` → `Add stack`을 엽니다.
+3. Git repository 또는 file upload 방식을 선택합니다.
+4. Compose file path를 `edgequake/docker/portainer-compose.yml`로 지정합니다.
+5. `.env.portainer.example`의 값을 Portainer environment variables에 넣습니다.
+6. `Create the stack`을 클릭합니다.
+
+### 2. 주의할 점
+
+- backend는 `11432:8080`, frontend는 `3000:3000`으로 공개됩니다.
+- 브라우저가 frontend를 열 때 API 호출은 `NEXT_PUBLIC_API_URL`로 빌드된 주소를 사용합니다.
+- 다른 머신에서 접속한다면 `NEXT_PUBLIC_API_URL`을 host/IP 기준으로 바꾼 뒤 frontend 이미지를 다시 빌드해야 합니다.
+
+---
+
+## 검증
+
+배포 후 아래를 확인합니다.
 
 ```bash
-# amd64 + arm64 지원 빌드
-docker buildx build \
-  --platform linux/amd64,linux/arm64 \
-  -t ghcr.io/raphaelmansuy/edgequake:${VERSION} \
-  -t ghcr.io/raphaelmansuy/edgequake:latest \
-  --push \
-  ./edgequake
+curl http://<host>:11432/health
+curl -I http://<host>:3000
 ```
 
-
-**Option B - Portainer 의 Build 기능 활용**:
-
-Pro Plan 사용 시 Portainer 에서 자동으로 빌드 및 캐싱됩니다.
+PostgreSQL은 Portainer UI에서 `postgres` 서비스 로그를 확인하거나, stack의 Console 기능에서 `pg_isready -U edgequake -d edgequake`를 실행합니다.
 
 ---
 
-## 5️⃣ 검증 체크리스트
+## 자주 하는 실수
 
-### ✅ Post-Deployment Verification
+### 1. frontend가 잘못된 backend로 붙는 경우
 
-1. **Service Status 확인**:
-   ```bash
-   # Portainer 웹 UI → Stacks → edgequake-app → Containers
-   
-   # 또는 CLI 로:
-   docker ps --filter "name=edgequake-app"
-   ```
+원인:
+- `NEXT_PUBLIC_API_URL`을 runtime env로만 넣음
+- 또는 host-reachable URL이 아닌 내부 서비스 이름을 넣음
 
-2. **Health Check 검증**:
-   ```bash
-   # Backend Health
-   curl http://<host>:8080/health
-   
-   # Frontend UI
-   curl -I http://<host>:3000
-   
-   # Database 연결 확인 (Postgres 컨테이너 내부)
-   docker exec edgequake-app-postgres pg_isready -U edgequake -d edgequake
-   ```
+해결:
+- `build.args.NEXT_PUBLIC_API_URL`을 수정하고 frontend 이미지를 다시 빌드합니다.
 
-3. **네트워크 검증**:
-   ```bash
-   # Portainer 내 네트워크 디버깅
-   docker network ls
-   
-   # 특정 서비스 간 통신 테스트
-   docker exec edgequake-app-frontend wget -O /dev/null http://edgequake:8080/health
-   ```
+### 2. PostgreSQL이 바로 종료되는 경우
+
+원인:
+- `POSTGRES_PASSWORD` 또는 `POSTGRES_DB` 값 누락
+
+해결:
+- `.env.portainer.example`의 값을 확인하고, Portainer stack의 env와 compose가 같은 값을 쓰는지 확인합니다.
+
+### 3. Ollama 또는 OpenAI-compatible proxy 연결 실패
+
+원인:
+- `OPENAI_BASE_URL` 또는 `OLLAMA_HOST`가 Docker host에서 접근 불가능
+
+해결:
+- `host.docker.internal` 경로와 Portainer의 `extra_hosts` 설정을 확인합니다.
 
 ---
 
-## 6️⃣常见问题 해결
+## 선택 사항: 이미지 기반 배포
 
-### Q1: "Container exited immediately" 오류
+build 대신 published image를 쓰고 싶다면, backend/frontend/postgres 이미지를 각각 GHCR에 올린 뒤 compose의 `build:`를 `image:`로 바꾸면 됩니다.
 
-
-**원인**: PostgreSQL init 스크립트 또는 환경 변수 누락.
-
-**해결**:
-```bash
-# 로그 확인
-docker logs edgequake-app-postgres
-
-# Portainer Stack → Containers → postgres → Logs
-```
-
-### Q2: Backend 가 Frontend 로부터 접속 불가
-
-
-**증상**: 3000 번 포트에서 `502 Bad Gateway` 또는 `Connection refused`.
-
-**원인**: `NEXT_PUBLIC_API_URL` 이 `localhost:8080` 으로 설정되어 내부 네트워크가 아닌 외부 호스트로 요청.
-
-**해결**: YAML 의 Build args 및 환경 변수를 확인합니다:
-```yaml
-frontend:
-  build:
-    args:
-      NEXT_PUBLIC_API_URL: http://edgequake:8080  # ✅ Correct
-  environment:
-    - NEXT_PUBLIC_API_URL=http://edgequake:8080  # ✅ Correct
-```
-
-### Q3: 볼륨 데이터 소실
-
-
-**증상**: Container 재시작 후 DB 데이터가 사라짐.
-
-**원인**: `volumes` 섹션의 드라이버 설정이 local 이지만 Portainer 가 다른 Docker Volume 을 생성함.
-
-**해결**:
-- Portainer → Volumes 메뉴에서 postgres-data 볼륨을 확인합니다.
-- 기존 Stack 을 삭제할 때 `-v` 플래그를 사용해야 데이터가 유지됩니다:
-
-
-  ```bash
-  # UI 에서 "Prune dangling volumes" 체크 해제
-
-### Q4: Ollama Host 연결 불가
-
-
-**증상**: Entity extraction 이 실패하고 로그에 `Connection refused to host.docker.internal:11434` 가 뜹니다.
-
-**해결**:
-- Docker 내부 Container 가 Ollama 를 호스트에서 실행 중으로 볼 수 없으면 외부 서비스나 OpenAI 로 변경합니다.
-
-
-  ```yaml
-  environmental:
-    - OLLAMA_HOST=http://host.docker.internal:11434
-  
-  extra_hosts:  # Linux 환경에서만 필요
-    - "host.docker.internal:host-gateway"
-  ```
-
----
-
-## 7️⃣ CI/CD 연동 (GitHub Actions 예시)
-
-
-```yaml
-# .github/workflows/portainer-deploy.yml
-name: Deploy to Portainer
-
-on:
-  push:
-    branches: [main]
-    tags: ['v*']
-
-jobs:
-  build-and-push:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      
-      # Backend 이미지 빌드 & Push
-      - name: Build Docker image
-        run: |
-          VERSION=${{ github.ref_type == 'tag' && github.ref_name || 'latest' }}
-          docker buildx build \
-            --platform linux/amd64,linux/arm64 \
-            -t ghcr.io/raphaelmansuy/edgequake:${VERSION} \
-            -t ghcr.io/raphaelmansuy/edgequake:latest \
-            --push \
-            ./edgequake
-      
-      # Postgres 이미지 빌드 & Push (custom extensions 포함)
-      - name: Build Postgres image
-        run: |
-          docker buildx build \
-            --platform linux/amd64,linux/arm64 \
-            -t ghcr.io/raphaelmansuy/edgequake-postgres:${VERSION} \
-            --push \
-            ./edgequake/docker
-      
-  deploy-portainer:
-    needs: build-and-push
-    runs-on: ubuntu-latest
-    steps:
-      # Portainer API 를 통한 배포 (선택사항)
-      - name: Trigger Portainer Stack Update
-        run: |
-          curl -X PUT \
-            -H "Authorization: Bearer ${{ secrets.PORTAINER_API_KEY }}" \
-            https://<portainer-host>:9000/api/stacks/1/git/reset \
-            --data 'webhook=true'
-```
-
----
-
-## 8️⃣ 모니터링 및 운영 가이드
-
-### Health Check Endpoints
-
-| Service | URL | Status 코드 |
-|---------|-----|------------|
-| Backend API | `http://<host>:8080/health` | 200 OK |
-| Swagger UI | `http://<host>:8080/swagger-ui` | 200 OK |
-| Frontend | `http://<host>:3000` | 200 OK |
-
-### Portainer Metrics Dashboard
-
-
-**추천 설정**:
-1. **Left Sidebar → Metrics** 에서 Prometheus 를 활성화합니다.
-2. Backend 에서 `/metrics` 엔드포인트를 지원합니다 (만약 구현 안 됨, Micrometer 또는 prometheus Rust crate 추가).
-
-### 로그 관리
-
-```bash
-# JSON 포맷 로깅 허용: docker compose logs -f json edgequake-app
-docker logs --tail 100 -f $(docker ps -q --filter "name=edgequake-app-backend")
-```
-
----
-
-## 9️⃣ 요약 및 Next Steps
-
-
-### ✅ 완료된 작업
-- [x] Portainer Stack 포맷 변환 전략 분석 (2 옵션)
-- [x] 환경 변수 리팩토링 가이드 작성
-- [x] Frontend/Backend 간 네트워크 통신 수정 제안
-- [x] CI/CD 파이프라인 예제 제공
-
-### 🚀 다음 단계 선택사항
-
-1. **GitOps 방식 자동화**: Portainer + GitHub 연동 (추천)
-2. **Custom Postgres 이미지** 빌드: pgvector + AGE extensions 포함
-3. **Prometheus/Grafana** 통합: Observability 강화
-4. **Backup Strategy**: 볼륨 백업/복구 자동화 스크립트
-
----
-
-
-## 🔗 관련 문서
-
-- [Docker Compose vs Portainer](https://docs.portainer.io/user/docker/compose/)
-- [Best Practices for Production Deployments](./production-deployment.md)
-- [Multi-Architecture Build Guide](./multi-arch-builds.md)
-
-**Last Updated**: 2026-03-31  
-**Author**: EdgeQuake Team (CEO & System Architect Role)
-
+그 경우에도 `NEXT_PUBLIC_API_URL`은 frontend 이미지를 만들 때 반드시 빌드 인자로 넣어야 합니다.

--- a/docs/portainer-stack-deployment.md
+++ b/docs/portainer-stack-deployment.md
@@ -1,0 +1,468 @@
+# EdgeQuake → Portainer Stack 배포 가이드
+
+**목표**: Docker Compe 파일을 Portainer 의 Stack 으로 완벽하게 변환하여 관리하는 방법
+
+---
+
+## 1️⃣ 현재 구조 분석
+
+최적의 Portainer Stack 배포를 위해 `docker/docker-compose.yml` 을 검토합니다.
+
+### 주요 서비스 구성
+| Service | 포트 | 용도 | 비고 |
+|---------|------|------|------|
+| `edgequake` | 8080 | Backend API (Rust/Axum) | PostgreSQL 의존성 있음 |
+| `frontend` | 3000 | Frontend UI (Next.js/React 19) | Backend 의존성 있음 |
+| `postgres` | 5432 | Database (PostgreSQL + pgvector + AGE) | 볼륨 persists 데이터 |
+
+### 환경 변수 구성
+- **Required**: `DATABASE_URL`, POSTGRES 설정
+- **Optional**: `OPENAI_API_KEY`, `OLLAMA_HOST` 등 LLM Provider 관련
+
+---
+
+## 2️⃣ Portainer Stack 변환 전략
+
+### 접근 방식 1: 파일 업로드 (가장 간단)
+Portainer 웹 UI 에서 compose 파일을 직접 업로드합니다.
+
+
+**장점**:
+- 빠른 배포 (5 분 이내)
+- 로컬/테스트 환경에 최적
+- Docker Compose 와 동일한 구조 유지
+
+**단점**:
+- 수동 업데이트 필요
+- 버전 관리 어려움
+
+### 접근 방식 2: Git Repository 연동 (권장 - 프로덕션)
+Git repo URL 을 Portainer 에 등록하여 자동 동기화합니다.
+
+
+**파일 위치**: `edgequake/docker/portainer-compose.yml` 으로 별도 분리 추천
+
+---
+
+## 3️⃣ 변환된 Compose 파일
+
+기존 `docker-compose.yml` 과의 주요 차이점:
+
+### A. Container Name 제거
+Portainer 가 자동으로 이름에 Stack 이름을 접두사로 붙이므로 중괄호로 사용합니다.
+
+```yaml
+services:
+  edgequake:
+    # container_name: edgequake (제거하거나 주석 처리)
+    container_name: ${STACK_NAME:-edgequake}-backend  # 동적 네임스페이스
+```
+
+### B. Build vs Image 모드 선택
+
+**Option 1 - Push to Registry (권장)**  
+1. `docker build` 로 이미지 빌드 & 태그
+2. Docker Hub / GitHub Container Registry 에 push
+3. Portainer 에서 `image:` 참조
+
+
+**옵션 코드**:
+
+```yaml
+edgequake:
+  image: ghcr.io/raphaelmansuy/edgequake:${TAG:-latest}
+  # build 제거 (이미지 풀)
+```
+
+
+**Option 2 - Local Build (개발용)**  
+Portainer 가 Docker Host 에서 직접 빌드합니다. `build:` 섹션 유지합니다.
+
+### C. Frontend API URL 수정
+
+Docker 내부 네트워크에서 Backend 를 접근하므로 localhost 대신 서비스 이름을 사용합니다:
+
+```yaml
+frontend:
+  build:
+    args:
+      NEXT_PUBLIC_API_URL: http://edgequake:8080  # 변경점!
+  environment:
+    - NEXT_PUBLIC_API_URL=http://edgequake:8080  # Docker 내부에서 사용
+```
+
+**Why?**  
+- Portainer Stack 내부에서는 `localhost` 가 아닌 서비스 이름 (`edgequake`) 으로 접근해야 합니다.
+- HTTP 요청이 외부 호스트 (`host.docker.internal`) 로 향하면 Connection refused 에러가 발생합니다.
+
+
+---
+
+## 4️⃣ 배포 단계별 가이드
+
+### 단계 1: Portainer 설정 (초기화)
+
+**Prerequisites**:
+```bash
+# 1. Docker Host 가 Portainer 과 통신 가능한지 확인
+docker context ls
+
+# 2. Portainer Stack 이 이미 설치되어 있는지 확인
+# (만약 없음, https://www.portainer.io/install/docker-engine 참조)
+docker run -d -p 8000:8000 -p 9000:9000 --name portainer \
+  --restart=always \
+  -v /var/run/docker.sock:/var/run/docker.sock \
+  -v portainer_data:/data \
+  portainer/portainer-ce:latest
+```
+
+### 단계 2: 환경 변수 설정
+
+**`.env` 파일 생성** (`docker/` 디렉토리 하위):
+
+
+```bash
+# Required
+POSTGRES_DB=edgequake
+POSTGRES_USER=edgequake
+POSTGRES_PASSWORD=SuperSecret123!
+
+# Optional - LLM Provider 선택
+OPENAI_API_KEY=sk-proj-your-openai-key  # OpenAI 모드
+# EDGEQUAKE_LLM_PROVIDER=openai         # 또는 ollama
+
+# Optional - Networking
+STACK_NAME=edgequake-app  # Portainer Stack 네임스페이스
+```
+
+### 단계 3: Compose 파일 수정 (최종본)
+
+`docker/portainer-compose.yml` 생성:
+
+
+```yaml
+version: '3.8'
+
+services:
+  edgequake:
+    image: ghcr.io/raphaelmansuy/edgequake:${TAG:-latest}
+    # 만약 빌드를直接使用하려면 `build:` 섹션 유지 (dev mode)
+    
+    restart: unless-stopped
+    environment:
+      - EDGEQUAKE_HOST=0.0.0.0
+      - EDGEQUAKE_PORT=8080
+      - DATABASE_URL=postgres://edgequake:${POSTGRES_PASSWORD}@postgres:5432/edgequake
+      - OPENAI_API_KEY=${OPENAI_API_KEY:-}
+      - OLLAMA_HOST=http://${OLLAMA_HOSTNAME:-host.docker.internal}:11434
+      - EDGEQUAKE_LLM_PROVIDER=${EDGEQUAKE_LLM_PROVIDER:-ollama}
+      - RUST_LOG=info,edgequake=debug
+    
+    depends_on:
+      postgres:
+        condition: service_healthy
+    
+    networks:
+      - edgequake-network
+    
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 10s
+
+  frontend:
+    image: ghcr.io/raphaelmansuy/edgequake-webui:${TAG:-latest}
+    
+    restart: unless-stopped
+    environment:
+      - NEXT_PUBLIC_API_URL=http://edgequake:8080
+      - NODE_ENV=production
+    
+    depends_on:
+      - edgequake
+    
+    networks:
+      - edgequake-network
+
+  postgres:
+    image: portainer/edgequake-postgres:${TAG:-latest}  
+    # 또는 공식 Postgres + Custom init 스크립트 사용
+    
+    restart: unless-stopped
+    environment:
+      - POSTGRES_USER=edgequake
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+      - POSTGRES_DB=edgequake
+    
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+      # ./init-extensions.sql 볼륨 마운트 필요 (pgvector + AGE)
+    
+    networks:
+      - edgequake-network
+    
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U edgequake -d edgequake"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+volumes:
+  postgres-data:
+    driver: local
+
+networks:
+  edgequake-network:
+    driver: bridge
+```
+
+### 단계 4: Portainer Web UI 에서 Stack 생성
+
+1. **Portainer 로 접속**: `http://<portainer-host>:9000`
+2. **Left Sidebar → Stacks** 클릭
+3. **Add stack** 버튼 클릭
+4. **Name**: `edgequake-app` (또는 원하는 이름)
+5. **Navigation method 선택**:
+   - **File browser**: 로컬에서 파일을 업로드
+     - `docker/portainer-compose.yml` 드래그&드롭
+   - **Web repository **(추천): Git URL 입력
+     - Repository URL: `https://github.com/raphaelmansuy/edgequake.git`
+     - Branch: `main` (또고 사용하려는 브랜치)
+     - Path in repository: `docker/portainer-compose.yml`
+6. **Environment Variables 설정** (필요한 경우):
+   - Git 기반일 때 `.env` 파일도 함께 업로드되거나, 
+   - UI 에서 직접 입력 가능 (예: `POSTGRES_PASSWORD=...`)
+7. **Create the stack** 클릭
+
+### 단계 5: 이미지 퍼블리시 선택 (프로덕션 모드)
+
+
+**Option A - Multi-Arch Image Build**:
+
+```bash
+# amd64 + arm64 지원 빌드
+docker buildx build \
+  --platform linux/amd64,linux/arm64 \
+  -t ghcr.io/raphaelmansuy/edgequake:${VERSION} \
+  -t ghcr.io/raphaelmansuy/edgequake:latest \
+  --push \
+  ./edgequake
+```
+
+
+**Option B - Portainer 의 Build 기능 활용**:
+
+Pro Plan 사용 시 Portainer 에서 자동으로 빌드 및 캐싱됩니다.
+
+---
+
+## 5️⃣ 검증 체크리스트
+
+### ✅ Post-Deployment Verification
+
+1. **Service Status 확인**:
+   ```bash
+   # Portainer 웹 UI → Stacks → edgequake-app → Containers
+   
+   # 또는 CLI 로:
+   docker ps --filter "name=edgequake-app"
+   ```
+
+2. **Health Check 검증**:
+   ```bash
+   # Backend Health
+   curl http://<host>:8080/health
+   
+   # Frontend UI
+   curl -I http://<host>:3000
+   
+   # Database 연결 확인 (Postgres 컨테이너 내부)
+   docker exec edgequake-app-postgres pg_isready -U edgequake -d edgequake
+   ```
+
+3. **네트워크 검증**:
+   ```bash
+   # Portainer 내 네트워크 디버깅
+   docker network ls
+   
+   # 특정 서비스 간 통신 테스트
+   docker exec edgequake-app-frontend wget -O /dev/null http://edgequake:8080/health
+   ```
+
+---
+
+## 6️⃣常见问题 해결
+
+### Q1: "Container exited immediately" 오류
+
+
+**원인**: PostgreSQL init 스크립트 또는 환경 변수 누락.
+
+**해결**:
+```bash
+# 로그 확인
+docker logs edgequake-app-postgres
+
+# Portainer Stack → Containers → postgres → Logs
+```
+
+### Q2: Backend 가 Frontend 로부터 접속 불가
+
+
+**증상**: 3000 번 포트에서 `502 Bad Gateway` 또는 `Connection refused`.
+
+**원인**: `NEXT_PUBLIC_API_URL` 이 `localhost:8080` 으로 설정되어 내부 네트워크가 아닌 외부 호스트로 요청.
+
+**해결**: YAML 의 Build args 및 환경 변수를 확인합니다:
+```yaml
+frontend:
+  build:
+    args:
+      NEXT_PUBLIC_API_URL: http://edgequake:8080  # ✅ Correct
+  environment:
+    - NEXT_PUBLIC_API_URL=http://edgequake:8080  # ✅ Correct
+```
+
+### Q3: 볼륨 데이터 소실
+
+
+**증상**: Container 재시작 후 DB 데이터가 사라짐.
+
+**원인**: `volumes` 섹션의 드라이버 설정이 local 이지만 Portainer 가 다른 Docker Volume 을 생성함.
+
+**해결**:
+- Portainer → Volumes 메뉴에서 postgres-data 볼륨을 확인합니다.
+- 기존 Stack 을 삭제할 때 `-v` 플래그를 사용해야 데이터가 유지됩니다:
+
+
+  ```bash
+  # UI 에서 "Prune dangling volumes" 체크 해제
+
+### Q4: Ollama Host 연결 불가
+
+
+**증상**: Entity extraction 이 실패하고 로그에 `Connection refused to host.docker.internal:11434` 가 뜹니다.
+
+**해결**:
+- Docker 내부 Container 가 Ollama 를 호스트에서 실행 중으로 볼 수 없으면 외부 서비스나 OpenAI 로 변경합니다.
+
+
+  ```yaml
+  environmental:
+    - OLLAMA_HOST=http://host.docker.internal:11434
+  
+  extra_hosts:  # Linux 환경에서만 필요
+    - "host.docker.internal:host-gateway"
+  ```
+
+---
+
+## 7️⃣ CI/CD 연동 (GitHub Actions 예시)
+
+
+```yaml
+# .github/workflows/portainer-deploy.yml
+name: Deploy to Portainer
+
+on:
+  push:
+    branches: [main]
+    tags: ['v*']
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      
+      # Backend 이미지 빌드 & Push
+      - name: Build Docker image
+        run: |
+          VERSION=${{ github.ref_type == 'tag' && github.ref_name || 'latest' }}
+          docker buildx build \
+            --platform linux/amd64,linux/arm64 \
+            -t ghcr.io/raphaelmansuy/edgequake:${VERSION} \
+            -t ghcr.io/raphaelmansuy/edgequake:latest \
+            --push \
+            ./edgequake
+      
+      # Postgres 이미지 빌드 & Push (custom extensions 포함)
+      - name: Build Postgres image
+        run: |
+          docker buildx build \
+            --platform linux/amd64,linux/arm64 \
+            -t ghcr.io/raphaelmansuy/edgequake-postgres:${VERSION} \
+            --push \
+            ./edgequake/docker
+      
+  deploy-portainer:
+    needs: build-and-push
+    runs-on: ubuntu-latest
+    steps:
+      # Portainer API 를 통한 배포 (선택사항)
+      - name: Trigger Portainer Stack Update
+        run: |
+          curl -X PUT \
+            -H "Authorization: Bearer ${{ secrets.PORTAINER_API_KEY }}" \
+            https://<portainer-host>:9000/api/stacks/1/git/reset \
+            --data 'webhook=true'
+```
+
+---
+
+## 8️⃣ 모니터링 및 운영 가이드
+
+### Health Check Endpoints
+
+| Service | URL | Status 코드 |
+|---------|-----|------------|
+| Backend API | `http://<host>:8080/health` | 200 OK |
+| Swagger UI | `http://<host>:8080/swagger-ui` | 200 OK |
+| Frontend | `http://<host>:3000` | 200 OK |
+
+### Portainer Metrics Dashboard
+
+
+**추천 설정**:
+1. **Left Sidebar → Metrics** 에서 Prometheus 를 활성화합니다.
+2. Backend 에서 `/metrics` 엔드포인트를 지원합니다 (만약 구현 안 됨, Micrometer 또는 prometheus Rust crate 추가).
+
+### 로그 관리
+
+```bash
+# JSON 포맷 로깅 허용: docker compose logs -f json edgequake-app
+docker logs --tail 100 -f $(docker ps -q --filter "name=edgequake-app-backend")
+```
+
+---
+
+## 9️⃣ 요약 및 Next Steps
+
+
+### ✅ 완료된 작업
+- [x] Portainer Stack 포맷 변환 전략 분석 (2 옵션)
+- [x] 환경 변수 리팩토링 가이드 작성
+- [x] Frontend/Backend 간 네트워크 통신 수정 제안
+- [x] CI/CD 파이프라인 예제 제공
+
+### 🚀 다음 단계 선택사항
+
+1. **GitOps 방식 자동화**: Portainer + GitHub 연동 (추천)
+2. **Custom Postgres 이미지** 빌드: pgvector + AGE extensions 포함
+3. **Prometheus/Grafana** 통합: Observability 강화
+4. **Backup Strategy**: 볼륨 백업/복구 자동화 스크립트
+
+---
+
+
+## 🔗 관련 문서
+
+- [Docker Compose vs Portainer](https://docs.portainer.io/user/docker/compose/)
+- [Best Practices for Production Deployments](./production-deployment.md)
+- [Multi-Architecture Build Guide](./multi-arch-builds.md)
+
+**Last Updated**: 2026-03-31  
+**Author**: EdgeQuake Team (CEO & System Architect Role)
+

--- a/edgequake/docker/.env.portainer.example
+++ b/edgequake/docker/.env.portainer.example
@@ -56,8 +56,10 @@ OLLAMA_HOST=http://host.docker.internal:11434
 # 
 # Only used when running in OpenAI mode with vision-capable model.
 # Timeout in seconds for vision LLM processing per document.
+# Writable base directory for the embedded pdfium cache.
 # ---------------------------------------------------------------------------
 EDGEQUAKE_VISION_TIMEOUT_SECS=600
+PDFIUM_AUTO_CACHE_DIR=/tmp/edgequake-pdfium-cache
 
 # ---------------------------------------------------------------------------
 # Debugging & Logging (Optional)

--- a/edgequake/docker/.env.portainer.example
+++ b/edgequake/docker/.env.portainer.example
@@ -1,0 +1,74 @@
+# ============================================================================
+# EdgeQuake Portainer Stack Environment Configuration
+# 
+# Copy this file to .env and customize values before deploying in Portainer.
+# Alternatively, set these variables directly in the Portainer Web UI.
+# ============================================================================
+
+# ---------------------------------------------------------------------------
+# PostgreSQL Database Configuration (Required)
+# ---------------------------------------------------------------------------
+POSTGRES_PASSWORD=SuperSecret123!
+POSTGRES_DB=edgequake
+POSTGRES_USER=edgequake
+
+# ---------------------------------------------------------------------------
+# Service Ports (Optional - defaults shown)
+# ---------------------------------------------------------------------------
+EDGEQUAKE_PORT=8080
+FRONTEND_PORT=3000
+POSTGRES_PORT=5432
+
+# ---------------------------------------------------------------------------
+# LLM Provider Configuration (Required for entity extraction)
+#
+# EdgeQuake is configured here for an OpenAI-compatible LiteLLM proxy.
+# Keep `OPENAI_API_KEY` empty and provide the compatible key/base URL below.
+# ---------------------------------------------------------------------------
+
+OPENAI_API_KEY=
+OPENAI_COMPATIBLE_API_KEY=sk-your-compatible-key
+OPENAI_BASE_URL=http://host.docker.internal:4000/v1
+
+# Runtime provider selection: OpenAI-compatible adapter
+EDGEQUAKE_LLM_PROVIDER=openai
+EDGEQUAKE_LLM_MODEL=qwen3.5-35b-a3b
+EDGEQUAKE_EMBEDDING_PROVIDER=openai
+EDGEQUAKE_EMBEDDING_MODEL=qwen3-embedding-0.6b
+EDGEQUAKE_EMBEDDING_DIMENSION=1024
+
+# Default workspace models for the LiteLLM alias
+EDGEQUAKE_DEFAULT_LLM_PROVIDER=litellm-local
+EDGEQUAKE_DEFAULT_LLM_MODEL=qwen3.5-35b-a3b
+EDGEQUAKE_DEFAULT_EMBEDDING_PROVIDER=litellm-local
+EDGEQUAKE_DEFAULT_EMBEDDING_MODEL=qwen3-embedding-0.6b
+EDGEQUAKE_DEFAULT_EMBEDDING_DIMENSION=1024
+EDGEQUAKE_VISION_PROVIDER=openai
+EDGEQUAKE_VISION_MODEL=qwen3.5-35b-a3b
+EDGEQUAKE_MODELS_CONFIG=/app/models.toml
+EDGEQUAKE_API_URL=http://localhost:11432
+
+# Ollama Configuration (only needed if EDGEQUAKE_LLM_PROVIDER=ollama)
+OLLAMA_HOST=http://host.docker.internal:11434
+
+# ---------------------------------------------------------------------------
+# PDF Vision Processing (Optional - for scanned/complex PDFs)
+# 
+# Only used when running in OpenAI mode with vision-capable model.
+# Timeout in seconds for vision LLM processing per document.
+# ---------------------------------------------------------------------------
+EDGEQUAKE_VISION_TIMEOUT_SECS=600
+
+# ---------------------------------------------------------------------------
+# Debugging & Logging (Optional)
+# ---------------------------------------------------------------------------
+RUST_LOG=debug,edgequake=debug
+RUST_BACKTRACE=1
+
+# ============================================================================
+# Notes:
+# 1. POSTGRES_PASSWORD must be a strong password for production deployments
+# 2. For Portainer, set `EDGEQUAKE_API_URL` to the public host URL if you are
+#    accessing the UI from another machine.
+# 3. Ollama requires local service running on the Docker host (port 11434)
+# ============================================================================

--- a/edgequake/docker/.env.portainer.example
+++ b/edgequake/docker/.env.portainer.example
@@ -8,7 +8,7 @@
 # ---------------------------------------------------------------------------
 # PostgreSQL Database Configuration (Required)
 # ---------------------------------------------------------------------------
-POSTGRES_PASSWORD=SuperSecret123!
+POSTGRES_PASSWORD=CHANGE_ME
 POSTGRES_DB=edgequake
 POSTGRES_USER=edgequake
 
@@ -46,7 +46,7 @@ EDGEQUAKE_DEFAULT_EMBEDDING_DIMENSION=1024
 EDGEQUAKE_VISION_PROVIDER=openai
 EDGEQUAKE_VISION_MODEL=qwen3.5-35b-a3b
 EDGEQUAKE_MODELS_CONFIG=/app/models.toml
-EDGEQUAKE_API_URL=http://localhost:11432
+NEXT_PUBLIC_API_URL=http://localhost:11432
 
 # Ollama Configuration (only needed if EDGEQUAKE_LLM_PROVIDER=ollama)
 OLLAMA_HOST=http://host.docker.internal:11434
@@ -70,7 +70,8 @@ RUST_BACKTRACE=1
 # ============================================================================
 # Notes:
 # 1. POSTGRES_PASSWORD must be a strong password for production deployments
-# 2. For Portainer, set `EDGEQUAKE_API_URL` to the public host URL if you are
-#    accessing the UI from another machine.
+# 2. For Portainer, set `NEXT_PUBLIC_API_URL` to the browser-reachable backend
+#    URL before building the frontend image. If you access the UI from another
+#    machine, use that machine's host/IP or domain instead of localhost.
 # 3. Ollama requires local service running on the Docker host (port 11434)
 # ============================================================================

--- a/edgequake/docker/docker-compose-cpu-build.yml
+++ b/edgequake/docker/docker-compose-cpu-build.yml
@@ -1,14 +1,16 @@
 services:
   edgequake:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile
     image: docker-edgequake:latest
-    container_name: edgequake-backend
     restart: unless-stopped
     ports:
       - "11432:8080"
     environment:
       - HOST=0.0.0.0
       - PORT=8080
-      - DATABASE_URL=${DATABASE_URL:-postgresql://edgequake:${POSTGRES_PASSWORD:-edgequake_pass}@host.docker.internal:5432/edgequake_db}
+      - DATABASE_URL=postgresql://${POSTGRES_USER:-edgequake}:${POSTGRES_PASSWORD:-CHANGE_ME}@postgres:5432/${POSTGRES_DB:-edgequake}
       - EDGEQUAKE_MODELS_CONFIG=/app/models.toml
       - OPENAI_API_KEY=${OPENAI_API_KEY:-}
       - OPENAI_COMPATIBLE_API_KEY=${OPENAI_COMPATIBLE_API_KEY:-}
@@ -28,11 +30,14 @@ services:
       - WORKER_THREADS=2
       - RUST_LOG=debug,edgequake=debug,tower_http=warn,axum=warn
       - RUST_BACKTRACE=1
+    depends_on:
+      postgres:
+        condition: service_healthy
     extra_hosts:
       - "host.docker.internal:host-gateway"
     volumes:
       - type: bind
-        source: /root/edgequake/config/models.toml
+        source: ../../config/models.toml
         target: /app/models.toml
         read_only: true
     healthcheck:
@@ -43,11 +48,42 @@ services:
       start_period: 40s
 
   frontend:
+    build:
+      context: ../../
+      dockerfile: edgequake_webui/Dockerfile
+      args:
+        NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL:-http://localhost:11432}
     image: docker-frontend:latest
-    container_name: edgequake-frontend
     restart: unless-stopped
     ports:
       - "3000:3000"
     environment:
-      EDGEQUAKE_API_URL: ${EDGEQUAKE_API_URL:-http://localhost:11432}
       NODE_ENV: production
+    depends_on:
+      - edgequake
+
+  postgres:
+    build:
+      context: .
+      dockerfile: Dockerfile.postgres
+    image: docker-postgres:latest
+    restart: unless-stopped
+    ports:
+      - "${POSTGRES_PORT:-5432}:5432"
+    environment:
+      - POSTGRES_USER=${POSTGRES_USER:-edgequake}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-CHANGE_ME}
+      - POSTGRES_DB=${POSTGRES_DB:-edgequake}
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+      - ./init-extensions.sql:/docker-entrypoint-initdb.d/init.sql:ro
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-edgequake} -d ${POSTGRES_DB:-edgequake}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+
+volumes:
+  postgres-data:
+    driver: local

--- a/edgequake/docker/docker-compose-cpu-build.yml
+++ b/edgequake/docker/docker-compose-cpu-build.yml
@@ -1,0 +1,53 @@
+services:
+  edgequake:
+    image: docker-edgequake:latest
+    container_name: edgequake-backend
+    restart: unless-stopped
+    ports:
+      - "11432:8080"
+    environment:
+      - HOST=0.0.0.0
+      - PORT=8080
+      - DATABASE_URL=${DATABASE_URL:-postgresql://edgequake:${POSTGRES_PASSWORD:-edgequake_pass}@host.docker.internal:5432/edgequake_db}
+      - EDGEQUAKE_MODELS_CONFIG=/app/models.toml
+      - OPENAI_API_KEY=${OPENAI_API_KEY:-}
+      - OPENAI_COMPATIBLE_API_KEY=${OPENAI_COMPATIBLE_API_KEY:-}
+      - OPENAI_BASE_URL=${OPENAI_BASE_URL:-http://host.docker.internal:4000/v1}
+      - EDGEQUAKE_LLM_PROVIDER=${EDGEQUAKE_LLM_PROVIDER:-openai}
+      - EDGEQUAKE_LLM_MODEL=${EDGEQUAKE_LLM_MODEL:-qwen3.5-35b-a3b}
+      - EDGEQUAKE_EMBEDDING_PROVIDER=${EDGEQUAKE_EMBEDDING_PROVIDER:-openai}
+      - EDGEQUAKE_EMBEDDING_MODEL=${EDGEQUAKE_EMBEDDING_MODEL:-qwen3-embedding-0.6b}
+      - EDGEQUAKE_EMBEDDING_DIMENSION=${EDGEQUAKE_EMBEDDING_DIMENSION:-1024}
+      - EDGEQUAKE_DEFAULT_LLM_PROVIDER=litellm-local
+      - EDGEQUAKE_DEFAULT_LLM_MODEL=qwen3.5-35b-a3b
+      - EDGEQUAKE_DEFAULT_EMBEDDING_PROVIDER=litellm-local
+      - EDGEQUAKE_DEFAULT_EMBEDDING_MODEL=qwen3-embedding-0.6b
+      - EDGEQUAKE_DEFAULT_EMBEDDING_DIMENSION=1024
+      - EDGEQUAKE_VISION_PROVIDER=${EDGEQUAKE_VISION_PROVIDER:-openai}
+      - EDGEQUAKE_VISION_MODEL=${EDGEQUAKE_VISION_MODEL:-qwen3.5-35b-a3b}
+      - WORKER_THREADS=2
+      - RUST_LOG=debug,edgequake=debug,tower_http=warn,axum=warn
+      - RUST_BACKTRACE=1
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    volumes:
+      - type: bind
+        source: /root/edgequake/config/models.toml
+        target: /app/models.toml
+        read_only: true
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
+
+  frontend:
+    image: docker-frontend:latest
+    container_name: edgequake-frontend
+    restart: unless-stopped
+    ports:
+      - "3000:3000"
+    environment:
+      EDGEQUAKE_API_URL: ${EDGEQUAKE_API_URL:-http://localhost:11432}
+      NODE_ENV: production

--- a/edgequake/docker/docker-compose.yml
+++ b/edgequake/docker/docker-compose.yml
@@ -51,14 +51,12 @@ services:
     build:
       context: ../../
       dockerfile: edgequake_webui/Dockerfile
-      args:
-        NEXT_PUBLIC_API_URL: http://localhost:8080
     container_name: edgequake-frontend
     restart: unless-stopped
     ports:
       - "${FRONTEND_PORT:-3000}:3000"
     environment:
-      - NEXT_PUBLIC_API_URL=http://localhost:8080
+      - EDGEQUAKE_API_URL=http://localhost:8080
       - NODE_ENV=production
     depends_on:
       - edgequake

--- a/edgequake/docker/docker-compose.yml
+++ b/edgequake/docker/docker-compose.yml
@@ -51,12 +51,13 @@ services:
     build:
       context: ../../
       dockerfile: edgequake_webui/Dockerfile
+      args:
+        NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL:-http://localhost:8080}
     container_name: edgequake-frontend
     restart: unless-stopped
     ports:
       - "${FRONTEND_PORT:-3000}:3000"
     environment:
-      - EDGEQUAKE_API_URL=http://localhost:8080
       - NODE_ENV=production
     depends_on:
       - edgequake

--- a/edgequake/docker/portainer-compose.yml
+++ b/edgequake/docker/portainer-compose.yml
@@ -1,0 +1,53 @@
+services:
+  edgequake:
+    image: docker-edgequake:latest
+    container_name: edgequake-backend
+    restart: unless-stopped
+    ports:
+      - "11432:8080"
+    environment:
+      - HOST=0.0.0.0
+      - PORT=8080
+      - DATABASE_URL=${DATABASE_URL:-postgresql://edgequake:${POSTGRES_PASSWORD:-edgequake_pass}@host.docker.internal:5432/edgequake_db}
+      - EDGEQUAKE_MODELS_CONFIG=/app/models.toml
+      - OPENAI_API_KEY=${OPENAI_API_KEY:-}
+      - OPENAI_COMPATIBLE_API_KEY=${OPENAI_COMPATIBLE_API_KEY:-sk-0000}
+      - OPENAI_BASE_URL=${OPENAI_BASE_URL:-http://host.docker.internal:4000/v1}
+      - EDGEQUAKE_LLM_PROVIDER=${EDGEQUAKE_LLM_PROVIDER:-openai}
+      - EDGEQUAKE_LLM_MODEL=${EDGEQUAKE_LLM_MODEL:-qwen3.5-35b-a3b}
+      - EDGEQUAKE_EMBEDDING_PROVIDER=${EDGEQUAKE_EMBEDDING_PROVIDER:-openai}
+      - EDGEQUAKE_EMBEDDING_MODEL=${EDGEQUAKE_EMBEDDING_MODEL:-qwen3-embedding-0.6b}
+      - EDGEQUAKE_EMBEDDING_DIMENSION=${EDGEQUAKE_EMBEDDING_DIMENSION:-1024}
+      - EDGEQUAKE_DEFAULT_LLM_PROVIDER=litellm-local
+      - EDGEQUAKE_DEFAULT_LLM_MODEL=qwen3.5-35b-a3b
+      - EDGEQUAKE_DEFAULT_EMBEDDING_PROVIDER=litellm-local
+      - EDGEQUAKE_DEFAULT_EMBEDDING_MODEL=qwen3-embedding-0.6b
+      - EDGEQUAKE_DEFAULT_EMBEDDING_DIMENSION=1024
+      - EDGEQUAKE_VISION_PROVIDER=${EDGEQUAKE_VISION_PROVIDER:-openai}
+      - EDGEQUAKE_VISION_MODEL=${EDGEQUAKE_VISION_MODEL:-qwen3.5-35b-a3b}
+      - WORKER_THREADS=2
+      - RUST_LOG=debug,edgequake=debug,tower_http=warn,axum=warn
+      - RUST_BACKTRACE=1
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    volumes:
+      - type: bind
+        source: /root/edgequake/config/models.toml
+        target: /app/models.toml
+        read_only: true
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
+
+  frontend:
+    image: docker-frontend:latest
+    container_name: edgequake-frontend
+    restart: unless-stopped
+    ports:
+      - "3000:3000"
+    environment:
+      EDGEQUAKE_API_URL: ${EDGEQUAKE_API_URL:-http://localhost:11432}
+      NODE_ENV: production

--- a/edgequake/docker/portainer-compose.yml
+++ b/edgequake/docker/portainer-compose.yml
@@ -1,15 +1,16 @@
 services:
   edgequake:
-    # docker build -t docker-edgequake:latest -f edgequake/docker/Dockerfile edgequake
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile
     image: docker-edgequake:latest
-    container_name: edgequake-backend
     restart: unless-stopped
     ports:
       - "11432:8080"
     environment:
       - HOST=0.0.0.0
       - PORT=8080
-      - DATABASE_URL=${DATABASE_URL:-postgresql://edgequake:${POSTGRES_PASSWORD:-edgequake_pass}@host.docker.internal:5432/edgequake_db}
+      - DATABASE_URL=postgresql://${POSTGRES_USER:-edgequake}:${POSTGRES_PASSWORD:-CHANGE_ME}@postgres:5432/${POSTGRES_DB:-edgequake}
       - EDGEQUAKE_MODELS_CONFIG=/app/models.toml
       - OPENAI_API_KEY=${OPENAI_API_KEY:-}
       - OPENAI_COMPATIBLE_API_KEY=${OPENAI_COMPATIBLE_API_KEY:-sk-0000}
@@ -31,11 +32,14 @@ services:
       - WORKER_THREADS=2
       - RUST_LOG=debug,edgequake=debug,tower_http=warn,axum=warn
       - RUST_BACKTRACE=1
+    depends_on:
+      postgres:
+        condition: service_healthy
     extra_hosts:
       - "host.docker.internal:host-gateway"
     volumes:
       - type: bind
-        source: /root/edgequake/config/models.toml
+        source: ../../config/models.toml
         target: /app/models.toml
         read_only: true
     healthcheck:
@@ -46,12 +50,42 @@ services:
       start_period: 40s
 
   frontend:
-    # docker build -t docker-frontend:latest -f edgequake_webui/Dockerfile .
+    build:
+      context: ../../
+      dockerfile: edgequake_webui/Dockerfile
+      args:
+        NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL:-http://localhost:11432}
     image: docker-frontend:latest
-    container_name: edgequake-frontend
     restart: unless-stopped
     ports:
       - "3000:3000"
     environment:
-      EDGEQUAKE_API_URL: ${EDGEQUAKE_API_URL:-http://localhost:11432}
       NODE_ENV: production
+    depends_on:
+      - edgequake
+
+  postgres:
+    build:
+      context: .
+      dockerfile: Dockerfile.postgres
+    image: docker-postgres:latest
+    restart: unless-stopped
+    ports:
+      - "${POSTGRES_PORT:-5432}:5432"
+    environment:
+      - POSTGRES_USER=${POSTGRES_USER:-edgequake}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-CHANGE_ME}
+      - POSTGRES_DB=${POSTGRES_DB:-edgequake}
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+      - ./init-extensions.sql:/docker-entrypoint-initdb.d/init.sql:ro
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-edgequake} -d ${POSTGRES_DB:-edgequake}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+
+volumes:
+  postgres-data:
+    driver: local

--- a/edgequake/docker/portainer-compose.yml
+++ b/edgequake/docker/portainer-compose.yml
@@ -1,5 +1,6 @@
 services:
   edgequake:
+    # docker build -t docker-edgequake:latest -f edgequake/docker/Dockerfile edgequake
     image: docker-edgequake:latest
     container_name: edgequake-backend
     restart: unless-stopped
@@ -25,6 +26,8 @@ services:
       - EDGEQUAKE_DEFAULT_EMBEDDING_DIMENSION=1024
       - EDGEQUAKE_VISION_PROVIDER=${EDGEQUAKE_VISION_PROVIDER:-openai}
       - EDGEQUAKE_VISION_MODEL=${EDGEQUAKE_VISION_MODEL:-qwen3.5-35b-a3b}
+      - EDGEQUAKE_VISION_TIMEOUT_SECS=${EDGEQUAKE_VISION_TIMEOUT_SECS:-600}
+      - PDFIUM_AUTO_CACHE_DIR=${PDFIUM_AUTO_CACHE_DIR:-/tmp/edgequake-pdfium-cache}
       - WORKER_THREADS=2
       - RUST_LOG=debug,edgequake=debug,tower_http=warn,axum=warn
       - RUST_BACKTRACE=1
@@ -43,6 +46,7 @@ services:
       start_period: 40s
 
   frontend:
+    # docker build -t docker-frontend:latest -f edgequake_webui/Dockerfile .
     image: docker-frontend:latest
     container_name: edgequake-frontend
     restart: unless-stopped


### PR DESCRIPTION
## Summary
This PR adds Portainer-oriented stack defaults and deployment documentation for EdgeQuake.

## Why
The repository already supports Docker-based deployments, but Portainer users need a ready-to-use stack file and clear environment defaults so they can run the project without hand-assembling the container configuration.

## Changes
- Add a Portainer stack compose example
- Add a Portainer environment example file
- Add a minimal CPU-only build that delegates inference to local or external APIs instead of running GPU-heavy workloads inside EdgeQuake
- Update the deployment guide to match the runtime config flow
- Include the PDF ingest cache defaults needed by containerized deployments

## Validation
- Branch was cherry-picked from the existing deployment/Portainer work
- The changes are documentation and deployment examples only