### PR TITLE
fix: MermaidBlock — safe fallback to source display when Mermaid parse fails

### DIFF
--- a/edgequake/crates/edgequake-api/src/safety_limits.rs
+++ b/edgequake/crates/edgequake-api/src/safety_limits.rs
@@ -319,8 +319,9 @@ fn check_api_key(provider_name: &str) -> Result<()> {
         "openrouter" => ("OPENROUTER_API_KEY", "OpenRouter"),
         _ => return Ok(()), // Local / key-less providers (ollama, lmstudio, mock, etc.)
     };
-    let key_present =
-        std::env::var(env_var).map(|v| !v.trim().is_empty()).unwrap_or(false);
+    let key_present = std::env::var(env_var)
+        .map(|v| !v.trim().is_empty())
+        .unwrap_or(false);
     if !key_present {
         return Err(LlmError::ConfigError(format!(
             "{env_var} is not set. To use the {display_name} provider, \

--- a/edgequake/docker/Dockerfile
+++ b/edgequake/docker/Dockerfile
@@ -36,6 +36,11 @@ COPY crates/ crates/
 COPY src/ src/
 COPY migrations/ migrations/
 COPY .sqlx .sqlx/
+# WHY: models.toml defines available LLM providers/models (gpt-5.4, claude-sonnet-4-6,
+# gemma4, etc.). The binary falls back to built-in defaults (edgequake-llm v0.5.1) which
+# only include gpt-4o and gpt-4o-mini — the new models are only in models.toml.
+# We copy it into the build layer so Stage 2 can retrieve it via --from=builder.
+COPY models.toml models.toml
 
 # Build release binary with SQLx offline mode (no database needed at build time).
 # pdfium-auto downloads and embeds the correct pdfium binary for TARGETPLATFORM.
@@ -70,9 +75,13 @@ ENV PDFIUM_AUTO_CACHE_DIR=/tmp/edgequake-pdfium-cache
 
 # Copy binary from builder
 COPY --from=builder /app/target/release/edgequake /usr/local/bin/
+# Copy models.toml so the runtime binary finds up-to-date models at ./models.toml
+# (CWD=/app, see WORKDIR above). Without this, the binary falls back to the compiled-in
+# defaults which lack the v0.9.8 models (gpt-5.4, claude-sonnet-4-6, gemma4).
+COPY --from=builder /app/models.toml /app/models.toml
 
 # Set ownership
-RUN chown edgequake:edgequake /usr/local/bin/edgequake
+RUN chown edgequake:edgequake /usr/local/bin/edgequake /app/models.toml
 
 # Switch to non-root user
 USER edgequake

--- a/edgequake_webui/src/components/query/markdown/MermaidBlock.tsx
+++ b/edgequake_webui/src/components/query/markdown/MermaidBlock.tsx
@@ -16,7 +16,7 @@ import {
     DialogTitle,
 } from '@/components/ui/dialog';
 import { cn } from '@/lib/utils';
-import { AlertTriangle, GitBranch, Maximize2, RefreshCw } from 'lucide-react';
+import { GitBranch, Maximize2, RefreshCw } from 'lucide-react';
 import { useTheme } from 'next-themes';
 import { memo, useEffect, useId, useRef, useState } from 'react';
 
@@ -103,6 +103,17 @@ export function sanitizeMermaidCode(code: string): { sanitized: string; issues: 
   if (sanitized.startsWith('```')) {
     sanitized = sanitized.replace(/^```(?:mermaid)?\n?/, '').replace(/\n?```$/, '');
     issues.push('Removed code block markers');
+  }
+
+  // Strip HTML tags from node labels.
+  // WHY: LLMs frequently emit <br>, <br/>, <b>, <i> etc. inside Mermaid node labels.
+  // Mermaid's tokeniser treats `<` as a shape delimiter (asymmetric node shape),
+  // so `<br>` in a label causes a parse error even with htmlLabels:true.
+  // We strip all HTML tags here; Mermaid's own \n handling is sufficient for layout.
+  if (/<[a-zA-Z][^>]*>|<\/[a-zA-Z]+>/.test(sanitized)) {
+    sanitized = sanitized.replace(/<br\s*\/?>/gi, ' ')  // <br> → space (most common)
+                          .replace(/<[^>]+>/g, '');     // strip any remaining HTML tags
+    issues.push('Stripped HTML tags from diagram source');
   }
 
   const lines = sanitized.split('\n');
@@ -198,7 +209,63 @@ export function sanitizeMermaidCode(code: string): { sanitized: string; issues: 
   return { sanitized, issues };
 }
 
-
+/**
+ * MermaidFallback — renders Mermaid source as a styled code block.
+ *
+ * Single Responsibility: display diagram syntax as readable text when SVG
+ * rendering is impossible. Never shows a red error panel; always preserves
+ * the diagram's information content so the user can read or copy it.
+ *
+ * WHY (First Principle): a diagram that can't be rendered still carries
+ * its full information in source form. Hiding it behind an error panel
+ * destroys that information; a code block exposes it.
+ */
+function MermaidFallback({
+  code,
+  className,
+  onRetry,
+}: {
+  code: string;
+  className?: string;
+  onRetry?: () => void;
+}) {
+  // Strip markdown fences — the plain source is what we display.
+  let source = code.trim();
+  if (source.startsWith('```')) {
+    source = source.replace(/^```(?:mermaid)?\n?/, '').replace(/\n?```$/, '').trim();
+  }
+  return (
+    <div
+      className={cn('my-4 rounded-lg border border-border overflow-hidden', className)}
+      role="figure"
+      aria-label="Mermaid diagram source"
+    >
+      {/* Header bar — minimal, non-alarming */}
+      <div className="flex items-center justify-between gap-2 px-4 py-2 bg-muted/60 border-b border-border/60">
+        <div className="flex items-center gap-2">
+          <GitBranch className="h-3.5 w-3.5 text-muted-foreground" aria-hidden="true" />
+          <span className="text-xs text-muted-foreground font-medium">Mermaid diagram (source)</span>
+        </div>
+        {onRetry && (
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-6 w-6 p-0 text-muted-foreground hover:text-foreground"
+            onClick={onRetry}
+            aria-label="Retry rendering diagram"
+            title="Retry"
+          >
+            <RefreshCw className="h-3.5 w-3.5" aria-hidden="true" />
+          </Button>
+        )}
+      </div>
+      {/* Source code — plain, selectable, scrollable */}
+      <pre className="overflow-x-auto p-4 text-xs leading-relaxed text-foreground/80 bg-muted/20 whitespace-pre">
+        <code>{source}</code>
+      </pre>
+    </div>
+  );
+}
 
 export const MermaidBlock = memo(function MermaidBlock({
   code,
@@ -343,53 +410,14 @@ export const MermaidBlock = memo(function MermaidBlock({
     );
   }
 
-  // Error state — graceful <pre> fallback showing raw source with friendly message
-  // instead of propagating the error to the Next.js overlay.
+  // Fallback: when Mermaid parsing fails even after sanitization, display the source
+  // as a styled code block instead of an error panel.
+  //
+  // WHY (First Principle): The diagram's information content lives in its source.
+  // A red error panel blocks that content; a code block preserves it.
+  // SOLID-SRP: MermaidFallback owns exactly one concern — rendering Mermaid as text.
   if (error) {
-    return (
-      <div
-        className={cn(
-          'my-4 rounded-lg border border-destructive/50 bg-destructive/5 p-4',
-          className
-        )}
-        role="alert"
-        aria-label="Diagram rendering failed"
-      >
-        <div className="flex items-start gap-3">
-          <AlertTriangle className="h-5 w-5 text-destructive shrink-0 mt-0.5" aria-hidden="true" />
-          <div className="flex-1 min-w-0">
-            <p className="text-sm font-medium text-destructive">
-              Failed to render Mermaid diagram
-            </p>
-            <p className="mt-1 text-xs text-destructive/70 break-words">{error}</p>
-            {/* Always show the raw source so users can inspect / copy it */}
-            <p className="mt-3 text-xs text-muted-foreground font-medium">Source (raw):</p>
-            <pre className="mt-1 overflow-x-auto rounded bg-muted p-3 text-xs text-muted-foreground whitespace-pre-wrap">
-              <code>{code}</code>
-            </pre>
-            {sanitizedCode && sanitizedCode !== code && (
-              <details className="mt-2">
-                <summary className="cursor-pointer text-xs text-muted-foreground hover:text-foreground">
-                  Show sanitized version
-                </summary>
-                <pre className="mt-1 overflow-x-auto rounded bg-muted p-3 text-xs text-muted-foreground whitespace-pre-wrap">
-                  <code>{sanitizedCode}</code>
-                </pre>
-              </details>
-            )}
-          </div>
-          <Button
-            variant="ghost"
-            size="sm"
-            className="text-destructive hover:text-destructive hover:bg-destructive/10"
-            onClick={handleRetry}
-            aria-label="Retry rendering diagram"
-          >
-            <RefreshCw className="h-4 w-4" aria-hidden="true" />
-          </Button>
-        </div>
-      </div>
-    );
+    return <MermaidFallback code={code} className={className} onRetry={handleRetry} />;
   }
 
   // Success - render the SVG with full-view button

--- a/edgequake_webui/src/components/query/markdown/MermaidBlock.tsx
+++ b/edgequake_webui/src/components/query/markdown/MermaidBlock.tsx
@@ -133,9 +133,11 @@ export function sanitizeMermaidCode(code: string): { sanitized: string; issues: 
 
     // Fix node definitions with bracket-style labels that contain special characters.
     // Matches patterns like: NodeId[label text] or NodeId[label (with parens)]
-    // Character class now includes forward-slash `/` and backslash `\`.
+    // Character class includes: parens, braces, pipes, angle brackets, slashes,
+    // @, &, #, : (common in email addresses and URLs), and Unicode.
+    // WHY: @ triggers LINK_ID token; & triggers AMP; # and : cause parser confusion.
     let processedLine = line.replace(
-      /([A-Za-z0-9_\u4e00-\u9fff\u3400-\u4dbf]+)\[([^\]"]*[(){}|><\/\\\u4e00-\u9fff\u3400-\u4dbf\u3000-\u303f\uff00-\uffef][^\]"]*)\]/g,
+      /([A-Za-z0-9_\u4e00-\u9fff\u3400-\u4dbf]+)\[([^\]"]*[(){}|><\/\\@&#:\u4e00-\u9fff\u3400-\u4dbf\u3000-\u303f\uff00-\uffef][^\]"]*)\]/g,
       (_match, nodeId: string, labelText: string) => {
         // If the label already has quotes, leave it alone
         if (labelText.startsWith('"') && labelText.endsWith('"')) return _match;
@@ -149,9 +151,9 @@ export function sanitizeMermaidCode(code: string): { sanitized: string; issues: 
 
     // Fix rhombus/diamond nodes with special chars: NodeId{label/with/slashes}
     // Mermaid `A{label}` is a valid rhombus but the label must be quoted if it
-    // contains `/`, `\`, `|`, `<`, `>` or Unicode.
+    // contains `/`, `\`, `|`, `<`, `>`, `@`, `&`, `#`, `:` or Unicode.
     processedLine = processedLine.replace(
-      /([A-Za-z0-9_]+)\{([^}"]*[/\\|<>\u4e00-\u9fff\u3400-\u4dbf][^}"]*)\}/g,
+      /([A-Za-z0-9_]+)\{([^}"]*[/\\|<>@&#:\u4e00-\u9fff\u3400-\u4dbf][^}"]*)\}/g,
       (_match, nodeId: string, labelText: string) => {
         if (labelText.startsWith('"') && labelText.endsWith('"')) return _match;
         const escaped = labelText.replace(/"/g, '#quot;');
@@ -172,6 +174,20 @@ export function sanitizeMermaidCode(code: string): { sanitized: string; issues: 
         const escaped = content.replace(/"/g, '#quot;');
         issues.push(`Fixed bare curly-brace node: {${content}} → _bare_${bareNodeCounter}["${escaped}"]`);
         return `_bare_${bareNodeCounter}["${escaped}"]`;
+      }
+    );
+
+    // Fix round-bracket (stadium) node labels that contain special characters.
+    // e.g. `A(user@domain.com)` → `A("user@domain.com")`
+    // WHY: `@`, `&`, `|`, `#`, `:`, `<`, `>`, `/`, `\` inside `()` labels
+    // cause Mermaid parse errors because the lexer interprets them as tokens.
+    processedLine = processedLine.replace(
+      /([A-Za-z0-9_]+)\(([^()"]*[@&|#:<>/\\][^()"]*)\)/g,
+      (_match, nodeId: string, labelText: string) => {
+        if (labelText.startsWith('"') && labelText.endsWith('"')) return _match;
+        const escaped = labelText.replace(/"/g, '#quot;');
+        issues.push(`Quoted round-bracket label: ${nodeId}("${escaped}")`);
+        return `${nodeId}("${escaped}")`;
       }
     );
 
@@ -347,7 +363,10 @@ export const MermaidBlock = memo(function MermaidBlock({
         }
       } catch (err) {
         if (!cancelled) {
-          console.error('Mermaid render error:', err);
+          // WHY: console.error() in Next.js dev mode triggers the global error overlay
+          // even when the error is caught and handled gracefully. We use console.debug
+          // so the info is visible in DevTools without polluting the overlay.
+          console.debug('[mermaid] graceful fallback:', err instanceof Error ? err.message : err);
           setError(err instanceof Error ? err.message : 'Failed to render diagram');
           setSvg(null);
         }
@@ -358,7 +377,10 @@ export const MermaidBlock = memo(function MermaidBlock({
       }
     }
 
-    renderDiagram();
+    // WHY: .catch(()=>{}) prevents an unhandled-promise-rejection if renderDiagram
+    // throws synchronously after being awaited (e.g., mermaid import failure).
+    // All intentional error paths are already handled inside the function.
+    renderDiagram().catch(() => {});
 
     return () => {
       cancelled = true;


### PR DESCRIPTION
## Problem

LLM-generated Mermaid diagrams that contain **`<br>` HTML tags** inside node labels fail to parse. Mermaid's tokeniser treats `<` as a shape-delimiter character, so `<br>` inside a label is seen as an asymmetric-shape token, not an HTML line-break. A diagram like:

```mermaid
graph TD
  billing_period_sub("Mar 27, 2026 – Apr 26, 2026<br>(Billing period)")
```

…causes a parse error on the `<br>` token. The current error state rendered a **red destructive panel** _and_ triggered the **Next.js error overlay**, making the entire UI feel broken.

## Root cause

1. `<br>` / HTML tags in Mermaid labels — `<` is a Mermaid shape token
2. On double parse-failure (original + sanitized both rejected), the component set `error` state and displayed a loud red UI component that caused the Next.js error overlay to appear

## Changes (First Principles / SOLID / DRY)

### `sanitizeMermaidCode()`
- **Strips HTML tags** (`<br>`, `<b>`, `<i>`, etc.) from the source before parsing
- `<br>` → space (most informative replacement); all other HTML tags stripped
- WHY: these are the most common LLM artefacts; stripping them recovers many diagrams without needing a fallback at all

### `MermaidFallback` component (new, SRP)
- **Single Responsibility**: renders Mermaid source as a styled code block
- No red border, no AlertTriangle, no destructive styling
- Has a subtle header badge `Mermaid diagram (source)` + optional retry button
- WHY (First Principle): the diagram's information lives in its source; hiding it behind an error destroys that information; a code block preserves it

### Error state
- Replaced red destructive panel with `<MermaidFallback />`
- Removed unused `AlertTriangle` import
- Result: unparseable diagrams degrade **gracefully** — user can read and copy the source, no alarming UI, no Next.js overlay

## Result

| Before | After |
|--------|-------|
| Red error panel + Next.js error overlay | Clean code block with subtle badge |
| Source hidden behind `Source (raw):` label | Source directly visible and selectable |
| `AlertTriangle` + destructive colours | `GitBranch` icon + neutral border |

Build: ✅ `bun run build` passes, `tsc --noEmit` zero errors