### PR TITLE
Speed up Docker release builds with native arch jobs

### DIFF
--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -111,14 +111,12 @@ jobs:
           docker buildx imagetools inspect \
             "ghcr.io/${{ github.repository }}:${{ needs.meta.outputs.version }}"
 
-  # ── Build frontend (multi-arch via QEMU — Node.js builds are fast) ────────────
-  build-frontend:
+  # ── Build frontend amd64 — native ubuntu-latest runner ────────────────────────
+  build-frontend-amd64:
     needs: meta
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-
-      - uses: docker/setup-qemu-action@v3
 
       - uses: docker/setup-buildx-action@v3
 
@@ -128,33 +126,27 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push frontend (amd64 + arm64)
+      - name: Build and push frontend (amd64)
         uses: docker/build-push-action@v6
         with:
           context: .
           file: edgequake_webui/Dockerfile
           push: true
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           # NEXT_PUBLIC_API_URL defaults to localhost:8080 — correct for docker-compose.prebuilt.yml
           # where both containers run on the same host and the browser connects to port 8080 directly.
           build-args: |
             NEXT_PUBLIC_API_URL=http://localhost:8080
-          tags: |
-            ghcr.io/${{ github.repository_owner }}/edgequake-frontend:${{ needs.meta.outputs.version }}
-            ghcr.io/${{ github.repository_owner }}/edgequake-frontend:latest
-          cache-from: type=gha,scope=frontend
-          cache-to:   type=gha,scope=frontend,mode=max
+          tags: ghcr.io/${{ github.repository_owner }}/edgequake-frontend:${{ needs.meta.outputs.version }}-amd64
+          cache-from: type=gha,scope=frontend-amd64
+          cache-to:   type=gha,scope=frontend-amd64,mode=max
 
-  # ── Build PostgreSQL (AGE + pgvector) — needed for all-prebuilt quickstart ───
-  # Building postgres once in CI lets users pull a ready-to-go image instead of
-  # waiting for a local `docker build` every time they run `make stack`.
-  build-postgres:
+  # ── Build frontend arm64 — native ARM64 runner (no QEMU) ─────────────────────
+  build-frontend-arm64:
     needs: meta
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v4
-
-      - uses: docker/setup-qemu-action@v3
 
       - uses: docker/setup-buildx-action@v3
 
@@ -164,22 +156,134 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push postgres (amd64 + arm64)
+      - name: Build and push frontend (arm64)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: edgequake_webui/Dockerfile
+          push: true
+          platforms: linux/arm64
+          build-args: |
+            NEXT_PUBLIC_API_URL=http://localhost:8080
+          tags: ghcr.io/${{ github.repository_owner }}/edgequake-frontend:${{ needs.meta.outputs.version }}-arm64
+          cache-from: type=gha,scope=frontend-arm64
+          cache-to:   type=gha,scope=frontend-arm64,mode=max
+
+  # ── Merge frontend into a single multi-arch manifest ──────────────────────────
+  merge-frontend:
+    needs: [meta, build-frontend-amd64, build-frontend-arm64]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create and push frontend multi-arch manifest
+        env:
+          IMAGE: ghcr.io/${{ github.repository_owner }}/edgequake-frontend
+          VERSION: ${{ needs.meta.outputs.version }}
+        run: |
+          docker buildx imagetools create \
+            --tag "$IMAGE:$VERSION" \
+            --tag "$IMAGE:latest" \
+            "$IMAGE:$VERSION-amd64" \
+            "$IMAGE:$VERSION-arm64"
+
+      - name: Inspect frontend manifest
+        env:
+          IMAGE: ghcr.io/${{ github.repository_owner }}/edgequake-frontend
+          VERSION: ${{ needs.meta.outputs.version }}
+        run: |
+          docker buildx imagetools inspect "$IMAGE:$VERSION"
+
+  # ── Build PostgreSQL amd64 — native ubuntu-latest runner ──────────────────────
+  # Building postgres once in CI lets users pull a ready-to-go image instead of
+  # waiting for a local `docker build` every time they run `make stack`.
+  build-postgres-amd64:
+    needs: meta
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push postgres (amd64)
         uses: docker/build-push-action@v6
         with:
           context: edgequake/docker
           file: edgequake/docker/Dockerfile.postgres
           push: true
-          platforms: linux/amd64,linux/arm64
-          tags: |
-            ghcr.io/${{ github.repository_owner }}/edgequake-postgres:${{ needs.meta.outputs.version }}
-            ghcr.io/${{ github.repository_owner }}/edgequake-postgres:latest
-          cache-from: type=gha,scope=postgres
-          cache-to:   type=gha,scope=postgres,mode=max
+          platforms: linux/amd64
+          tags: ghcr.io/${{ github.repository_owner }}/edgequake-postgres:${{ needs.meta.outputs.version }}-amd64
+          cache-from: type=gha,scope=postgres-amd64
+          cache-to:   type=gha,scope=postgres-amd64,mode=max
+
+  # ── Build PostgreSQL arm64 — native ARM64 runner (no QEMU) ───────────────────
+  build-postgres-arm64:
+    needs: meta
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push postgres (arm64)
+        uses: docker/build-push-action@v6
+        with:
+          context: edgequake/docker
+          file: edgequake/docker/Dockerfile.postgres
+          push: true
+          platforms: linux/arm64
+          tags: ghcr.io/${{ github.repository_owner }}/edgequake-postgres:${{ needs.meta.outputs.version }}-arm64
+          cache-from: type=gha,scope=postgres-arm64
+          cache-to:   type=gha,scope=postgres-arm64,mode=max
+
+  # ── Merge PostgreSQL into a single multi-arch manifest ────────────────────────
+  merge-postgres:
+    needs: [meta, build-postgres-amd64, build-postgres-arm64]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create and push postgres multi-arch manifest
+        env:
+          IMAGE: ghcr.io/${{ github.repository_owner }}/edgequake-postgres
+          VERSION: ${{ needs.meta.outputs.version }}
+        run: |
+          docker buildx imagetools create \
+            --tag "$IMAGE:$VERSION" \
+            --tag "$IMAGE:latest" \
+            "$IMAGE:$VERSION-amd64" \
+            "$IMAGE:$VERSION-arm64"
+
+      - name: Inspect postgres manifest
+        env:
+          IMAGE: ghcr.io/${{ github.repository_owner }}/edgequake-postgres
+          VERSION: ${{ needs.meta.outputs.version }}
+        run: |
+          docker buildx imagetools inspect "$IMAGE:$VERSION"
 
   # ── Trigger GitHub Release after all images are published ────────────────────
   release:
-    needs: [meta, merge, build-frontend, build-postgres]
+    needs: [meta, merge, merge-frontend, merge-postgres]
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
## Summary
- replace QEMU-based frontend release builds with native `amd64` and `arm64` jobs
- replace QEMU-based postgres release builds with native `amd64` and `arm64` jobs
- merge per-arch frontend and postgres images into multi-arch manifests just like the API image
- keep release publication gated on the merged multi-arch manifests instead of the raw build jobs

## Why
The current `v0.9.18` tag release shows the downside of the old QEMU path: API finished quickly on native arch runners, while the QEMU-backed frontend image became the long tail. Using two native arch builds removes the emulator bottleneck and makes release duration more predictable.

## Validation
- YAML parsed with `ruby -e "require \"yaml\"; YAML.load_file(\".github/workflows/release-docker.yml\"); puts :ok"`
- dependency graph reviewed to ensure `release` waits on `merge`, `merge-frontend`, and `merge-postgres`