### PR TITLE
fix: close issues #201 #202 #207 #208 — naive mode, i18n locales, entity dedup, Ollama context length

### DIFF
--- a/docker-compose.quickstart.yml
+++ b/docker-compose.quickstart.yml
@@ -107,6 +107,11 @@ services:
       #   '127.x.x.x' — use 'host.docker.internal' or a real IP/hostname.
       #   quickstart.sh auto-translates loopback addresses when launching.
       OLLAMA_HOST:                  ${OLLAMA_HOST:-http://host.docker.internal:11434}
+      # WHY: Pass through OLLAMA_CONTEXT_LENGTH so users can tune the model
+      # token window without rebuilding. Default 32768; set to 131072 for large docs.
+      OLLAMA_CONTEXT_LENGTH:        ${OLLAMA_CONTEXT_LENGTH:-32768}
+      OLLAMA_MODEL:                 ${OLLAMA_MODEL:-}
+      OLLAMA_EMBEDDING_MODEL:       ${OLLAMA_EMBEDDING_MODEL:-}
       PDFIUM_AUTO_CACHE_DIR:        /tmp/edgequake-pdfium-cache
       RUST_LOG:                     ${RUST_LOG:-info}
     extra_hosts:

--- a/edgequake/crates/edgequake-api/src/handlers/chat/mod.rs
+++ b/edgequake/crates/edgequake-api/src/handlers/chat/mod.rs
@@ -119,14 +119,21 @@ fn parse_query_mode(mode: &Option<String>) -> QueryMode {
 
 /// Convert an ISO 639-1 language code to its full English name.
 /// Used to build a clear language directive for the LLM prompt.
+///
+/// WHY: Region-tagged locales like "fr-FR" must be normalized to bare codes
+/// ("fr") before matching. Browsers often send "fr-FR" instead of "fr", and
+/// without stripping the region the match falls through to "English", causing
+/// the LLM to respond in English regardless of the user's language setting.
 fn language_code_to_name(code: &str) -> &'static str {
-    match code.to_lowercase().as_str() {
+    // Strip region suffix: "fr-FR" → "fr", "zh-TW" → "zh"
+    let base = code.split('-').next().unwrap_or(code);
+    match base.to_lowercase().as_str() {
         "en" => "English",
-        "zh" | "zh-cn" | "zh-tw" | "zh-hans" | "zh-hant" => "Chinese",
+        "zh" => "Chinese",
         "fr" => "French",
         "de" => "German",
         "es" => "Spanish",
-        "pt" | "pt-br" => "Portuguese",
+        "pt" => "Portuguese",
         "it" => "Italian",
         "ja" => "Japanese",
         "ko" => "Korean",

--- a/edgequake/crates/edgequake-api/src/handlers/documents/upload/file_upload.rs
+++ b/edgequake/crates/edgequake-api/src/handlers/documents/upload/file_upload.rs
@@ -10,6 +10,7 @@ use crate::error::{ApiError, ApiResult};
 use crate::middleware::TenantContext;
 use crate::services::ContentHasher;
 use crate::state::AppState;
+use edgequake_pipeline::normalize_entity_name;
 
 use crate::file_validation::validate_file;
 #[allow(unused_imports)]
@@ -351,9 +352,13 @@ pub async fn upload_file(
                 serde_json::json!(&workspace_id_for_storage),
             );
 
+            // WHY: Normalize entity names to UPPERCASE_UNDERSCORE before storage.
+            // Without this, variants like "Systems Thinking" and "systems thinking"
+            // are stored as separate nodes, bypassing deduplication in the merger.
+            let entity_key = normalize_entity_name(&entity.name);
             match state
                 .graph_storage
-                .upsert_node(&entity.name, properties)
+                .upsert_node(&entity_key, properties)
                 .await
             {
                 Ok(_) => {
@@ -386,8 +391,8 @@ pub async fn upload_file(
                 }
                 metadata["workspace_id"] = serde_json::json!(&workspace_id_for_storage);
 
-                // Use entity name as vector ID for dedup
-                let entity_id = format!("entity:{}", entity.name);
+                // Use normalized entity key as vector ID for dedup (matches graph node ID)
+                let entity_id = format!("entity:{}", entity_key);
                 if let Err(e) = workspace_vector_storage
                     .upsert(&[(entity_id.clone(), embedding.clone(), metadata)])
                     .await

--- a/edgequake/crates/edgequake-api/src/handlers/documents/upload/text_upload.rs
+++ b/edgequake/crates/edgequake-api/src/handlers/documents/upload/text_upload.rs
@@ -11,6 +11,7 @@ use crate::middleware::TenantContext;
 use crate::services::ContentHasher;
 use crate::state::AppState;
 use edgequake_core::MetricsTriggerType;
+use edgequake_pipeline::normalize_entity_name;
 
 #[allow(unused_imports)]
 use crate::handlers::documents::storage_helpers::get_workspace_vector_storage_with_fallback;
@@ -479,9 +480,13 @@ pub async fn upload_document(
                     serde_json::json!(&entity.source_chunk_ids),
                 );
 
+                // WHY: Normalize entity names to UPPERCASE_UNDERSCORE before storage.
+                // Without this, variants like "Systems Thinking" and "systems thinking"
+                // are stored as separate nodes, bypassing deduplication in the merger.
+                let entity_key = normalize_entity_name(&entity.name);
                 state
                     .graph_storage
-                    .upsert_node(&entity.name, properties)
+                    .upsert_node(&entity_key, properties)
                     .await?;
 
                 // CRITICAL: Also store entity embedding in vector storage for query_local retrieval
@@ -500,7 +505,7 @@ pub async fn upload_document(
                     }
                     metadata["workspace_id"] = serde_json::json!(&workspace_id_for_storage);
 
-                    let entity_id = format!("entity:{}", entity.name);
+                    let entity_id = format!("entity:{}", entity_key);
                     if let Err(e) = workspace_vector_storage
                         .upsert(&[(entity_id.clone(), embedding.clone(), metadata)])
                         .await

--- a/edgequake/crates/edgequake-query/src/sota_engine/query_modes.rs
+++ b/edgequake/crates/edgequake-query/src/sota_engine/query_modes.rs
@@ -576,23 +576,24 @@ impl SOTAQueryEngine {
         workspace_id: Option<String>,
     ) -> Result<QueryContext> {
         let mut context = QueryContext::new();
-        let mf = MetadataFilter::from_tenant_workspace(tenant_id, workspace_id);
 
-        // SPEC-007: tenant/workspace filter pushed to storage layer via query_filtered.
+        // WHY: Use vector_type filter at the SQL layer so LIMIT operates only on chunk
+        // vectors. Without this, large graphs (60k+ entities) cause the top-k results
+        // to be dominated by entity vectors, leaving 0 chunks after in-memory filtering.
+        // SPEC-007: tenant/workspace/type filter pushed to storage layer via query_filtered.
+        let mf = MetadataFilter::from_tenant_workspace_type(tenant_id, workspace_id, "chunk");
+
         let results = self
             .vector_storage
             .query_filtered(
                 &embeddings.query,
-                self.config.max_chunks * 2,
+                self.config.max_chunks,
                 None,
                 mf.as_ref(),
             )
             .await?;
 
-        // Filter to chunk vectors only
-        let chunk_results = filter_by_type(results, VectorType::Chunk);
-
-        for result in chunk_results
+        for result in results
             .iter()
             .filter(|r| r.score >= self.config.min_score)
             .take(self.config.max_chunks)

--- a/edgequake/crates/edgequake-query/src/sota_engine/vector_queries.rs
+++ b/edgequake/crates/edgequake-query/src/sota_engine/vector_queries.rs
@@ -22,23 +22,27 @@ impl SOTAQueryEngine {
         vector_storage: &Arc<dyn VectorStorage>,
     ) -> Result<QueryContext> {
         let mut context = QueryContext::new();
-        let mf = MetadataFilter::from_tenant_workspace(tenant_id, workspace_id);
 
-        // WHY 2x oversampling: Vector storage returns all types (entities, relationships, chunks).
-        // We retrieve 2x max_chunks to compensate for non-chunk results in top results.
-        // SPEC-007: tenant/workspace filter pushed to storage layer via query_filtered.
+        // WHY: Use vector_type filter at the SQL layer so LIMIT operates only on chunk
+        // vectors. Without this, large graphs (60k+ entities) cause the top-k results
+        // to be dominated by entity vectors, leaving 0 chunks after in-memory filtering.
+        // SPEC-007: tenant/workspace/type filter pushed to storage layer via query_filtered.
+        let mf = MetadataFilter::from_tenant_workspace_type(
+            tenant_id,
+            workspace_id,
+            "chunk",
+        );
+
         let results = vector_storage
             .query_filtered(
                 &embeddings.query,
-                self.config.max_chunks * 2,
+                self.config.max_chunks,
                 None,
                 mf.as_ref(),
             )
             .await?;
 
-        let chunk_results = filter_by_type(results, VectorType::Chunk);
-
-        for result in chunk_results
+        for result in results
             .iter()
             .filter(|r| r.score >= self.config.min_score)
             .take(self.config.max_chunks)

--- a/edgequake/crates/edgequake-storage/src/adapters/memory/vector.rs
+++ b/edgequake/crates/edgequake-storage/src/adapters/memory/vector.rs
@@ -385,6 +385,13 @@ impl VectorStorage for MemoryVectorStorage {
                         }
                     }
                 }
+                // Vector type filter (e.g. "chunk", "entity", "relationship")
+                if let Some(vtype) = &mf.vector_type {
+                    let meta_type = meta.get("type").and_then(|v| v.as_str()).unwrap_or("");
+                    if meta_type != vtype {
+                        return false;
+                    }
+                }
                 true
             })
             .map(|(id, vec)| {
@@ -1045,6 +1052,7 @@ mod tests {
             document_ids: Some(vec!["doc1".to_string()]),
             tenant_id: Some("t1".to_string()),
             workspace_id: Some("ws1".to_string()),
+            vector_type: None,
         };
         let results = storage
             .query_filtered(&[1.0, 0.0, 0.0], 10, None, Some(&mf))

--- a/edgequake/crates/edgequake-storage/src/adapters/postgres/vector.rs
+++ b/edgequake/crates/edgequake-storage/src/adapters/postgres/vector.rs
@@ -767,6 +767,15 @@ impl VectorStorage for PgVectorStorage {
             param_offset += 1;
         }
 
+        // Vector type (e.g. "chunk", "entity", "relationship")
+        // WHY: Pushed to SQL layer so LIMIT operates on correctly-typed vectors.
+        // Without this, naive mode on large graphs returns only entity vectors
+        // in the top-k, resulting in 0 chunk results after in-memory filtering.
+        if mf.vector_type.is_some() {
+            conditions.push(format!("metadata->>'type' = ${}", param_offset));
+            param_offset += 1;
+        }
+
         let where_clause = if conditions.is_empty() {
             String::new()
         } else {
@@ -818,6 +827,12 @@ impl VectorStorage for PgVectorStorage {
         if let Some(wid) = &mf.workspace_id {
             args.add(wid).map_err(|e| {
                 StorageError::Database(format!("Failed to bind workspace_id: {}", e))
+            })?;
+        }
+
+        if let Some(vtype) = &mf.vector_type {
+            args.add(vtype).map_err(|e| {
+                StorageError::Database(format!("Failed to bind vector_type: {}", e))
             })?;
         }
 

--- a/edgequake/crates/edgequake-storage/src/traits/vector.rs
+++ b/edgequake/crates/edgequake-storage/src/traits/vector.rs
@@ -52,12 +52,22 @@ pub struct MetadataFilter {
     pub tenant_id: Option<String>,
     /// Filter by workspace ID.
     pub workspace_id: Option<String>,
+    /// Filter by vector type (e.g. "chunk", "entity", "relationship").
+    ///
+    /// WHY: At scale (60k+ entities, 10k+ chunks), the top-k results from a workspace
+    /// vector table are dominated by entity vectors if no type filter is applied.
+    /// Pushing type filtering to the SQL layer ensures the LIMIT clause operates on
+    /// the correct vector type, preventing naive mode from returning 0 chunks.
+    pub vector_type: Option<String>,
 }
 
 impl MetadataFilter {
     /// Returns true when no filter fields are set.
     pub fn is_empty(&self) -> bool {
-        self.document_ids.is_none() && self.tenant_id.is_none() && self.workspace_id.is_none()
+        self.document_ids.is_none()
+            && self.tenant_id.is_none()
+            && self.workspace_id.is_none()
+            && self.vector_type.is_none()
     }
 
     /// Build a filter from optional tenant and workspace IDs.
@@ -72,6 +82,24 @@ impl MetadataFilter {
             document_ids: None,
             tenant_id,
             workspace_id,
+            vector_type: None,
+        })
+    }
+
+    /// Build a filter with tenant, workspace, and vector type.
+    ///
+    /// WHY: Naive mode must filter by type=chunk at the SQL level to avoid returning
+    /// entity/relationship vectors when the top-k results are entity-dominated.
+    pub fn from_tenant_workspace_type(
+        tenant_id: Option<String>,
+        workspace_id: Option<String>,
+        vector_type: impl Into<String>,
+    ) -> Option<Self> {
+        Some(Self {
+            document_ids: None,
+            tenant_id,
+            workspace_id,
+            vector_type: Some(vector_type.into()),
         })
     }
 }
@@ -243,6 +271,7 @@ mod tests {
             document_ids: Some(vec!["doc1".into(), "doc2".into()]),
             tenant_id: Some("t1".into()),
             workspace_id: Some("ws1".into()),
+            vector_type: None,
         };
         let json = serde_json::to_string(&mf).unwrap();
         let mf2: MetadataFilter = serde_json::from_str(&json).unwrap();

--- a/edgequake/docker/.env.example
+++ b/edgequake/docker/.env.example
@@ -40,6 +40,13 @@ EDGEQUAKE_LLM_PROVIDER=ollama
 # ── Ollama ────────────────────────────────────────────────────────────────────
 # When running inside Docker, host.docker.internal reaches the host machine.
 OLLAMA_HOST=http://host.docker.internal:11434
+# Context window size in tokens. Ollama default (2048) is too small for RAG.
+# Set to 32768 for standard use, or 131072 for very large document chunks.
+# WHY: This env var is now passed through Docker compose; previously it was
+# read by edgequake-llm but not forwarded into the container.
+OLLAMA_CONTEXT_LENGTH=32768
+# Override the default Ollama model (leave empty to use edgequake-llm default)
+# OLLAMA_MODEL=qwen2.5:latest
 
 # ── Embedding overrides ───────────────────────────────────────────────────────
 # EDGEQUAKE_EMBEDDING_MODEL=text-embedding-3-small

--- a/edgequake/docker/docker-compose.prebuilt.yml
+++ b/edgequake/docker/docker-compose.prebuilt.yml
@@ -47,6 +47,9 @@ services:
       # WHY host.docker.internal: Ollama typically runs on the host, not inside
       # Docker. Using the gateway address lets the container reach the host port.
       - OLLAMA_HOST=${OLLAMA_HOST:-http://host.docker.internal:11434}
+      - OLLAMA_CONTEXT_LENGTH=${OLLAMA_CONTEXT_LENGTH:-32768}
+      - OLLAMA_MODEL=${OLLAMA_MODEL:-}
+      - OLLAMA_EMBEDDING_MODEL=${OLLAMA_EMBEDDING_MODEL:-}
       - EDGEQUAKE_EMBEDDING_MODEL=${EDGEQUAKE_EMBEDDING_MODEL:-}
       - EDGEQUAKE_EMBEDDING_DIMENSION=${EDGEQUAKE_EMBEDDING_DIMENSION:-}
       - EDGEQUAKE_VISION_TIMEOUT_SECS=${EDGEQUAKE_VISION_TIMEOUT_SECS:-600}

--- a/edgequake/docker/docker-compose.yml
+++ b/edgequake/docker/docker-compose.yml
@@ -53,6 +53,12 @@ services:
       # NOTE: Only set OLLAMA_HOST when you actually want to use Ollama.
       #       Remove or leave blank when using OpenAI / another cloud provider.
       - OLLAMA_HOST=${OLLAMA_HOST:-http://host.docker.internal:11434}
+      # WHY: Expose OLLAMA_CONTEXT_LENGTH so users can tune token window without
+      # rebuilding the image. Ollama default is 2048 which is too small for many
+      # documents; common override is 32768 or 131072.
+      - OLLAMA_CONTEXT_LENGTH=${OLLAMA_CONTEXT_LENGTH:-32768}
+      - OLLAMA_MODEL=${OLLAMA_MODEL:-}
+      - OLLAMA_EMBEDDING_MODEL=${OLLAMA_EMBEDDING_MODEL:-}
       - EDGEQUAKE_LLM_PROVIDER=${EDGEQUAKE_LLM_PROVIDER:-ollama}
       - EDGEQUAKE_EMBEDDING_PROVIDER=${EDGEQUAKE_EMBEDDING_PROVIDER:-}
       # Vision extraction timeout (seconds). Default 600s (10 min).

--- a/edgequake_webui/src/components/shared/language-selector.tsx
+++ b/edgequake_webui/src/components/shared/language-selector.tsx
@@ -14,7 +14,10 @@ import { useTranslation } from 'react-i18next';
 export function LanguageSelector() {
   const { i18n } = useTranslation();
   
-  const currentLanguage = languages.find((lang) => lang.code === i18n.language) || languages[0];
+  const currentLanguage =
+    languages.find(
+      (lang) => lang.code === (i18n.language?.split("-")[0] ?? "en"),
+    ) || languages[0];
 
   const handleLanguageChange = (code: LanguageCode) => {
     i18n.changeLanguage(code);

--- a/edgequake_webui/src/lib/i18n.ts
+++ b/edgequake_webui/src/lib/i18n.ts
@@ -43,6 +43,10 @@ i18n
       order: ["localStorage", "navigator", "htmlTag"],
       caches: ["localStorage"],
       lookupLocalStorage: "edgequake-language",
+      // WHY: Strip region suffix so "fr-FR" resolves to "fr", "zh-TW" to "zh", etc.
+      // Without this, region-tagged locales from the browser fail to match any
+      // supported language code and fall back to English, ignoring user preference.
+      convertDetectedLanguage: (lng: string) => lng.split("-")[0],
     },
   });
 


### PR DESCRIPTION
## Summary

This PR closes 4 open issues with targeted fixes across Rust backend and TypeScript frontend.

---

### Fix #208 — Naive mode returns zero results at scale

**Root cause**: `query_naive` fetched `max_chunks * 2` vectors total, then filtered in memory with `filter_by_type(..., VectorType::Chunk)`. At scale (60k+ entities), all top-40 results were entity vectors, leaving 0 chunks after filtering.

**Fix**: Added `vector_type: Option<String>` to `MetadataFilter`. Both Postgres and in-memory adapters now push the type filter to the SQL/collection level, so LIMIT applies only to chunk vectors. Removed the 2x oversampling hack.

**Files**: `edgequake-storage/src/traits/vector.rs`, `adapters/postgres/vector.rs`, `adapters/memory/vector.rs`, `edgequake-query/src/sota_engine/query_modes.rs`, `vector_queries.rs`

---

### Fix #207 — Region-tagged locales (fr-FR) break language selection

**Root cause (dual)**:
1. `i18next-browser-languagedetector` emits `"fr-FR"` from browser but supported codes are bare (`"fr"`), so detection silently fell back to English
2. `language-selector.tsx` used strict equality `lang.code === i18n.language` which fails for `"fr-FR"` vs `"fr"`
3. Backend `language_code_to_name("fr-FR")` hit the `_` fallback arm → English prompt

**Fix**: 
- `i18n.ts`: `convertDetectedLanguage: (lng) => lng.split("-")[0]`
- `language-selector.tsx`: compare against `i18n.language?.split("-")[0]`
- `chat/mod.rs`: strip region suffix before matching in `language_code_to_name()`

---

### Fix #202 — Case-insensitive entity deduplication

**Root cause**: The pipeline merger correctly normalizes entity names via `normalize_entity_name()`, but `file_upload.rs` and `text_upload.rs` call `upsert_node(&entity.name, ...)` directly — bypassing normalization. Entities like "Systems Thinking" and "systems thinking" were stored as separate graph nodes.

**Fix**: Import and apply `normalize_entity_name()` in both upload handlers before calling `upsert_node()` and the vector storage upsert.

---

### Fix #201 — OLLAMA_CONTEXT_LENGTH env var not forwarded in Docker

**Root cause**: The env var is read by `edgequake-llm` at provider construction but was never listed in Docker compose environment blocks, so it was silently dropped when running in containers.

**Fix**: Added `OLLAMA_CONTEXT_LENGTH=${OLLAMA_CONTEXT_LENGTH:-32768}` to all three compose files and documented it in `.env.example`.

---

## Test Evidence

```
cargo test --workspace --lib
→ 72 passed; 0 failed
cargo clippy -p edgequake-storage -p edgequake-query -p edgequake-api
→ 0 errors; 1 pre-existing doc warning (unrelated)
npx tsc --noEmit (edgequake_webui)
→ 0 errors
```

Closes #201
Closes #202
Closes #207
Closes #208