### PR TITLE
Release 0.9.18: fix issue 144 deployment, config, docs, and licensing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,9 +5,11 @@
 # LLM Provider Configuration (CRITICAL - READ THIS)
 # =============================================================================
 # EdgeQuake uses explicit environment variables to determine which LLM provider to use.
-# 
-# RECOMMENDATION: Always explicitly set EDGEQUAKE_DEFAULT_LLM_PROVIDER to avoid
-# configuration confusion. The provider selection should be predictable and clear.
+#
+# RECOMMENDATION: Prefer the canonical EDGEQUAKE_* names below. Compatibility
+# aliases (`MODEL_PROVIDER`, `CHAT_MODEL`, `EMBEDDING_PROVIDER`,
+# `EMBEDDING_MODEL`, `EMBEDDING_DIMENSION`) are also accepted for migration,
+# but the canonical EdgeQuake names take precedence.
 
 # -----------------------------------------------------------------------------
 # Workspace Default Models (REQUIRED FOR PREDICTABLE CONFIGURATION)
@@ -16,10 +18,17 @@
 # ALWAYS SET THESE to avoid auto-detection behavior:
 
 EDGEQUAKE_DEFAULT_LLM_PROVIDER=openai
-EDGEQUAKE_DEFAULT_LLM_MODEL=gpt-4o-mini
+EDGEQUAKE_DEFAULT_LLM_MODEL=gpt-5-mini
 EDGEQUAKE_DEFAULT_EMBEDDING_PROVIDER=openai
 EDGEQUAKE_DEFAULT_EMBEDDING_MODEL=text-embedding-3-small
 EDGEQUAKE_DEFAULT_EMBEDDING_DIMENSION=1536
+
+# Compatibility aliases (optional; useful when reusing a LightRAG-style env file)
+# MODEL_PROVIDER=openai
+# CHAT_MODEL=gpt-5-mini
+# EMBEDDING_PROVIDER=openai
+# EMBEDDING_MODEL=text-embedding-3-small
+# EMBEDDING_DIMENSION=1536
 
 # SPEC-040: Vision LLM for PDF-to-Markdown conversion (edgequake-pdf2md)
 # Uses a vision-capable model to extract structured Markdown from PDF page images.
@@ -50,7 +59,7 @@ EDGEQUAKE_VISION_MODEL=gpt-4.1-nano
 # OPENAI_BASE_URL=https://api.openai.com/v1  # Optional: custom endpoint
 
 # Default OpenAI Models:
-#   - Chat/LLM: gpt-4o-mini (128K context, $0.15/$0.60 per 1M tokens)
+#   - Chat/LLM: gpt-5-mini
 #   - Embedding: text-embedding-3-small (1536 dimensions)
 
 # -----------------------------------------------------------------------------
@@ -105,8 +114,8 @@ OLLAMA_HOST=http://localhost:11434
 
 # =============================================================================
 # Database Configuration
-# ============================================================================= PostgreSQL Database URL (optional - enables persistent storage)
-# If not set, the application will use in-memory storage (data lost on restart)
+# =============================================================================
+# PostgreSQL is required for server mode.
 # Format: postgresql://username:password@host:port/database
 # DATABASE_URL=postgresql://postgres:postgres@localhost:5432/edgequake
 
@@ -117,17 +126,10 @@ HOST=0.0.0.0
 PORT=8080
 
 # =============================================================================
-# PDF Extraction Configuration (OODA-E2E-01)
+# PDF Extraction Configuration
 # =============================================================================
-# Path to libpdfium shared library for PDF text extraction.
-# Required for PDF upload processing. Without this, PDF extraction
-# falls back to MockBackend (returns empty content).
-#
-# Download from: https://github.com/bblanchon/pdfium-binaries/releases
-# Bundled with project at: edgequake/crates/edgequake-pdf/lib/lib/libpdfium.dylib
-#
-# The server will auto-discover the bundled library, but you can override:
-# PDFIUM_DYNAMIC_LIB_PATH=/path/to/libpdfium.dylib
+# pdfium is embedded automatically via edgequake-pdf2md/pdfium-auto.
+# No PDFIUM_DYNAMIC_LIB_PATH is required for normal installs.
 
 # =============================================================================
 # Worker Configuration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,38 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.9.18] - 2026-04-09
+
+### Fixed
+
+- **Issue #144 fully closed: prebuilt Docker path, env compatibility aliases, and OSS onboarding**.
+
+  **Implementation**
+  1. Added deterministic compatibility aliases for LightRAG-style environment names:
+     `MODEL_PROVIDER`, `CHAT_MODEL`, `EMBEDDING_PROVIDER`, `EMBEDDING_MODEL`,
+     `EMBEDDING_DIMENSION`.
+  2. Aliases are normalized into canonical `EDGEQUAKE_*` variables at startup and in app-state
+     constructors, so the rest of the provider stack keeps a single code path.
+  3. Workspace default resolution now honors the same aliases directly with explicit precedence:
+     `EDGEQUAKE_DEFAULT_*` → `EDGEQUAKE_*` → compatibility alias → compiled default.
+  4. Added unit and E2E coverage for the alias path to prevent regressions and empty-string /
+     Docker Compose edge cases.
+
+  **Docker / release**
+  1. `edgequake/docker/docker-compose.prebuilt.yml` now pulls the published
+     `ghcr.io/raphaelmansuy/edgequake-postgres` image instead of building PostgreSQL locally.
+  2. The documented prebuilt path is now truly all-prebuilt: API, frontend, and PostgreSQL are
+     all versioned GHCR images.
+
+  **Documentation**
+  1. Rewrote `CONTRIBUTING.md` to standard open-source contribution flow.
+  2. Updated Docker and configuration docs with the compatibility alias mapping and the versioned
+     prebuilt-image workflow.
+  3. Updated the LightRAG migration guide with alias examples and explicit tenant/workspace
+     guidance: for 1,000 businesses, use 1,000 tenants and then add workspaces inside each tenant.
+  4. Normalized project-owned release metadata and SDK manifests to Apache-2.0 only so published
+     artifacts match the repository `LICENSE`.
+
 ## [0.9.17] - 2026-04-09
 
 ### Fixed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,484 +1,121 @@
 # Contributing to EdgeQuake
 
-Thank you for your interest in EdgeQuake! This document outlines how to contribute to the project.
+EdgeQuake accepts standard open-source contributions through GitHub issues and pull requests.
 
----
+## Before You Start
 
-## About EdgeQuake Development
+- Search existing [issues](https://github.com/raphaelmansuy/edgequake/issues) and [pull requests](https://github.com/raphaelmansuy/edgequake/pulls) before opening a new one.
+- For bug reports, include reproduction steps, expected behavior, actual behavior, logs, and environment details.
+- For larger changes, open an issue or discussion first so the direction is agreed before implementation.
 
-EdgeQuake is developed using a unique **100% automated** approach powered by **edgecode**, a State-of-the-Art (SOTA) coding agent created by **Raphaël MANSUY**.
+## Development Setup
 
-### Specification-Driven Development
-
-All development in EdgeQuake follows a **Specification-Driven Development** methodology:
-
-1. **Every change starts with a specification** in the `specs/` directory
-2. **Specifications are detailed and comprehensive** - they outline objectives, approach, and success criteria
-3. **edgecode implements from specifications** - the coding agent reads specs and implements the changes
-4. **Iterative OODA Loop** - each iteration produces: Observe → Orient → Decide → Act
-5. **No manual coding** - all code changes are generated from specifications
-
-### Example Specification Structure
-
-```
-specs/004-documentation-mission/
-├── ooda_loop/
-│   ├── iteration_01/
-│   │   ├── observe.md    # Data gathered, analysis
-│   │   ├── orient.md     # Gap analysis, findings
-│   │   ├── decide.md     # Action plan, priorities
-│   │   └── act.md        # Implementation, changes made
-│   ├── iteration_02/
-│   │   └── ...
-│   └── summary.md        # Cross-iteration insights
-```
-
----
-
-## Current Status: edgecode Is Not Yet Public
-
-**edgecode is being developed and will be released soon.**
-
-Until then, all contributions must go through **Raphaël MANSUY** directly.
-
----
-
-## How to Contribute
-
-### Bug Reports
-
-Report bugs using GitHub Issues:
-
-1. Go to [EdgeQuake Issues](https://github.com/raphaelmansuy/edgequake/issues)
-2. Click "New issue" → "Bug report"
-3. Provide:
-   - Clear description of the bug
-   - Steps to reproduce
-   - Expected behavior
-   - Actual behavior
-   - Environment (OS, Rust version, etc.)
-
-**Example:**
-
-```
-Title: PDF extraction fails with multi-column layouts
-
-Description:
-When uploading a PDF with 2-column layout, the text appears in wrong order.
-
-Steps to reproduce:
-1. Upload test_multicolumn.pdf via UI
-2. Check extracted chunks
-3. Notice text order is jumbled
-
-Expected: Text follows left-to-right, top-to-bottom reading order
-Actual: Text alternates between columns
-```
-
-### Feature Requests
-
-Suggest features using GitHub Discussions:
-
-1. Go to [EdgeQuake Discussions](https://github.com/raphaelmansuy/edgequake/discussions)
-2. Click "New discussion" → "Ideas"
-3. Provide:
-   - Clear description of desired feature
-   - Use case and rationale
-   - Proposed approach (if any)
-   - Examples or mockups (if applicable)
-
-**Example:**
-
-```
-Title: Support for streaming document uploads
-
-Description:
-For large documents (>100MB), streaming upload would improve user experience.
-
-Use Case:
-Users with slow connections struggle to upload large PDFs.
-
-Proposed Approach:
-- Add chunked upload endpoint: POST /api/v1/documents/stream
-- Client sends document in 5MB chunks
-- Server reassembles and processes
-
-Benefits:
-- Better UX for large files
-- Can show progress bar
-- Can retry individual chunks on failure
-```
-
-### Documentation Improvements
-
-Documentation improvements are welcome! For now:
-
-1. Fork the repository
-2. Make documentation changes
-3. Submit a pull request
-4. Request review from [@raphaelmansuy](https://github.com/raphaelmansuy)
-
-**Documentation changes don't require specifications** - they follow traditional PR workflow.
-
-### Major Contributions
-
-For major features or architectural changes:
-
-1. **Create a specification** in `specs/` following the OODA Loop structure
-2. **Describe the change in detail:**
-   - Problem statement
-   - Proposed solution
-   - Why it's needed
-   - Impact on existing code
-   - Testing strategy
-3. **Contact Raphaël MANSUY** for review and implementation
-4. edgecode will implement from your specification
-
----
-
-## Development Workflow
-
-### If You're Developing with edgecode
-
-1. **Write a detailed specification** in `specs/`
-2. **Use the OODA Loop structure:**
-   - `observe.md` - Analyze current state
-   - `orient.md` - Identify gaps and approach
-   - `decide.md` - Prioritize and plan
-   - `act.md` - Document implementation
-3. **Reference the specification file** in your development work
-4. **Use the commitment directives:**
-   - Commit messages: `OODA-XX: <decision summary>`
-   - Include specification files in commits
-
-### If You're Contributing Code Manually
-
-1. **Follow Rust style guidelines:**
-
-   ```bash
-   cargo fmt
-   cargo clippy
-   ```
-
-2. **Write tests:**
-   - Unit tests for components
-   - Integration tests for workflows
-   - E2E tests for user-facing features
-
-3. **Run the full test suite:**
-
-   ```bash
-   cargo test
-   ```
-
-4. **Check documentation:**
-   - Update docs/ if adding new features
-   - Keep AGENTS.md up to date if changing workflows
-
-5. **Use conventional commits:**
-
-   ```
-   <type>(<scope>): <subject>
-
-   <body>
-
-   <footer>
-   ```
-
-   Example:
-
-   ```
-   feat(pdf): add table detection enhancement
-
-   Implement enhanced table detection for multi-column layouts.
-   Uses vision mode to detect table boundaries before text extraction.
-
-   Fixes #123
-   ```
-
----
-
-## Project Structure
-
-### Source Code
-
-- **Backend**: `edgequake/crates/` - 11 Rust crates
-  - `edgequake-core/` - Orchestration
-  - `edgequake-llm/` - LLM providers
-  - `edgequake-storage/` - Storage adapters
-  - `edgequake-api/` - REST API
-  - `edgequake-pipeline/` - Document processing
-  - `edgequake-query/` - Query engine
-  - And 5 more...
-
-- **Frontend**: `edgequake_webui/` - React 19 + TypeScript
-
-### Documentation
-
-- **Main docs**: `docs/` - 44+ files, 10,000+ lines
-- **Guidelines**: `AGENTS.md` - Agent workflow
-- **Specifications**: `specs/` - OODA Loop iterations
-
-### Tests
-
-- **Backend tests**: `edgequake/crates/*/tests/`
-- **Frontend tests**: `edgequake_webui/tests/`
-- **E2E tests**: `e2e/`
-
----
-
-## Code Style
-
-### Rust Code
-
-- **Format**: Use `cargo fmt`
-- **Lint**: Use `cargo clippy`
-- **Naming**: PascalCase for types, snake_case for functions
-- **Comments**: Explain WHY, not WHAT
-- **Tests**: Every public API should have tests
-
-Example:
-
-```rust
-/// Extracts entities from a text chunk using LLM
-///
-/// # Arguments
-/// * `text` - The text to extract entities from
-/// * `entity_types` - Types of entities to extract
-///
-/// # Returns
-/// Vector of extracted entities with confidence scores
-pub async fn extract_entities(
-    text: &str,
-    entity_types: &[EntityType],
-) -> Result<Vec<Entity>> {
-    // Implementation
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[tokio::test]
-    async fn test_extract_entities() {
-        // Test implementation
-    }
-}
-```
-
-### TypeScript/React Code
-
-- **Format**: 2-space indentation
-- **Lint**: ESLint configuration in place
-- **Naming**: camelCase for functions/variables, PascalCase for components
-- **Comments**: Explain complex logic
-- **Props**: Use TypeScript interfaces
-
-Example:
-
-```typescript
-interface DocumentUploadProps {
-  onSuccess: (docId: string) => void;
-  maxSizeMB?: number;
-}
-
-export function DocumentUpload({
-  onSuccess,
-  maxSizeMB = 100,
-}: DocumentUploadProps) {
-  // Component implementation
-}
-```
-
-### Documentation
-
-- **Markdown**: Clear, concise, well-organized
-- **Links**: Use relative paths for internal links
-- **Code blocks**: Language-specific syntax highlighting
-- **Examples**: Provide working examples with expected output
-- **ASCII diagrams**: For architecture visualization
-
----
-
-## Testing
-
-### Backend Tests
+### Backend
 
 ```bash
-# Run all tests
+git clone https://github.com/raphaelmansuy/edgequake.git
+cd edgequake
+make postgres-start
+make dev-bg
+make status
+```
+
+### Frontend
+
+```bash
+cd edgequake_webui
+pnpm install
+pnpm dev
+```
+
+### Optional Providers
+
+- Ollama: `ollama serve`
+- OpenAI: `export OPENAI_API_KEY="sk-..."`
+
+## Architecture and Project Layout
+
+- Architecture overview: `docs/architecture/overview.md`
+- Crate reference: `docs/architecture/crates/README.md`
+- Runtime configuration: `docs/operations/configuration.md`
+- Docker and deployment: `docs/operations/docker-quickstart.md`, `docs/operations/deployment.md`
+- Current feature inventory: `docs/features.md`
+
+## Branching and Pull Requests
+
+1. Fork the repository and create a topic branch from the default branch.
+2. Make the smallest change that solves the problem.
+3. Add or update tests.
+4. Update documentation when behavior, configuration, or operations change.
+5. Open a pull request with:
+   - a concise summary
+   - linked issue numbers when applicable
+   - operational impact
+   - test evidence
+
+## Code Standards
+
+- Keep functions focused and avoid duplication.
+- Prefer explicit, deterministic configuration over heuristics.
+- Follow Rust idioms and run:
+
+```bash
+cargo fmt
+cargo clippy --workspace --all-targets
 cargo test
+```
 
-# Run tests for specific crate
+- For frontend changes, also run:
+
+```bash
+cd edgequake_webui
+pnpm test
+```
+
+## Testing Expectations
+
+- Unit tests for pure logic and helpers
+- Integration tests for crate boundaries
+- E2E coverage for user-visible behavior when configuration, routing, or workflows change
+
+Useful targeted commands:
+
+```bash
 cargo test -p edgequake-core
-
-# Run specific test
-cargo test --test e2e_pipeline
-
-# Run tests with output
-cargo test -- --nocapture
+cargo test -p edgequake-api --test e2e_provider_integration
+cargo test -p edgequake-api --test e2e_provider_status
 ```
 
-### Frontend Tests
+## Documentation Expectations
 
-```bash
-# Run all tests
-bun test
+Update docs when you change:
 
-# Run tests in watch mode
-bun test --watch
+- environment variables
+- Docker workflows
+- API behavior
+- contributor workflow
 
-# Run specific test file
-bun test document-upload
-```
+Preferred locations:
 
-### Quality Gates
+- user-facing operations: `docs/operations/`
+- tutorials and migration guidance: `docs/tutorials/`
+- architecture notes: `docs/architecture/`
 
-```bash
-# Run all quality checks
-make test-quality
+## Finding Work
 
-# Run specific checks
-make test-invariants  # Invariant tests
-make test-timing      # Test timing (<30s)
-make test-count       # Test count (>=2600)
-make test-flaky       # Detect flaky tests
-```
+- Start with issues labeled `good first issue`, `help wanted`, or `documentation`.
+- Use `docs/features.md` and the open issue tracker as the current roadmap snapshot.
+- If you want to propose a larger feature, open an issue with the problem statement, expected UX/API, rollout plan, and test plan.
 
----
+## Review Checklist
 
-## Making a Pull Request
+Before submitting, verify:
 
-1. **Fork the repository**
+- tests pass locally for the affected area
+- new env vars are documented
+- Docker instructions still work
+- no secrets or generated artifacts are committed
 
-2. **Create a feature branch:**
+## Community Standards
 
-   ```bash
-   git checkout -b feature/your-feature-name
-   ```
-
-3. **Make your changes and commit:**
-
-   ```bash
-   git commit -m "feat: add your feature"
-   ```
-
-4. **Push to your fork:**
-
-   ```bash
-   git push origin feature/your-feature-name
-   ```
-
-5. **Create a Pull Request on GitHub:**
-   - Clear title and description
-   - Link any related issues
-   - Include testing instructions
-
-6. **Wait for review from [@raphaelmansuy](https://github.com/raphaelmansuy)**
-
----
-
-## Contact Information
-
-### For Questions or Collaboration
-
-- **GitHub Issues**: [Bug reports and feature requests](https://github.com/raphaelmansuy/edgequake/issues)
-- **GitHub Discussions**: [General questions and ideas](https://github.com/raphaelmansuy/edgequake/discussions)
-- **GitHub**: [@raphaelmansuy](https://github.com/raphaelmansuy)
-- **LinkedIn**: [raphaelmansuy](https://www.linkedin.com/in/raphaelmansuy)
-- **Twitter/X**: [@raphaelmansuy](https://twitter.com/raphaelmansuy)
-
-### For Major Contributions
-
-Email or direct message **Raphaël MANSUY** via:
-
-- LinkedIn: [raphaelmansuy](https://www.linkedin.com/in/raphaelmansuy)
-- GitHub: [@raphaelmansuy](https://github.com/raphaelmansuy)
-
----
-
-## Development Tools
-
-### Required
-
-- **Rust**: 1.78+ ([Install](https://rustup.rs))
-- **Node.js**: 18+ or Bun 1.0+ ([Install](https://nodejs.org))
-- **Docker**: For PostgreSQL ([Install](https://www.docker.com))
-
-### Recommended
-
-- **VS Code**: With Rust Analyzer
-- **Ollama**: For local LLM ([Install](https://ollama.ai))
-- **PostgreSQL Client**: `psql` for database debugging
-
-### Make Commands
-
-```bash
-# Development
-make dev              # Start full stack
-make dev-bg           # Start in background
-make backend-dev      # Backend only
-make frontend-dev     # Frontend only
-
-# Testing
-make test             # Run all tests
-make lint             # Lint all code
-make format           # Format all code
-
-# Maintenance
-make clean            # Clean build artifacts
-make stop             # Stop all services
-```
-
----
-
-## Code of Conduct
-
-Please read and follow our [Code of Conduct](CODE_OF_CONDUCT.md). We are committed to providing a welcoming and inclusive environment for all contributors.
-
----
-
-## License
-
-By contributing to EdgeQuake, you agree that your contributions will be licensed under the Apache License 2.0. See [LICENSE](LICENSE) for details.
-
----
-
-## Questions?
-
-If you have any questions about contributing, please:
-
-1. Check [AGENTS.md](AGENTS.md) for detailed agent workflow documentation
-2. Review [docs/README.md](docs/README.md) for architecture and concepts
-3. Ask in [GitHub Discussions](https://github.com/raphaelmansuy/edgequake/discussions)
-4. Contact [@raphaelmansuy](https://github.com/raphaelmansuy)
-
-**Thank you for your interest in EdgeQuake!** 🙏
-
----
-
-## Versioning Workflow (Best Practice)
-
-EdgeQuake uses a unified, automated versioning strategy for both backend (Rust) and frontend (Next.js):
-
-1. **Single Source of Truth:**
-   - The root `VERSION` file holds the canonical version.
-   - All `Cargo.toml` files and `edgequake_webui/package.json` are updated to match.
-2. **Automated Bumping:**
-   - Use `make version-bump VERSION=<new_version>` to bump version everywhere.
-   - This updates `VERSION`, all `Cargo.toml`, and frontend `package.json`.
-3. **Tagging Releases:**
-   - Use `make version-tag VERSION=<new_version>` to commit, tag, and push the release.
-4. **Changelog:**
-   - Update `CHANGELOG.md` after each version bump.
-5. **Display:**
-   - Version is embedded in backend (via `build.rs`) and shown in the health API and frontend UI.
-
-**Example Release Flow:**
-
-```sh
-make version-bump VERSION=0.2.0
-# Update CHANGELOG.md
-make version-tag VERSION=0.2.0
-```
-
-See the Makefile and scripts/bump-version.sh for details.
+By participating, you agree to follow `CODE_OF_CONDUCT.md`.

--- a/docs/operations/configuration.md
+++ b/docs/operations/configuration.md
@@ -142,9 +142,25 @@ DATABASE_URL="postgresql://edgequake:pass@pgbouncer:6432/edgequake"
 | --------------------------------- | ------- | -------- | -------------------------------------------------- |
 | `EDGEQUAKE_MODELS_CONFIG`         | String  | None     | Path to custom models.toml                         |
 | `EDGEQUAKE_LLM_PROVIDER`          | String  | `ollama` | Default LLM provider                               |
+| `EDGEQUAKE_LLM_MODEL`             | String  | None     | Override LLM model name                            |
 | `EDGEQUAKE_EMBEDDING_PROVIDER`    | String  | `ollama` | Override embedding provider type (hybrid mode)     |
 | `EDGEQUAKE_EMBEDDING_MODEL`       | String  | None     | Override embedding model name                      |
 | `EDGEQUAKE_EMBEDDING_DIMENSION`   | Integer | `768`    | Override embedding vector dimension                |
+
+### Compatibility aliases
+
+EdgeQuake also accepts the following migration aliases. They are normalized at startup so the rest
+of the application continues to use the canonical `EDGEQUAKE_*` names:
+
+| Alias | Canonical variable |
+| --- | --- |
+| `MODEL_PROVIDER` | `EDGEQUAKE_LLM_PROVIDER` |
+| `CHAT_MODEL` | `EDGEQUAKE_LLM_MODEL` |
+| `EMBEDDING_PROVIDER` | `EDGEQUAKE_EMBEDDING_PROVIDER` |
+| `EMBEDDING_MODEL` | `EDGEQUAKE_EMBEDDING_MODEL` |
+| `EMBEDDING_DIMENSION` | `EDGEQUAKE_EMBEDDING_DIMENSION` |
+
+When both an alias and a canonical variable are set, the canonical variable wins.
 
 ### Hybrid Provider Mode (closes [#140](https://github.com/raphaelmansuy/edgequake/issues/140))
 

--- a/docs/operations/docker-quickstart.md
+++ b/docs/operations/docker-quickstart.md
@@ -19,7 +19,7 @@ curl -fsSL https://raw.githubusercontent.com/raphaelmansuy/edgequake/edgequake-m
   | docker compose -f - up -d
 ```
 
-That's it. Three images (API, Web UI, PostgreSQL) are pulled from GitHub Container Registry and started.
+That's it. Three versioned images (API, Web UI, PostgreSQL) are pulled from GitHub Container Registry and started.
 
 **Then open:** http://localhost:3000
 
@@ -114,6 +114,9 @@ OPENAI_BASE_URL=http://localhost:1234/v1 \
 | Variable                 | Default                             | Description                            |
 | ------------------------ | ----------------------------------- | -------------------------------------- |
 | `EDGEQUAKE_LLM_PROVIDER` | `ollama`                            | `ollama`, `openai`, `lmstudio`, `mock` |
+| `EDGEQUAKE_LLM_MODEL`    | provider-specific default           | Main chat / extraction model           |
+| `EDGEQUAKE_EMBEDDING_PROVIDER` | same as LLM                   | Override embedding provider            |
+| `EDGEQUAKE_EMBEDDING_MODEL` | provider-specific default        | Embedding model override               |
 | `OPENAI_API_KEY`         | _(empty)_                           | Required when provider is `openai`     |
 | `OPENAI_BASE_URL`        | _(empty)_                           | Override OpenAI base URL               |
 | `OLLAMA_HOST`            | `http://host.docker.internal:11434` | Ollama server address                  |
@@ -121,6 +124,20 @@ OPENAI_BASE_URL=http://localhost:1234/v1 \
 | `EDGEQUAKE_PORT`         | `8080`                              | API port                               |
 | `FRONTEND_PORT`          | `3000`                              | Web UI port                            |
 | `POSTGRES_PASSWORD`      | `edgequake_secret`                  | PostgreSQL password                    |
+
+### Migration aliases
+
+If you are migrating from a LightRAG-style environment file, EdgeQuake also accepts:
+
+| Alias | Canonical variable |
+| --- | --- |
+| `MODEL_PROVIDER` | `EDGEQUAKE_LLM_PROVIDER` |
+| `CHAT_MODEL` | `EDGEQUAKE_LLM_MODEL` |
+| `EMBEDDING_PROVIDER` | `EDGEQUAKE_EMBEDDING_PROVIDER` |
+| `EMBEDDING_MODEL` | `EDGEQUAKE_EMBEDDING_MODEL` |
+| `EMBEDDING_DIMENSION` | `EDGEQUAKE_EMBEDDING_DIMENSION` |
+
+Canonical `EDGEQUAKE_*` variables always win when both are set.
 
 ---
 

--- a/docs/tutorials/migration-from-lightrag.md
+++ b/docs/tutorials/migration-from-lightrag.md
@@ -279,6 +279,17 @@ curl -X PUT http://localhost:8080/api/v1/workspaces/$WORKSPACE_ID \
   }'
 ```
 
+Compatibility aliases are also supported if you want to reuse an existing env file during migration:
+
+```bash
+export MODEL_PROVIDER="openai"
+export CHAT_MODEL="gpt-5-nano"
+export EMBEDDING_MODEL="text-embedding-3-small"
+```
+
+EdgeQuake normalizes those aliases to its canonical `EDGEQUAKE_*` variables at startup. If both are
+set, the canonical `EDGEQUAKE_*` values take precedence.
+
 ### Storage Configuration
 
 **LightRAG**:
@@ -321,6 +332,20 @@ edgequake
 | Relationship extraction      | Same algorithm                     |
 | Query modes                  | Same: naive, local, global, hybrid |
 | Neo4j storage                | Apache AGE (PostgreSQL)            |
+
+---
+
+## Tenant and Workspace Planning
+
+For multi-business SaaS deployments, use **one tenant per business** and then create one or more
+workspaces inside that tenant for internal separation.
+
+Example for 1,000 businesses:
+
+- `1,000 tenants`
+- `N workspaces per tenant` for departments, environments, or use cases
+
+This keeps billing, permissions, quotas, and data isolation aligned with the business boundary.
 
 ---
 

--- a/edgequake/Cargo.lock
+++ b/edgequake/Cargo.lock
@@ -1391,7 +1391,7 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "edgequake"
-version = "0.9.17"
+version = "0.9.18"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1415,7 +1415,7 @@ dependencies = [
 
 [[package]]
 name = "edgequake-api"
-version = "0.9.17"
+version = "0.9.18"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1478,7 +1478,7 @@ dependencies = [
 
 [[package]]
 name = "edgequake-auth"
-version = "0.9.17"
+version = "0.9.18"
 dependencies = [
  "argon2",
  "async-trait",
@@ -1496,7 +1496,7 @@ dependencies = [
 
 [[package]]
 name = "edgequake-core"
-version = "0.9.17"
+version = "0.9.18"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1508,6 +1508,7 @@ dependencies = [
  "md5",
  "serde",
  "serde_json",
+ "serial_test",
  "sqlx",
  "tempfile",
  "thiserror 2.0.18",
@@ -1586,7 +1587,7 @@ dependencies = [
 
 [[package]]
 name = "edgequake-pipeline"
-version = "0.9.17"
+version = "0.9.18"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1607,7 +1608,7 @@ dependencies = [
 
 [[package]]
 name = "edgequake-query"
-version = "0.9.17"
+version = "0.9.18"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1649,7 +1650,7 @@ dependencies = [
 
 [[package]]
 name = "edgequake-storage"
-version = "0.9.17"
+version = "0.9.18"
 dependencies = [
  "async-trait",
  "chrono",

--- a/edgequake/Cargo.toml
+++ b/edgequake/Cargo.toml
@@ -68,10 +68,10 @@ criterion = { workspace = true }
 tokio-test = { workspace = true }
 
 [workspace.package]
-version = "0.9.17"
+version = "0.9.18"
 edition = "2021"
 rust-version = "1.78"
-license = "MIT OR Apache-2.0"
+license = "Apache-2.0"
 authors = ["EdgeQuake Team"]
 repository = "https://github.com/edgequake/edgequake"
 description = "High-performance RAG system with knowledge graph capabilities"

--- a/edgequake/README.md
+++ b/edgequake/README.md
@@ -3,7 +3,7 @@
 **High-Performance RAG with Knowledge Graph**
 
 [![Rust](https://img.shields.io/badge/rust-1.78+-orange.svg)](https://www.rust-lang.org)
-[![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue.svg)](LICENSE)
+[![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](LICENSE)
 [![Docker](https://img.shields.io/badge/docker-GHCR-blue.svg)](https://github.com/raphaelmansuy/edgequake/pkgs/container/edgequake)
 
 EdgeQuake is a next-generation Retrieval-Augmented Generation (RAG) system built in Rust, designed for high performance, reliability, and scalability. It combines vector similarity search with knowledge graph traversal to provide contextually rich answers.
@@ -208,12 +208,7 @@ Contributions are welcome! Please read our contributing guidelines before submit
 
 ## License
 
-Licensed under either of:
-
-- Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE))
-- MIT License ([LICENSE-MIT](LICENSE-MIT))
-
-at your option.
+Licensed under the Apache License, Version 2.0. See [LICENSE](../LICENSE).
 
 ## Acknowledgments
 

--- a/edgequake/crates/edgequake-api/src/handlers/workspaces/bulk_ops/mod.rs
+++ b/edgequake/crates/edgequake-api/src/handlers/workspaces/bulk_ops/mod.rs
@@ -160,7 +160,7 @@ pub(super) fn build_pdf_task(
         .vision_llm_provider
         .as_deref()
         .filter(|p| !p.is_empty())
-        .unwrap_or_else(|| workspace.llm_provider.as_str())
+        .unwrap_or(workspace.llm_provider.as_str())
         .to_string();
     let vision_model = workspace.vision_llm_model.clone().filter(|m| !m.is_empty());
 

--- a/edgequake/crates/edgequake-api/src/openapi.rs
+++ b/edgequake/crates/edgequake-api/src/openapi.rs
@@ -11,7 +11,7 @@ use crate::handlers;
         title = "EdgeQuake API",
         version = "0.1.0",
         description = "High-performance RAG system with Knowledge Graph",
-        license(name = "MIT OR Apache-2.0"),
+        license(name = "Apache-2.0"),
         contact(
             name = "EdgeQuake Team"
         )

--- a/edgequake/crates/edgequake-api/src/state/memory.rs
+++ b/edgequake/crates/edgequake-api/src/state/memory.rs
@@ -6,6 +6,7 @@
 use std::sync::Arc;
 
 use edgequake_auth::{AuthConfig, JwtService, PasswordService, RbacService};
+use edgequake_core::env::apply_model_env_aliases;
 use edgequake_core::{InMemoryConversationService, InMemoryWorkspaceService};
 use edgequake_llm::ModelsConfig;
 use edgequake_pipeline::Pipeline;
@@ -105,6 +106,8 @@ impl AppState {
     /// 4. Fallback to Mock provider
     pub fn new_memory(llm_api_key: Option<impl Into<String>>) -> Self {
         use edgequake_llm::ProviderFactory;
+
+        apply_model_env_aliases();
 
         // If API key provided, set it in environment for factory to use
         if let Some(key) = llm_api_key {

--- a/edgequake/crates/edgequake-api/src/state/postgres.rs
+++ b/edgequake/crates/edgequake-api/src/state/postgres.rs
@@ -6,6 +6,7 @@
 use std::sync::Arc;
 
 use edgequake_auth::{AuthConfig, JwtService, PasswordService, RbacService};
+use edgequake_core::env::apply_model_env_aliases;
 use edgequake_core::{ConversationServiceImpl, WorkspaceServiceImpl};
 use edgequake_llm::ModelsConfig;
 use edgequake_pipeline::Pipeline;
@@ -88,6 +89,8 @@ impl AppState {
         llm_api_key: impl Into<String>,
     ) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
         use edgequake_llm::ProviderFactory;
+
+        apply_model_env_aliases();
 
         let database_url = database_url.into();
         let llm_api_key = llm_api_key.into();

--- a/edgequake/crates/edgequake-api/tests/common/mod.rs
+++ b/edgequake/crates/edgequake-api/tests/common/mod.rs
@@ -31,6 +31,53 @@ pub const TEST_USER_ID: &str = "bbbbbbbb-0019-0019-0019-bbbbbbbbbbbb";
 /// Default test workspace ID (valid UUID for workspace-scoped operations).
 pub const TEST_WORKSPACE_ID: &str = "cccccccc-0019-0019-0019-cccccccccccc";
 
+/// Environment variables that influence provider auto-detection.
+///
+/// WHY: E2E tests must not depend on whatever third-party credentials happen to
+/// exist on the developer machine or CI runner. Keeping this list centralized
+/// makes provider-related tests deterministic and easier to maintain.
+const PROVIDER_DETECTION_ENV_VARS: &[&str] = &[
+    "EDGEQUAKE_LLM_PROVIDER",
+    "EDGEQUAKE_LLM_MODEL",
+    "EDGEQUAKE_EMBEDDING_PROVIDER",
+    "EDGEQUAKE_EMBEDDING_MODEL",
+    "EDGEQUAKE_EMBEDDING_DIMENSION",
+    "EDGEQUAKE_DEFAULT_LLM_PROVIDER",
+    "EDGEQUAKE_DEFAULT_LLM_MODEL",
+    "EDGEQUAKE_DEFAULT_EMBEDDING_PROVIDER",
+    "EDGEQUAKE_DEFAULT_EMBEDDING_MODEL",
+    "EDGEQUAKE_DEFAULT_EMBEDDING_DIMENSION",
+    "MODEL_PROVIDER",
+    "CHAT_MODEL",
+    "EMBEDDING_PROVIDER",
+    "EMBEDDING_MODEL",
+    "EMBEDDING_DIMENSION",
+    "OLLAMA_HOST",
+    "OLLAMA_MODEL",
+    "LMSTUDIO_HOST",
+    "LMSTUDIO_MODEL",
+    "OPENAI_API_KEY",
+    "OPENAI_BASE_URL",
+    "ANTHROPIC_API_KEY",
+    "GEMINI_API_KEY",
+    "GOOGLE_API_KEY",
+    "GOOGLE_ACCESS_TOKEN",
+    "GOOGLE_CLOUD_PROJECT",
+    "GOOGLE_CLOUD_REGION",
+    "GOOGLE_CLOUD_LOCATION",
+    "GOOGLE_APPLICATION_CREDENTIALS",
+    "MISTRAL_API_KEY",
+    "XAI_API_KEY",
+    "OPENROUTER_API_KEY",
+    "AZURE_OPENAI_API_KEY",
+    "AZURE_OPENAI_ENDPOINT",
+    "AZURE_OPENAI_CONTENTGEN_API_KEY",
+    "AZURE_OPENAI_CONTENTGEN_API_ENDPOINT",
+    "MINIMAX_API_KEY",
+    "HF_TOKEN",
+    "HUGGINGFACE_TOKEN",
+];
+
 // ============================================================================
 // App Setup
 // ============================================================================
@@ -50,6 +97,13 @@ pub fn create_test_app() -> axum::Router {
     };
     let server = Server::new(config, AppState::test_state());
     server.build_router()
+}
+
+/// Remove all environment variables that can change provider selection.
+pub fn clear_provider_detection_env() {
+    for key in PROVIDER_DETECTION_ENV_VARS {
+        std::env::remove_var(key);
+    }
 }
 
 // ============================================================================

--- a/edgequake/crates/edgequake-api/tests/e2e_provider_integration.rs
+++ b/edgequake/crates/edgequake-api/tests/e2e_provider_integration.rs
@@ -10,6 +10,9 @@
 //! @implements SPEC-032: Ollama/LM Studio provider support - Configuration validation
 //! @iteration OODA Loop #3 - Phase 5B
 
+mod common;
+
+use common::clear_provider_detection_env;
 use edgequake_api::state::AppState;
 use serial_test::serial;
 
@@ -32,10 +35,7 @@ fn is_ollama_available() -> bool {
 #[tokio::test]
 #[serial]
 async fn test_appstate_default_mock_provider() {
-    // Clean all provider environment variables
-    std::env::remove_var("EDGEQUAKE_LLM_PROVIDER");
-    std::env::remove_var("OLLAMA_HOST");
-    std::env::remove_var("OPENAI_API_KEY");
+    clear_provider_detection_env();
 
     // Create AppState - should use Mock provider
     let state = AppState::new_memory(None::<String>);
@@ -64,10 +64,8 @@ async fn test_appstate_default_mock_provider() {
 #[tokio::test]
 #[serial]
 async fn test_appstate_explicit_mock_selection() {
-    // Set explicit provider selection
+    clear_provider_detection_env();
     std::env::set_var("EDGEQUAKE_LLM_PROVIDER", "mock");
-    std::env::remove_var("OLLAMA_HOST");
-    std::env::remove_var("OPENAI_API_KEY");
 
     let state = AppState::new_memory(None::<String>);
 
@@ -75,7 +73,30 @@ async fn test_appstate_explicit_mock_selection() {
     assert_eq!(state.embedding_provider.dimension(), 1536);
 
     // Cleanup
-    std::env::remove_var("EDGEQUAKE_LLM_PROVIDER");
+    clear_provider_detection_env();
+}
+
+/// Test that compatibility aliases are normalized before provider factory use.
+#[tokio::test]
+#[serial]
+async fn test_appstate_model_provider_alias_selection() {
+    clear_provider_detection_env();
+    std::env::set_var("MODEL_PROVIDER", "mock");
+    std::env::set_var("CHAT_MODEL", "gpt-5-mini");
+    std::env::set_var("EMBEDDING_MODEL", "text-embedding-3-small");
+
+    let state = AppState::new_memory(None::<String>);
+
+    assert_eq!(state.llm_provider.name(), "mock");
+    assert_eq!(state.embedding_provider.name(), "mock");
+    assert_eq!(std::env::var("EDGEQUAKE_LLM_PROVIDER").unwrap(), "mock");
+    assert_eq!(std::env::var("EDGEQUAKE_LLM_MODEL").unwrap(), "gpt-5-mini");
+    assert_eq!(
+        std::env::var("EDGEQUAKE_EMBEDDING_MODEL").unwrap(),
+        "text-embedding-3-small"
+    );
+
+    clear_provider_detection_env();
 }
 
 /// Test dimension differences between Mock and Ollama providers.
@@ -83,9 +104,7 @@ async fn test_appstate_explicit_mock_selection() {
 #[serial]
 async fn test_provider_dimension_matrix() {
     // Test 1: Mock provider
-    std::env::remove_var("EDGEQUAKE_LLM_PROVIDER");
-    std::env::remove_var("OLLAMA_HOST");
-    std::env::remove_var("OPENAI_API_KEY");
+    clear_provider_detection_env();
 
     let state_mock = AppState::new_memory(None::<String>);
     let mock_dimension = state_mock.embedding_provider.dimension();

--- a/edgequake/crates/edgequake-api/tests/e2e_provider_status.rs
+++ b/edgequake/crates/edgequake-api/tests/e2e_provider_status.rs
@@ -3,20 +3,20 @@
 //! @implements SPEC-032: Ollama/LM Studio provider support - Status API tests
 //! @iteration OODA Loop #5 - Phase 5E.8
 
+mod common;
+
 use axum::{
     body::Body,
     http::{Request, StatusCode},
 };
+use common::clear_provider_detection_env;
 use serial_test::serial;
 use tower::ServiceExt;
 
 #[tokio::test]
 #[serial]
 async fn test_provider_status_mock() {
-    // Setup: Use Mock provider
-    std::env::remove_var("OPENAI_API_KEY");
-    std::env::remove_var("OLLAMA_HOST");
-    std::env::remove_var("EDGEQUAKE_LLM_PROVIDER");
+    clear_provider_detection_env();
 
     let app_state = edgequake_api::AppState::new_memory(None::<String>);
     let app = edgequake_api::create_router(app_state);
@@ -57,10 +57,8 @@ async fn test_provider_status_mock() {
 #[tokio::test]
 #[serial]
 async fn test_provider_status_ollama() {
-    // Setup: Use Ollama provider
+    clear_provider_detection_env();
     std::env::set_var("OLLAMA_HOST", "http://localhost:11434");
-    std::env::remove_var("OPENAI_API_KEY");
-    std::env::remove_var("EDGEQUAKE_LLM_PROVIDER");
 
     let app_state = edgequake_api::AppState::new_memory(None::<String>);
     let app = edgequake_api::create_router(app_state);
@@ -90,16 +88,13 @@ async fn test_provider_status_ollama() {
     assert_eq!(status["storage"]["dimension"], 768);
 
     // Cleanup
-    std::env::remove_var("OLLAMA_HOST");
+    clear_provider_detection_env();
 }
 
 #[tokio::test]
 #[serial]
 async fn test_provider_status_uptime() {
-    // Setup
-    std::env::remove_var("OPENAI_API_KEY");
-    std::env::remove_var("OLLAMA_HOST");
-    std::env::remove_var("EDGEQUAKE_LLM_PROVIDER");
+    clear_provider_detection_env();
 
     let app_state = edgequake_api::AppState::new_memory(None::<String>);
     let app = edgequake_api::create_router(app_state);
@@ -148,9 +143,7 @@ async fn test_provider_status_uptime() {
 async fn test_provider_status_dimension_mismatch() {
     // Setup: Create state with mismatched dimensions (if possible in future)
     // For now, just verify the field exists
-    std::env::remove_var("OPENAI_API_KEY");
-    std::env::remove_var("OLLAMA_HOST");
-    std::env::remove_var("EDGEQUAKE_LLM_PROVIDER");
+    clear_provider_detection_env();
 
     let app_state = edgequake_api::AppState::new_memory(None::<String>);
     let app = edgequake_api::create_router(app_state);

--- a/edgequake/crates/edgequake-core/Cargo.toml
+++ b/edgequake/crates/edgequake-core/Cargo.toml
@@ -35,3 +35,4 @@ tokio = { workspace = true, features = ["full", "macros", "rt-multi-thread"] }
 tokio-test = { workspace = true }
 edgequake-query = { path = "../edgequake-query" }
 tempfile = "3.10"
+serial_test = "3"

--- a/edgequake/crates/edgequake-core/src/config.rs
+++ b/edgequake/crates/edgequake-core/src/config.rs
@@ -258,6 +258,8 @@ impl Config {
     pub fn from_env() -> Self {
         let mut config = Self::default();
 
+        crate::env::apply_model_env_aliases();
+
         // Storage
         if let Ok(url) = std::env::var("EDGEQUAKE_DATABASE_URL") {
             config.storage.database_url = url;
@@ -302,6 +304,7 @@ impl Config {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serial_test::serial;
 
     #[test]
     fn test_default_config() {
@@ -322,5 +325,29 @@ mod tests {
     fn test_socket_addr() {
         let config = Config::default();
         assert_eq!(config.socket_addr(), "0.0.0.0:8080");
+    }
+
+    #[test]
+    #[serial]
+    fn test_from_env_supports_model_aliases() {
+        std::env::remove_var("EDGEQUAKE_LLM_PROVIDER");
+        std::env::remove_var("EDGEQUAKE_LLM_MODEL");
+        std::env::remove_var("EDGEQUAKE_EMBEDDING_MODEL");
+        std::env::set_var("MODEL_PROVIDER", "mock");
+        std::env::set_var("CHAT_MODEL", "gpt-5-mini");
+        std::env::set_var("EMBEDDING_MODEL", "text-embedding-3-small");
+
+        let config = Config::from_env();
+
+        std::env::remove_var("MODEL_PROVIDER");
+        std::env::remove_var("CHAT_MODEL");
+        std::env::remove_var("EMBEDDING_MODEL");
+        std::env::remove_var("EDGEQUAKE_LLM_PROVIDER");
+        std::env::remove_var("EDGEQUAKE_LLM_MODEL");
+        std::env::remove_var("EDGEQUAKE_EMBEDDING_MODEL");
+
+        assert_eq!(config.llm.provider, "mock");
+        assert_eq!(config.llm.model, "gpt-5-mini");
+        assert_eq!(config.llm.embedding_model, "text-embedding-3-small");
     }
 }

--- a/edgequake/crates/edgequake-core/src/env.rs
+++ b/edgequake/crates/edgequake-core/src/env.rs
@@ -1,0 +1,40 @@
+//! Environment variable helpers for deterministic model/provider resolution.
+
+/// Compatibility aliases for teams migrating from LightRAG-style naming.
+pub const LLM_PROVIDER_ALIASES: &[&str] = &["MODEL_PROVIDER", "CHAT_PROVIDER"];
+pub const LLM_MODEL_ALIASES: &[&str] = &["CHAT_MODEL", "LLM_MODEL"];
+pub const EMBEDDING_PROVIDER_ALIASES: &[&str] = &["EMBEDDING_PROVIDER"];
+pub const EMBEDDING_MODEL_ALIASES: &[&str] = &["EMBEDDING_MODEL"];
+pub const EMBEDDING_DIMENSION_ALIASES: &[&str] = &["EMBEDDING_DIMENSION"];
+
+/// Read an environment variable and return `None` when it is absent or empty.
+pub fn non_empty_env_var(key: &str) -> Option<String> {
+    std::env::var(key).ok().filter(|value| !value.is_empty())
+}
+
+/// Return the first present, non-empty environment variable from `keys`.
+pub fn first_non_empty_env_var(keys: &[&str]) -> Option<String> {
+    keys.iter().find_map(|key| non_empty_env_var(key))
+}
+
+/// Normalize compatibility aliases into EdgeQuake's canonical env vars.
+///
+/// Canonical variables always win. Aliases are only copied when the canonical
+/// variable is unset or empty, which makes the precedence deterministic.
+pub fn apply_model_env_aliases() {
+    normalize_env_alias("EDGEQUAKE_LLM_PROVIDER", LLM_PROVIDER_ALIASES);
+    normalize_env_alias("EDGEQUAKE_LLM_MODEL", LLM_MODEL_ALIASES);
+    normalize_env_alias("EDGEQUAKE_EMBEDDING_PROVIDER", EMBEDDING_PROVIDER_ALIASES);
+    normalize_env_alias("EDGEQUAKE_EMBEDDING_MODEL", EMBEDDING_MODEL_ALIASES);
+    normalize_env_alias("EDGEQUAKE_EMBEDDING_DIMENSION", EMBEDDING_DIMENSION_ALIASES);
+}
+
+fn normalize_env_alias(canonical_key: &str, alias_keys: &[&str]) {
+    if non_empty_env_var(canonical_key).is_some() {
+        return;
+    }
+
+    if let Some(alias_value) = first_non_empty_env_var(alias_keys) {
+        std::env::set_var(canonical_key, alias_value);
+    }
+}

--- a/edgequake/crates/edgequake-core/src/lib.rs
+++ b/edgequake/crates/edgequake-core/src/lib.rs
@@ -38,6 +38,7 @@
 pub mod cache;
 pub mod config;
 pub mod conversation_service;
+pub mod env;
 pub mod error;
 pub mod keyword_extractor;
 #[cfg(feature = "pipeline")]

--- a/edgequake/crates/edgequake-core/src/types/multitenancy/workspace.rs
+++ b/edgequake/crates/edgequake-core/src/types/multitenancy/workspace.rs
@@ -4,17 +4,10 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use uuid::Uuid;
 
-/// Read an environment variable and return `None` when the variable is
-/// absent **or** set to an empty string.
-///
-/// WHY: Docker Compose expands `${VAR:-}` to an empty string when `VAR` is
-/// not set on the host.  `std::env::var` returns `Ok("")` for those values,
-/// which silently overrides the hard-coded fallback.  This helper treats
-/// empty strings the same as missing variables so callers can chain
-/// `.or_else(|| …)` safely.
-fn non_empty_env_var(key: &str) -> Option<String> {
-    std::env::var(key).ok().filter(|s| !s.is_empty())
-}
+use crate::env::{
+    first_non_empty_env_var, non_empty_env_var, EMBEDDING_DIMENSION_ALIASES,
+    EMBEDDING_MODEL_ALIASES, EMBEDDING_PROVIDER_ALIASES, LLM_MODEL_ALIASES, LLM_PROVIDER_ALIASES,
+};
 
 // ============================================================================
 // Model Configuration Constants (SPEC-032)
@@ -196,11 +189,23 @@ impl Workspace {
         // explicitly filter out empty strings before falling back to the next
         // candidate in the resolution chain.
         let provider = non_empty_env_var("EDGEQUAKE_DEFAULT_LLM_PROVIDER")
-            .or_else(|| non_empty_env_var("EDGEQUAKE_LLM_PROVIDER"))
+            .or_else(|| {
+                first_non_empty_env_var(&[
+                    "EDGEQUAKE_LLM_PROVIDER",
+                    LLM_PROVIDER_ALIASES[0],
+                    LLM_PROVIDER_ALIASES[1],
+                ])
+            })
             .unwrap_or_else(|| DEFAULT_LLM_PROVIDER.to_string());
 
         let model = non_empty_env_var("EDGEQUAKE_DEFAULT_LLM_MODEL")
-            .or_else(|| non_empty_env_var("EDGEQUAKE_LLM_MODEL"))
+            .or_else(|| {
+                first_non_empty_env_var(&[
+                    "EDGEQUAKE_LLM_MODEL",
+                    LLM_MODEL_ALIASES[0],
+                    LLM_MODEL_ALIASES[1],
+                ])
+            })
             .unwrap_or_else(|| Self::default_model_for_provider(&provider));
 
         (model, provider)
@@ -217,18 +222,27 @@ impl Workspace {
         // compose expansion of `${VAR:-}` produces Ok("") not Err, so we
         // must filter those out before falling back to the next candidate.
         let provider = non_empty_env_var("EDGEQUAKE_DEFAULT_EMBEDDING_PROVIDER")
-            .or_else(|| non_empty_env_var("EDGEQUAKE_EMBEDDING_PROVIDER"))
+            .or_else(|| {
+                first_non_empty_env_var(&[
+                    "EDGEQUAKE_EMBEDDING_PROVIDER",
+                    EMBEDDING_PROVIDER_ALIASES[0],
+                ])
+            })
             .unwrap_or_else(|| DEFAULT_EMBEDDING_PROVIDER.to_string());
 
         let model = non_empty_env_var("EDGEQUAKE_DEFAULT_EMBEDDING_MODEL")
-            .or_else(|| non_empty_env_var("EDGEQUAKE_EMBEDDING_MODEL"))
+            .or_else(|| {
+                first_non_empty_env_var(&["EDGEQUAKE_EMBEDDING_MODEL", EMBEDDING_MODEL_ALIASES[0]])
+            })
             .unwrap_or_else(|| Self::default_embedding_model_for_provider(&provider));
 
-        let dimension = std::env::var("EDGEQUAKE_DEFAULT_EMBEDDING_DIMENSION")
-            .ok()
-            .filter(|s| !s.is_empty())
-            .and_then(|s| s.parse().ok())
-            .unwrap_or_else(|| Self::detect_dimension_from_model(&model));
+        let dimension = first_non_empty_env_var(&[
+            "EDGEQUAKE_DEFAULT_EMBEDDING_DIMENSION",
+            "EDGEQUAKE_EMBEDDING_DIMENSION",
+            EMBEDDING_DIMENSION_ALIASES[0],
+        ])
+        .and_then(|s| s.parse().ok())
+        .unwrap_or_else(|| Self::detect_dimension_from_model(&model));
 
         (model, provider, dimension)
     }
@@ -732,5 +746,50 @@ mod tests {
             model, DEFAULT_LLM_MODEL,
             "empty env var must not override the default model"
         );
+    }
+
+    #[test]
+    fn test_llm_config_supports_light_rag_style_aliases() {
+        let _guard = ENV_TEST_LOCK.lock().unwrap();
+
+        std::env::remove_var("EDGEQUAKE_DEFAULT_LLM_PROVIDER");
+        std::env::remove_var("EDGEQUAKE_DEFAULT_LLM_MODEL");
+        std::env::remove_var("EDGEQUAKE_LLM_PROVIDER");
+        std::env::remove_var("EDGEQUAKE_LLM_MODEL");
+        std::env::set_var("MODEL_PROVIDER", "openai");
+        std::env::set_var("CHAT_MODEL", "gpt-5-nano");
+
+        let (model, provider) = Workspace::default_llm_config();
+
+        std::env::remove_var("MODEL_PROVIDER");
+        std::env::remove_var("CHAT_MODEL");
+
+        assert_eq!(provider, "openai");
+        assert_eq!(model, "gpt-5-nano");
+    }
+
+    #[test]
+    fn test_embedding_config_supports_compatibility_aliases() {
+        let _guard = ENV_TEST_LOCK.lock().unwrap();
+
+        std::env::remove_var("EDGEQUAKE_DEFAULT_EMBEDDING_PROVIDER");
+        std::env::remove_var("EDGEQUAKE_DEFAULT_EMBEDDING_MODEL");
+        std::env::remove_var("EDGEQUAKE_DEFAULT_EMBEDDING_DIMENSION");
+        std::env::remove_var("EDGEQUAKE_EMBEDDING_PROVIDER");
+        std::env::remove_var("EDGEQUAKE_EMBEDDING_MODEL");
+        std::env::remove_var("EDGEQUAKE_EMBEDDING_DIMENSION");
+        std::env::set_var("EMBEDDING_PROVIDER", "openai");
+        std::env::set_var("EMBEDDING_MODEL", "text-embedding-3-small");
+        std::env::set_var("EMBEDDING_DIMENSION", "1536");
+
+        let (model, provider, dimension) = Workspace::default_embedding_config();
+
+        std::env::remove_var("EMBEDDING_PROVIDER");
+        std::env::remove_var("EMBEDDING_MODEL");
+        std::env::remove_var("EMBEDDING_DIMENSION");
+
+        assert_eq!(provider, "openai");
+        assert_eq!(model, "text-embedding-3-small");
+        assert_eq!(dimension, 1536);
     }
 }

--- a/edgequake/docker/README.md
+++ b/edgequake/docker/README.md
@@ -1,54 +1,81 @@
 # EdgeQuake Docker Deployment
 
-This directory contains Docker configuration for deploying EdgeQuake.
+This directory ships two supported Docker flows:
 
-## ⚠️ Disclaimer
+- `docker-compose.prebuilt.yml`: pull versioned GHCR images for API, frontend, and PostgreSQL
+- `docker-compose.yml`: build the API and frontend locally, then run the PostgreSQL image locally
 
-**PDF to Markdown Integration Status**: The PDF-to-Markdown feature is currently integrated in an **early prototype** stage. For testing and evaluating EdgeQuake's core functionality, please use **markdown documents** rather than PDFs. This ensures you can fully leverage the stable features of the system while we continue to refine the PDF extraction pipeline.
+## Prebuilt Flow
 
-## Quick Start
+Use this when you want the fastest install path and a repeatable release version.
 
 ```bash
-# Build and start all services
-docker-compose up -d
-
-# View logs
-docker-compose logs -f edgequake
-
-# Stop services
-docker-compose down
+cd edgequake/docker
+docker compose -f docker-compose.prebuilt.yml up -d
 ```
+
+Pin a specific release:
+
+```bash
+EDGEQUAKE_VERSION=0.9.18 docker compose -f docker-compose.prebuilt.yml up -d
+```
+
+Use OpenAI:
+
+```bash
+EDGEQUAKE_LLM_PROVIDER=openai \
+OPENAI_API_KEY=sk-... \
+docker compose -f docker-compose.prebuilt.yml up -d
+```
+
+## Source-Build Flow
+
+Use this when you are changing the backend or frontend locally and want Docker to rebuild them.
+
+```bash
+cd edgequake/docker
+docker compose -f docker-compose.yml up -d --build
+```
+
+## Provider Configuration
+
+Canonical EdgeQuake names:
+
+```bash
+EDGEQUAKE_LLM_PROVIDER=openai
+EDGEQUAKE_LLM_MODEL=gpt-5-mini
+EDGEQUAKE_EMBEDDING_PROVIDER=openai
+EDGEQUAKE_EMBEDDING_MODEL=text-embedding-3-small
+```
+
+Compatibility aliases for migration from LightRAG-style env files:
+
+```bash
+MODEL_PROVIDER=openai
+CHAT_MODEL=gpt-5-mini
+EMBEDDING_PROVIDER=openai
+EMBEDDING_MODEL=text-embedding-3-small
+```
+
+Canonical `EDGEQUAKE_*` variables take precedence when both are set.
 
 ## Services
 
-| Service     | Port | Description              |
-| ----------- | ---- | ------------------------ |
-| `edgequake` | 8080 | EdgeQuake API server     |
-| `postgres`  | 5432 | PostgreSQL with pgvector |
+| Service | Port | Description |
+| --- | --- | --- |
+| `edgequake` | `8080` | EdgeQuake API server |
+| `frontend` | `3000` | Next.js web UI |
+| `postgres` | `5432` | PostgreSQL with `pgvector` and Apache AGE |
 
-## Environment Variables
-
-Create a `.env` file:
-
-```bash
-# Required
-OPENAI_API_KEY=sk-your-api-key
-
-# Optional
-EDGEQUAKE_PORT=8080
-POSTGRES_PASSWORD=edgequake_secret
-```
-
-## Production Deployment
-
-For production, use `docker-compose.prod.yml`:
+## Common Commands
 
 ```bash
-docker-compose -f docker-compose.yml -f docker-compose.prod.yml up -d
-```
+# Logs
+docker compose -f docker-compose.prebuilt.yml logs -f
 
-## Building the Image
+# Stop
+docker compose -f docker-compose.prebuilt.yml down
 
-```bash
-docker build -t edgequake:latest -f Dockerfile ..
+# Stop and remove data
+docker compose -f docker-compose.prebuilt.yml down -v
 ```

--- a/edgequake/docker/docker-compose.prebuilt.yml
+++ b/edgequake/docker/docker-compose.prebuilt.yml
@@ -1,10 +1,8 @@
 # EdgeQuake — Full stack using prebuilt GHCR images
 #
 # This is the fastest way to get EdgeQuake running locally.
-# The EdgeQuake API binary is pulled from GitHub Container Registry (no Rust
-# toolchain or cargo build required).
-# PostgreSQL is built locally from the minimal Dockerfile.postgres because the
-# Apache AGE + pgvector extensions require a patched image that is not on Docker Hub.
+# The API, frontend, and PostgreSQL images are all pulled from GitHub Container
+# Registry, so there is no Rust, Node.js, or local Docker build requirement.
 #
 # Quick start:
 #   cd edgequake/docker
@@ -95,12 +93,8 @@ services:
       start_period: 20s
 
   # ── PostgreSQL with pgvector + Apache AGE ─────────────────────────────────
-  # WHY built locally: Apache AGE requires a custom build — no official prebuilt
-  # Docker Hub image provides both pgvector AND apache_age in one image.
   postgres:
-    build:
-      context: .
-      dockerfile: Dockerfile.postgres
+    image: ghcr.io/raphaelmansuy/edgequake-postgres:${EDGEQUAKE_VERSION:-latest}
     container_name: edgequake-postgres
     restart: unless-stopped
     ports:

--- a/sdks/csharp/README.md
+++ b/sdks/csharp/README.md
@@ -208,4 +208,4 @@ tests/EdgeQuakeSDK.Tests/
 
 ## License
 
-MIT
+Apache-2.0

--- a/sdks/kotlin/README.md
+++ b/sdks/kotlin/README.md
@@ -322,4 +322,4 @@ mvn compile -q  # Kotlin compiler checks
 
 ## License
 
-MIT
+Apache-2.0

--- a/sdks/php/README.md
+++ b/sdks/php/README.md
@@ -237,4 +237,4 @@ tests/
 
 ## License
 
-MIT
+Apache-2.0

--- a/sdks/php/composer.json
+++ b/sdks/php/composer.json
@@ -2,7 +2,7 @@
   "name": "edgequake/sdk",
   "description": "PHP SDK for the EdgeQuake RAG API",
   "type": "library",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "require": {
     "php": ">=8.1"
   },

--- a/sdks/ruby/README.md
+++ b/sdks/ruby/README.md
@@ -238,4 +238,4 @@ test/
 
 ## License
 
-MIT
+Apache-2.0

--- a/sdks/ruby/edgequake.gemspec
+++ b/sdks/ruby/edgequake.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |spec|
   spec.summary       = "Ruby SDK for the EdgeQuake RAG API"
   spec.description   = "Zero-dependency Ruby client for EdgeQuake REST API with full CRUD support."
   spec.homepage      = "https://github.com/edgequake/edgequake"
-  spec.license       = "MIT"
+  spec.license       = "Apache-2.0"
   spec.required_ruby_version = ">= 3.0"
 
   spec.files = Dir["lib/**/*.rb"]

--- a/wiki/EdgeQuake.md
+++ b/wiki/EdgeQuake.md
@@ -50,7 +50,7 @@ EdgeQuake is an advanced Retrieval-Augmented Generation (RAG) framework implemen
 - [Troubleshooting](docs/troubleshooting/)
 
 ## License
-EdgeQuake is licensed under the MIT License.
+EdgeQuake is licensed under the Apache License, Version 2.0.
 
 ---
 For more details, see the README and documentation in the repository.


### PR DESCRIPTION
## Summary
- fix issue #144 by making the prebuilt Docker path fully GHCR-based
- add deterministic LightRAG-style env aliases with canonical `EDGEQUAKE_*` normalization
- harden provider E2E tests against machine-specific env auto-detection
- normalize project-owned metadata/docs to Apache-2.0 only
- update contribution, configuration, Docker, and migration docs for the fix release

## Verification
- `cargo fmt --all`
- `cargo clippy --workspace --lib -- -D warnings`
- `cargo test --workspace --lib --no-fail-fast`
- `cargo test -p edgequake-api --test e2e_provider_integration`
- `cargo test -p edgequake-api --test e2e_provider_status`
- `docker compose -f docker-compose.quickstart.yml config`
- `docker compose -f edgequake/docker/docker-compose.prebuilt.yml config`

## Release notes
- version bumped to `0.9.18`
- changelog updated
- issue #144 already commented and closed after implementation verification