### PR TITLE
fix: make entity similarity score threshold configurable

### DIFF
--- a/edgequake/crates/edgequake-query/src/sota_engine/mod.rs
+++ b/edgequake/crates/edgequake-query/src/sota_engine/mod.rs
@@ -151,7 +151,13 @@ impl Default for SOTAQueryConfig {
             // 30000 tokens uses only 23% of the context window — safe and effective.
             max_context_tokens: 30000,
             graph_depth: 2,
-            min_score: 0.1,
+            // Configurable via EDGEQUAKE_MIN_ENTITY_SCORE env var (default: 0.1).
+            // Lower this (e.g. 0.0) to retrieve low-frequency entities that score
+            // below the default threshold on bare name queries.
+            min_score: std::env::var("EDGEQUAKE_MIN_ENTITY_SCORE")
+                .ok()
+                .and_then(|v| v.parse::<f32>().ok())
+                .unwrap_or(0.1),
             use_keyword_extraction: true,
             use_adaptive_mode: true,
             // WHY derived from max_context_tokens: The truncation budget MUST match


### PR DESCRIPTION
## Problem
Low-frequency entities are silently filtered out of local mode query results
before graph traversal even begins. The hardcoded min_score threshold of 0.1
in SOTAQueryConfig drops any entity whose cosine similarity score falls below
that value.

For entities that appear in only one or two documents with moderate importance
scores (~0.5), bare name queries produce low similarity scores that don't
clear this threshold — even though the entity exists in the graph with
multiple relationships.

Concrete example: querying "Wilson McKendrick" (a solicitors firm with 12
graph relationships) returns zero results. The entity is present and correctly
ingested — it is simply filtered out by min_score before reaching graph
traversal.

Fixes #206

## Type of change
- [x] Bug fix

## Changes
- Read `min_score` from `EDGEQUAKE_MIN_ENTITY_SCORE` env var in
  `SOTAQueryConfig::default()` (default: 0.1 for full backward compatibility)
- Setting to 0.0 disables threshold filtering entirely, passing all entities
  to graph traversal regardless of similarity score

## Testing
Set `EDGEQUAKE_MIN_ENTITY_SCORE=0.0` and query a low-frequency entity by
bare name. Entity should appear in results where it previously returned
zero results.