### PR TITLE
fix(storage): eliminate 13s KV COUNT(*) scans (SPEC-011)

### DIFF
--- a/edgequake/crates/edgequake-api/src/handlers/auth/user_management.rs
+++ b/edgequake/crates/edgequake-api/src/handlers/auth/user_management.rs
@@ -201,11 +201,7 @@ pub async fn list_users(
 
     // WHY Issue #205: Use prefix scan to list all user keys.
     // USER_KEY_PREFIX = "auth:user:" so filter to keys starting with that prefix.
-    let all_keys = state
-        .kv_storage
-        .keys()
-        .await
-        .map_err(storage_err)?;
+    let all_keys = state.kv_storage.keys().await.map_err(storage_err)?;
 
     let user_keys: Vec<String> = all_keys
         .into_iter()
@@ -233,7 +229,11 @@ pub async fn list_users(
     let total = users.len();
     let total_pages = total.div_ceil(page_size as usize) as u32;
     let start = ((page - 1) * page_size) as usize;
-    let page_users: Vec<UserInfo> = users.into_iter().skip(start).take(page_size as usize).collect();
+    let page_users: Vec<UserInfo> = users
+        .into_iter()
+        .skip(start)
+        .take(page_size as usize)
+        .collect();
 
     Ok(Json(ListUsersResponse {
         users: page_users,
@@ -367,11 +367,7 @@ pub async fn update_user(
         // WHY: Guard against demoting the last admin — system would be unmanageable.
         if current_role == Role::Admin && parsed != Role::Admin {
             // Count remaining admins (excluding this user)
-            let all_keys = state
-                .kv_storage
-                .keys()
-                .await
-                .map_err(storage_err)?;
+            let all_keys = state.kv_storage.keys().await.map_err(storage_err)?;
             let mut admin_count = 0u32;
             for key in all_keys.iter().filter(|k| k.starts_with(USER_KEY_PREFIX)) {
                 let uid = key.trim_start_matches(USER_KEY_PREFIX);

--- a/edgequake/crates/edgequake-api/src/handlers/chat/completion.rs
+++ b/edgequake/crates/edgequake-api/src/handlers/chat/completion.rs
@@ -268,21 +268,25 @@ pub async fn chat_completion(
     // WHY: Some models (e.g. mistral-small-latest) silently drop image content.
     // The vision provider (e.g. pixtral-large-latest) is used instead when available.
     // A request-level provider override takes precedence over the server-default vision provider.
-    let (llm_override, used_provider, used_model) =
-        if llm_override.is_none() && engine_request.images.as_ref().is_some_and(|imgs| !imgs.is_empty()) {
-            if let Some(ref vision_provider) = state.vision_llm_provider {
-                debug!("Using vision LLM provider for image query (FEAT0203)");
-                (
-                    Some(Arc::clone(vision_provider) as Arc<dyn edgequake_llm::traits::LLMProvider>),
-                    Some("vision".to_string()),
-                    Some("vision-model".to_string()),
-                )
-            } else {
-                (llm_override, used_provider, used_model)
-            }
+    let (llm_override, used_provider, used_model) = if llm_override.is_none()
+        && engine_request
+            .images
+            .as_ref()
+            .is_some_and(|imgs| !imgs.is_empty())
+    {
+        if let Some(ref vision_provider) = state.vision_llm_provider {
+            debug!("Using vision LLM provider for image query (FEAT0203)");
+            (
+                Some(Arc::clone(vision_provider) as Arc<dyn edgequake_llm::traits::LLMProvider>),
+                Some("vision".to_string()),
+                Some("vision-model".to_string()),
+            )
         } else {
             (llm_override, used_provider, used_model)
-        };
+        }
+    } else {
+        (llm_override, used_provider, used_model)
+    };
 
     // OADA-228: Get workspace-specific embedding provider and vector storage
     // This ensures query embeddings match the dimension of stored vectors

--- a/edgequake/crates/edgequake-api/src/handlers/chat/mod.rs
+++ b/edgequake/crates/edgequake-api/src/handlers/chat/mod.rs
@@ -572,16 +572,52 @@ mod tests {
     #[test]
     fn test_language_code_to_name_region_tagged_codes() {
         // Most common region-tagged locales that browsers send
-        assert_eq!(language_code_to_name("fr-FR"), "French", "fr-FR must resolve to French");
-        assert_eq!(language_code_to_name("fr-BE"), "French", "fr-BE (Belgian French)");
-        assert_eq!(language_code_to_name("fr-CA"), "French", "fr-CA (Canadian French)");
-        assert_eq!(language_code_to_name("de-DE"), "German", "de-DE must resolve to German");
-        assert_eq!(language_code_to_name("de-AT"), "German", "de-AT (Austrian German)");
+        assert_eq!(
+            language_code_to_name("fr-FR"),
+            "French",
+            "fr-FR must resolve to French"
+        );
+        assert_eq!(
+            language_code_to_name("fr-BE"),
+            "French",
+            "fr-BE (Belgian French)"
+        );
+        assert_eq!(
+            language_code_to_name("fr-CA"),
+            "French",
+            "fr-CA (Canadian French)"
+        );
+        assert_eq!(
+            language_code_to_name("de-DE"),
+            "German",
+            "de-DE must resolve to German"
+        );
+        assert_eq!(
+            language_code_to_name("de-AT"),
+            "German",
+            "de-AT (Austrian German)"
+        );
         assert_eq!(language_code_to_name("es-ES"), "Spanish");
-        assert_eq!(language_code_to_name("es-MX"), "Spanish", "es-MX (Mexican Spanish)");
-        assert_eq!(language_code_to_name("zh-TW"), "Chinese", "zh-TW must resolve to Chinese");
-        assert_eq!(language_code_to_name("zh-CN"), "Chinese", "zh-CN must resolve to Chinese");
-        assert_eq!(language_code_to_name("pt-BR"), "Portuguese", "pt-BR must resolve to Portuguese");
+        assert_eq!(
+            language_code_to_name("es-MX"),
+            "Spanish",
+            "es-MX (Mexican Spanish)"
+        );
+        assert_eq!(
+            language_code_to_name("zh-TW"),
+            "Chinese",
+            "zh-TW must resolve to Chinese"
+        );
+        assert_eq!(
+            language_code_to_name("zh-CN"),
+            "Chinese",
+            "zh-CN must resolve to Chinese"
+        );
+        assert_eq!(
+            language_code_to_name("pt-BR"),
+            "Portuguese",
+            "pt-BR must resolve to Portuguese"
+        );
         assert_eq!(language_code_to_name("pt-PT"), "Portuguese");
         assert_eq!(language_code_to_name("en-US"), "English");
         assert_eq!(language_code_to_name("en-GB"), "English");

--- a/edgequake/crates/edgequake-api/src/handlers/chat/streaming.rs
+++ b/edgequake/crates/edgequake-api/src/handlers/chat/streaming.rs
@@ -348,27 +348,25 @@ pub async fn chat_completion_stream(
         // FEAT0203: When images are attached, prefer the vision-capable LLM provider.
         // WHY: Some models (e.g. mistral-small-latest) silently drop image content.
         // A request-level provider override takes precedence over the server-default vision provider.
-        let (llm_override, used_provider, used_model) =
-            if llm_override.is_none()
-                && engine_request
-                    .images
-                    .as_ref()
-                    .is_some_and(|imgs| !imgs.is_empty())
-            {
-                if let Some(ref vision_provider) = state_clone.vision_llm_provider {
-                    debug!("Using vision LLM provider for image query (FEAT0203 streaming)");
-                    (
-                        Some(Arc::clone(vision_provider)
-                            as Arc<dyn edgequake_llm::traits::LLMProvider>),
-                        Some("vision".to_string()),
-                        Some("vision-model".to_string()),
-                    )
-                } else {
-                    (llm_override, used_provider, used_model)
-                }
+        let (llm_override, used_provider, used_model) = if llm_override.is_none()
+            && engine_request
+                .images
+                .as_ref()
+                .is_some_and(|imgs| !imgs.is_empty())
+        {
+            if let Some(ref vision_provider) = state_clone.vision_llm_provider {
+                debug!("Using vision LLM provider for image query (FEAT0203 streaming)");
+                (
+                    Some(Arc::clone(vision_provider) as Arc<dyn edgequake_llm::traits::LLMProvider>),
+                    Some("vision".to_string()),
+                    Some("vision-model".to_string()),
+                )
             } else {
                 (llm_override, used_provider, used_model)
-            };
+            }
+        } else {
+            (llm_override, used_provider, used_model)
+        };
 
         // Execute streaming query with context using SOTA engine (LightRAG-style)
         // OODA-228: Get workspace embedding provider and vector storage for proper isolation

--- a/edgequake/crates/edgequake-api/src/handlers/costs.rs
+++ b/edgequake/crates/edgequake-api/src/handlers/costs.rs
@@ -141,14 +141,7 @@ pub async fn get_cost_summary(
         }));
     }
     // Query all document metadata to aggregate costs
-    let keys = state.kv_storage.keys().await?;
-
-    // Find all metadata keys
-    let metadata_keys: Vec<String> = keys
-        .iter()
-        .filter(|k| k.ends_with("-metadata"))
-        .cloned()
-        .collect();
+    let metadata_keys = state.kv_storage.keys_like("%-metadata").await?;
 
     let mut total_cost = 0.0;
     let mut total_input_tokens = 0usize;
@@ -378,12 +371,7 @@ pub async fn get_cost_history(
     let granularity = params.granularity.as_deref().unwrap_or("day");
 
     // Query all document metadata
-    let keys = state.kv_storage.keys().await?;
-    let metadata_keys: Vec<String> = keys
-        .iter()
-        .filter(|k| k.ends_with("-metadata"))
-        .cloned()
-        .collect();
+    let metadata_keys = state.kv_storage.keys_like("%-metadata").await?;
 
     // Group costs by time period
     let mut period_data: BTreeMap<String, (f64, usize, usize)> = BTreeMap::new();

--- a/edgequake/crates/edgequake-api/src/handlers/documents/delete/bulk.rs
+++ b/edgequake/crates/edgequake-api/src/handlers/documents/delete/bulk.rs
@@ -41,14 +41,7 @@ pub async fn delete_all_documents(
 ) -> ApiResult<Json<DeleteAllDocumentsResponse>> {
     tracing::info!(workspace_id = ?tenant_ctx.workspace_id, "Bulk delete documents requested");
 
-    let keys = state.kv_storage.keys().await?;
-
-    // Find all document metadata keys to identify unique documents
-    let metadata_keys: Vec<String> = keys
-        .iter()
-        .filter(|k| k.ends_with("-metadata"))
-        .cloned()
-        .collect();
+    let metadata_keys = state.kv_storage.keys_like("%-metadata").await?;
 
     let mut deleted_count = 0usize;
     let mut total_chunks_deleted = 0usize;
@@ -146,11 +139,7 @@ pub async fn delete_all_documents(
 
         // Attempt to delete this document within the validated workspace scope.
         let chunk_prefix = format!("{}-chunk-", document_id);
-        let chunk_ids: Vec<String> = keys
-            .iter()
-            .filter(|k| k.starts_with(&chunk_prefix))
-            .cloned()
-            .collect();
+        let chunk_ids = state.kv_storage.keys_with_prefix(&chunk_prefix).await?;
 
         let content_key = format!("{}-content", document_id);
 

--- a/edgequake/crates/edgequake-api/src/handlers/documents/delete/impact.rs
+++ b/edgequake/crates/edgequake-api/src/handlers/documents/delete/impact.rs
@@ -30,21 +30,13 @@ pub async fn analyze_deletion_impact(
     State(state): State<AppState>,
     axum::extract::Path(document_id): axum::extract::Path<String>,
 ) -> ApiResult<Json<DeletionImpactResponse>> {
-    let keys = state.kv_storage.keys().await?;
-
-    // Find chunks belonging to this document
     let chunk_prefix = format!("{}-chunk-", document_id);
-    let chunk_ids: Vec<String> = keys
-        .iter()
-        .filter(|k| k.starts_with(&chunk_prefix))
-        .cloned()
-        .collect();
+    let chunk_ids = state.kv_storage.keys_with_prefix(&chunk_prefix).await?;
 
-    // Also check for metadata and content keys
     let metadata_key = format!("{}-metadata", document_id);
     let content_key = format!("{}-content", document_id);
-    let has_metadata = keys.contains(&metadata_key);
-    let has_content = keys.contains(&content_key);
+    let has_metadata = state.kv_storage.get_by_id(&metadata_key).await?.is_some();
+    let has_content = state.kv_storage.get_by_id(&content_key).await?.is_some();
 
     // Document must have either chunks, metadata, or content
     if chunk_ids.is_empty() && !has_metadata && !has_content {

--- a/edgequake/crates/edgequake-api/src/handlers/documents/query/detail.rs
+++ b/edgequake/crates/edgequake-api/src/handlers/documents/query/detail.rs
@@ -53,10 +53,7 @@ pub async fn get_document(
 
     // SPEC-011: prefix scan — no full keys() table scan
     let chunk_prefix = format!("{}-chunk-", document_id);
-    let chunk_keys = state
-        .kv_storage
-        .keys_with_prefix(&chunk_prefix)
-        .await?;
+    let chunk_keys = state.kv_storage.keys_with_prefix(&chunk_prefix).await?;
     let chunk_count = chunk_keys.len();
     debug!(chunk_count = chunk_count, "Document chunk keys loaded");
 

--- a/edgequake/crates/edgequake-api/src/handlers/documents/query/detail.rs
+++ b/edgequake/crates/edgequake-api/src/handlers/documents/query/detail.rs
@@ -51,19 +51,14 @@ pub async fn get_document(
     let metadata = metadata_values.into_iter().next();
     debug!(has_metadata = metadata.is_some(), "Metadata value present");
 
-    // Check if document exists by metadata or chunks
-    let keys = state.kv_storage.keys().await?;
-    debug!(total_keys = keys.len(), "Total keys in storage");
-    let matching_keys: Vec<_> = keys
-        .iter()
-        .filter(|k| k.contains(&document_id))
-        .cloned()
-        .collect();
-    debug!(matching_keys = ?matching_keys, "Keys matching document ID");
-    let chunk_count = keys
-        .iter()
-        .filter(|k| k.starts_with(&format!("{}-chunk-", document_id)))
-        .count();
+    // SPEC-011: prefix scan — no full keys() table scan
+    let chunk_prefix = format!("{}-chunk-", document_id);
+    let chunk_keys = state
+        .kv_storage
+        .keys_with_prefix(&chunk_prefix)
+        .await?;
+    let chunk_count = chunk_keys.len();
+    debug!(chunk_count = chunk_count, "Document chunk keys loaded");
 
     // Document must have either metadata or chunks
     if metadata.is_none() && chunk_count == 0 {

--- a/edgequake/crates/edgequake-api/src/handlers/documents/query/list.rs
+++ b/edgequake/crates/edgequake-api/src/handlers/documents/query/list.rs
@@ -59,31 +59,36 @@ pub async fn list_documents(
         }));
     }
 
-    let keys = state.kv_storage.keys().await?;
-    debug!(key_count = keys.len(), "Total keys in KV storage");
-    debug!(keys = ?keys, "All keys in KV storage");
+    // SPEC-011: SQL LIKE filters avoid O(N) full key scan + in-memory filter.
+    let metadata_keys = state.kv_storage.keys_like("%-metadata").await?;
+    let chunk_keys = state.kv_storage.keys_like("%-chunk-%").await?;
+    debug!(
+        metadata_key_count = metadata_keys.len(),
+        chunk_key_count = chunk_keys.len(),
+        "KV keys loaded via LIKE filters"
+    );
 
     // Group by document and collect metadata keys
     let mut doc_chunks: std::collections::HashMap<String, usize> = std::collections::HashMap::new();
-    let mut metadata_keys: Vec<String> = Vec::new();
 
-    for key in &keys {
+    for key in &chunk_keys {
         // Skip injection entries — they are managed by the /knowledge route (SPEC-0002)
         if key.starts_with("injection::") {
             continue;
         }
-        if key.ends_with("-metadata") {
-            debug!(metadata_key = %key, "Found metadata key");
-            metadata_keys.push(key.clone());
-        } else if key.contains("-chunk-") {
-            // Only count actual chunk keys (e.g., "doc-id-chunk-0")
-            if let Some(doc_id) = key.split("-chunk-").next() {
-                // Filter out non-document keys (like -metadata, -content suffixes)
-                if !doc_id.ends_with("-metadata") && !doc_id.ends_with("-content") {
-                    *doc_chunks.entry(doc_id.to_string()).or_default() += 1;
-                }
+        if let Some(doc_id) = key.split("-chunk-").next() {
+            // Filter out non-document keys (like -metadata, -content suffixes)
+            if !doc_id.ends_with("-metadata") && !doc_id.ends_with("-content") {
+                *doc_chunks.entry(doc_id.to_string()).or_default() += 1;
             }
         }
+    }
+
+    for key in &metadata_keys {
+        if key.starts_with("injection::") {
+            continue;
+        }
+        debug!(metadata_key = %key, "Found metadata key");
     }
 
     // Fetch all metadata and store complete document info

--- a/edgequake/crates/edgequake-api/src/handlers/documents/query/track_status.rs
+++ b/edgequake/crates/edgequake-api/src/handlers/documents/query/track_status.rs
@@ -26,21 +26,15 @@ pub async fn get_track_status(
     State(state): State<AppState>,
     axum::extract::Path(track_id): axum::extract::Path<String>,
 ) -> ApiResult<Json<TrackStatusResponse>> {
-    let keys = state.kv_storage.keys().await?;
-
-    // Find all metadata keys
-    let metadata_keys: Vec<String> = keys
-        .iter()
-        .filter(|k| k.ends_with("-metadata"))
-        .cloned()
-        .collect();
+    let metadata_keys = state.kv_storage.keys_like("%-metadata").await?;
+    let chunk_keys = state.kv_storage.keys_like("%-chunk-%").await?;
 
     // Fetch all metadata
     let metadata_values = state.kv_storage.get_by_ids(&metadata_keys).await?;
 
     // Group chunks by document
     let mut doc_chunks: std::collections::HashMap<String, usize> = std::collections::HashMap::new();
-    for key in &keys {
+    for key in &chunk_keys {
         if let Some(doc_id) = key.split("-chunk-").next() {
             if !doc_id.ends_with("-metadata") && !doc_id.ends_with("-content") {
                 *doc_chunks.entry(doc_id.to_string()).or_default() += 1;

--- a/edgequake/crates/edgequake-api/src/handlers/documents/storage_helpers.rs
+++ b/edgequake/crates/edgequake-api/src/handlers/documents/storage_helpers.rs
@@ -758,13 +758,8 @@ pub(super) async fn delete_document_for_reingestion(
     .await?;
 
     // Delete chunk embeddings from vector storage
-    let keys = state.kv_storage.keys().await?;
     let chunk_prefix = format!("{}-chunk-", document_id);
-    let chunk_ids: Vec<String> = keys
-        .iter()
-        .filter(|k| k.starts_with(&chunk_prefix))
-        .cloned()
-        .collect();
+    let chunk_ids = state.kv_storage.keys_with_prefix(&chunk_prefix).await?;
 
     if !chunk_ids.is_empty() {
         if let Err(e) = workspace_vector_storage.delete(&chunk_ids).await {

--- a/edgequake/crates/edgequake-api/src/handlers/documents/upload/file_upload.rs
+++ b/edgequake/crates/edgequake-api/src/handlers/documents/upload/file_upload.rs
@@ -110,29 +110,25 @@ pub async fn upload_file(
         // WHY: If the configured LLM doesn't support vision (e.g. Mistral text-only),
         // we still ingest the image as a document with a descriptive placeholder rather
         // than returning a hard error to the user.
-        let extracted = match extract_text_from_image(
-            &content,
-            mime,
-            &filename,
-            state.llm_provider.as_ref(),
-        )
-        .await
-        {
-            Ok(text) => text,
-            Err(e) => {
-                tracing::warn!(
-                    filename = %filename,
-                    error = %e,
-                    "Vision extraction failed; storing image with placeholder text"
-                );
-                format!(
-                    "# Image Document: {filename}\n\n\
+        let extracted =
+            match extract_text_from_image(&content, mime, &filename, state.llm_provider.as_ref())
+                .await
+            {
+                Ok(text) => text,
+                Err(e) => {
+                    tracing::warn!(
+                        filename = %filename,
+                        error = %e,
+                        "Vision extraction failed; storing image with placeholder text"
+                    );
+                    format!(
+                        "# Image Document: {filename}\n\n\
                      *Automatic text extraction failed: {e}*\n\n\
                      Configure a vision-capable LLM (e.g., gpt-4o, gemma3:12b, llava) \
                      to enable OCR/text extraction from image uploads."
-                )
-            }
-        };
+                    )
+                }
+            };
         (extracted, mime)
     } else {
         // ── Text path: validate size, extension, and UTF-8 ───────────────────

--- a/edgequake/crates/edgequake-api/src/handlers/documents/upload/image_extract.rs
+++ b/edgequake/crates/edgequake-api/src/handlers/documents/upload/image_extract.rs
@@ -66,10 +66,9 @@ pub async fn extract_text_from_image(
 
     let messages = vec![system_message, user_message];
 
-    let response = llm
-        .chat(&messages, None)
-        .await
-        .map_err(|e| ApiError::Internal(format!("Vision LLM call failed for '{}': {}", filename, e)))?;
+    let response = llm.chat(&messages, None).await.map_err(|e| {
+        ApiError::Internal(format!("Vision LLM call failed for '{}': {}", filename, e))
+    })?;
 
     let text = response.content.trim().to_string();
 

--- a/edgequake/crates/edgequake-api/src/handlers/health.rs
+++ b/edgequake/crates/edgequake-api/src/handlers/health.rs
@@ -72,9 +72,10 @@ pub use crate::handlers::health_types::{
 )]
 pub async fn health_check(State(state): State<AppState>) -> ApiResult<Json<HealthResponse>> {
     let components = ComponentHealth {
-        kv_storage: state.kv_storage.count().await.is_ok(),
-        vector_storage: state.vector_storage.count().await.is_ok(),
-        graph_storage: state.graph_storage.node_count().await.is_ok(),
+        // SPEC-011: ping() is O(1); count() was O(N) full-table scan per health probe.
+        kv_storage: state.kv_storage.ping().await.is_ok(),
+        vector_storage: state.vector_storage.ping().await.is_ok(),
+        graph_storage: state.graph_storage.ping().await.is_ok(),
         llm_provider: true, // Assume available, actual check would require API call
     };
 

--- a/edgequake/crates/edgequake-api/src/handlers/lineage/queries.rs
+++ b/edgequake/crates/edgequake-api/src/handlers/lineage/queries.rs
@@ -124,20 +124,12 @@ pub async fn get_document_lineage(
     // SECURITY: Verify the document belongs to the requesting tenant/workspace first.
     verify_document_access(state.kv_storage.as_ref(), &document_id, &tenant_ctx).await?;
 
-    // WHY: We scan KV keys by prefix rather than querying a separate index.
-    // This is correct for in-memory and moderate-scale PostgreSQL KV stores.
-    // For very large datasets (>100K documents), consider adding a dedicated
-    // chunk-count index to avoid full key scan.
-    let keys = state.kv_storage.keys().await?;
+    // SPEC-011: prefix scan for document chunks; point lookup for metadata
     let chunk_prefix = format!("{}-chunk-", document_id);
-    let chunk_ids: Vec<String> = keys
-        .iter()
-        .filter(|k| k.starts_with(&chunk_prefix))
-        .cloned()
-        .collect();
+    let chunk_ids = state.kv_storage.keys_with_prefix(&chunk_prefix).await?;
 
     let metadata_key = format!("{}-metadata", document_id);
-    if chunk_ids.is_empty() && !keys.contains(&metadata_key) {
+    if chunk_ids.is_empty() && state.kv_storage.get_by_id(&metadata_key).await?.is_none() {
         return Err(ApiError::NotFound(format!(
             "Document '{}' not found",
             document_id

--- a/edgequake/crates/edgequake-api/src/handlers/workspaces/stats.rs
+++ b/edgequake/crates/edgequake-api/src/handlers/workspaces/stats.rs
@@ -161,19 +161,17 @@ async fn try_kv_storage_stats(
     state: &AppState,
     workspace_id: Uuid,
 ) -> Result<WorkspaceStatsResponse, ApiError> {
-    // Get all keys from KV storage
-    let all_keys = state
+    // SPEC-011: fetch only metadata + chunk keys instead of full table scan.
+    let metadata_keys = state
         .kv_storage
-        .keys()
+        .keys_like("%-metadata")
         .await
-        .map_err(|e| ApiError::Internal(format!("Failed to get KV storage keys: {}", e)))?;
-
-    // Filter metadata keys
-    let metadata_keys: Vec<String> = all_keys
-        .iter()
-        .filter(|k| k.ends_with("-metadata"))
-        .cloned()
-        .collect();
+        .map_err(|e| ApiError::Internal(format!("Failed to get KV metadata keys: {}", e)))?;
+    let chunk_keys = state
+        .kv_storage
+        .keys_like("%-chunk-%")
+        .await
+        .map_err(|e| ApiError::Internal(format!("Failed to get KV chunk keys: {}", e)))?;
 
     // Get all metadata values
     let metadata_values = state
@@ -232,8 +230,8 @@ async fn try_kv_storage_stats(
     let mut embedding_count = 0;
 
     for doc_id in &workspace_doc_ids {
-        // Count chunk keys for this document
-        let doc_chunk_keys: Vec<String> = all_keys
+        // Count chunk keys for this document (from pre-filtered chunk key list)
+        let doc_chunk_keys: Vec<String> = chunk_keys
             .iter()
             .filter(|k| k.starts_with(&format!("{}-chunk-", doc_id)))
             .cloned()

--- a/edgequake/crates/edgequake-api/src/processor/pipeline_checkpoint.rs
+++ b/edgequake/crates/edgequake-api/src/processor/pipeline_checkpoint.rs
@@ -293,18 +293,13 @@ pub async fn clear_pipeline_checkpoint(kv: &Arc<dyn KVStorage>, document_id: &st
 /// and removes them. This prevents unbounded storage growth from crashed
 /// processing runs that never completed.
 pub async fn cleanup_stale_checkpoints(kv: &Arc<dyn KVStorage>) {
-    let all_keys = match kv.keys().await {
+    let checkpoint_keys = match kv.keys_like("%-pipeline-checkpoint").await {
         Ok(keys) => keys,
         Err(e) => {
-            warn!(error = %e, "Failed to list KV keys for checkpoint cleanup");
+            warn!(error = %e, "Failed to list checkpoint keys for cleanup");
             return;
         }
     };
-
-    let checkpoint_keys: Vec<String> = all_keys
-        .into_iter()
-        .filter(|k| k.ends_with(&format!("-{}", CHECKPOINT_PREFIX)))
-        .collect();
 
     if checkpoint_keys.is_empty() {
         return;

--- a/edgequake/crates/edgequake-api/src/processor/text_insert.rs
+++ b/edgequake/crates/edgequake-api/src/processor/text_insert.rs
@@ -388,10 +388,7 @@ impl DocumentTaskProcessor {
                                         label, current, total, pct
                                     )
                                 };
-                                updated.insert(
-                                    "current_stage".to_string(),
-                                    json!("embedding"),
-                                );
+                                updated.insert("current_stage".to_string(), json!("embedding"));
                                 updated.insert("stage_message".to_string(), json!(msg));
                                 updated.insert(
                                     "stage_progress".to_string(),

--- a/edgequake/crates/edgequake-api/src/state/postgres.rs
+++ b/edgequake/crates/edgequake-api/src/state/postgres.rs
@@ -213,13 +213,22 @@ impl AppState {
             std::env::var("EDGEQUAKE_LLM_PROVIDER").unwrap_or_else(|_| "auto-detected".to_string())
         );
 
-        // Create PostgreSQL-backed storages
-        let kv_storage = Arc::new(PostgresKVStorage::new(pg_config.clone()));
-        let vector_storage = Arc::new(PgVectorStorage::with_dimension(
+        // Create PostgreSQL-backed storages (SPEC-011: single shared pool)
+        use edgequake_storage::adapters::postgres::PostgresPool;
+        let storage_pool = PostgresPool::from_existing(pool.clone(), pg_config.clone());
+        let kv_storage = Arc::new(PostgresKVStorage::with_pool(
+            storage_pool.clone(),
+            pg_config.clone(),
+        ));
+        let vector_storage = Arc::new(PgVectorStorage::with_pool_and_dimension(
+            storage_pool.clone(),
             pg_config.clone(),
             embedding_dim,
         ));
-        let graph_storage = Arc::new(PostgresAGEGraphStorage::new(pg_config.clone()));
+        let graph_storage = Arc::new(PostgresAGEGraphStorage::with_pool(
+            storage_pool,
+            pg_config.clone(),
+        ));
 
         // OODA-228: Ensure default vector storage has correct dimension BEFORE initialize
         // WHY: If embedding provider changed (e.g., OpenAI 1536 → Ollama 768),

--- a/edgequake/crates/edgequake-api/src/state/provider_setup.rs
+++ b/edgequake/crates/edgequake-api/src/state/provider_setup.rs
@@ -224,7 +224,11 @@ pub fn resolve_vision_llm_provider() -> Option<Arc<dyn LLMProvider>> {
     match crate::safety_limits::create_safe_llm_provider(
         if llm_provider_name.is_empty() {
             // Auto-detect: use whichever key is present.
-            if std::env::var("MISTRAL_API_KEY").is_ok() { "mistral" } else { "openai" }
+            if std::env::var("MISTRAL_API_KEY").is_ok() {
+                "mistral"
+            } else {
+                "openai"
+            }
         } else {
             &llm_provider_name
         },

--- a/edgequake/crates/edgequake-api/tests/e2e_storage_performance_spec011.rs
+++ b/edgequake/crates/edgequake-api/tests/e2e_storage_performance_spec011.rs
@@ -81,7 +81,10 @@ async fn setup_app_with_workspace() -> (AppState, Router, Uuid, Uuid) {
         .unwrap();
 
     let row_count = seed_kv(&state, ws.workspace_id, tenant.tenant_id).await;
-    assert!(row_count >= 2000, "seed should create 2000+ rows, got {row_count}");
+    assert!(
+        row_count >= 2000,
+        "seed should create 2000+ rows, got {row_count}"
+    );
 
     let router = Server::new(
         ServerConfig {

--- a/edgequake/crates/edgequake-api/tests/e2e_storage_performance_spec011.rs
+++ b/edgequake/crates/edgequake-api/tests/e2e_storage_performance_spec011.rs
@@ -1,0 +1,245 @@
+//! E2E performance contract tests — SPEC-011 storage guarantees.
+//!
+//! Seeds a large in-memory KV dataset and asserts latency SLOs from
+//! [PERFORMANCE_GUARANTEE.md](../../../specs/11-performance-issue/PERFORMANCE_GUARANTEE.md).
+//!
+//! Run: `cargo test -p edgequake-api --test e2e_storage_performance_spec011`
+
+use std::time::Instant;
+
+use axum::{body::Body, extract::State, http::Request, Router};
+use edgequake_api::handlers::health::health_check;
+use edgequake_api::{AppState, Server, ServerConfig};
+use edgequake_core::{CreateWorkspaceRequest, Tenant, TenantPlan};
+use serde_json::json;
+use tower::ServiceExt;
+use uuid::Uuid;
+
+/// Reference load: 100 documents × 25 chunks + metadata ≈ 2,600 KV rows.
+const SEED_DOC_COUNT: usize = 100;
+const SEED_CHUNKS_PER_DOC: usize = 25;
+
+const SLO_HEALTH_MS: u128 = 200;
+const SLO_PING_MS: u128 = 50;
+const SLO_PREFIX_SCAN_MS: u128 = 100;
+const SLO_LIST_DOCUMENTS_MS: u128 = 500;
+
+async fn seed_kv(state: &AppState, workspace_id: Uuid, tenant_id: Uuid) -> usize {
+    let ws = workspace_id.to_string();
+    let tenant = tenant_id.to_string();
+    let mut batch = Vec::with_capacity(SEED_DOC_COUNT * (SEED_CHUNKS_PER_DOC + 1));
+
+    for i in 0..SEED_DOC_COUNT {
+        let doc_id = format!("perf-doc-{i:04}");
+        batch.push((
+            format!("{doc_id}-metadata"),
+            json!({
+                "id": doc_id,
+                "title": format!("Doc {i}"),
+                "status": "completed",
+                "workspace_id": ws,
+                "tenant_id": tenant,
+            }),
+        ));
+        for c in 0..SEED_CHUNKS_PER_DOC {
+            batch.push((
+                format!("{doc_id}-chunk-{c}"),
+                json!({"text": "chunk", "index": c}),
+            ));
+        }
+    }
+
+    state.kv_storage.upsert(&batch).await.unwrap();
+    batch.len()
+}
+
+async fn setup_app_with_workspace() -> (AppState, Router, Uuid, Uuid) {
+    let state = AppState::test_state();
+    let tenant = Tenant::new("Perf Tenant", "perf-tenant").with_plan(TenantPlan::Pro);
+    let tenant = state.workspace_service.create_tenant(tenant).await.unwrap();
+    let ws = state
+        .workspace_service
+        .create_workspace(
+            tenant.tenant_id,
+            CreateWorkspaceRequest {
+                name: "Perf WS".into(),
+                slug: None,
+                description: None,
+                max_documents: None,
+                llm_model: None,
+                llm_provider: None,
+                embedding_model: None,
+                embedding_provider: None,
+                embedding_dimension: None,
+                vision_llm_model: None,
+                pdf_parser_backend: None,
+                entity_types: None,
+                vision_llm_provider: None,
+            },
+        )
+        .await
+        .unwrap();
+
+    let row_count = seed_kv(&state, ws.workspace_id, tenant.tenant_id).await;
+    assert!(row_count >= 2000, "seed should create 2000+ rows, got {row_count}");
+
+    let router = Server::new(
+        ServerConfig {
+            host: "127.0.0.1".into(),
+            port: 0,
+            enable_cors: false,
+            enable_compression: false,
+            enable_swagger: false,
+        },
+        state.clone(),
+    )
+    .build_router();
+
+    (state, router, ws.workspace_id, tenant.tenant_id)
+}
+
+#[tokio::test]
+async fn test_health_slo_with_large_kv() {
+    let (state, _, _, _) = setup_app_with_workspace().await;
+
+    let start = Instant::now();
+    let result = health_check(State(state)).await;
+    let elapsed = start.elapsed();
+
+    assert!(result.is_ok(), "health must succeed: {:?}", result.err());
+    assert!(
+        elapsed.as_millis() < SLO_HEALTH_MS,
+        "GET /health SLO violated: {:?} >= {SLO_HEALTH_MS}ms (uses ping not count)",
+        elapsed
+    );
+}
+
+#[tokio::test]
+async fn test_kv_ping_slo_with_large_kv() {
+    let (state, _, _, _) = setup_app_with_workspace().await;
+
+    let start = Instant::now();
+    state.kv_storage.ping().await.unwrap();
+    let elapsed = start.elapsed();
+
+    assert!(
+        elapsed.as_millis() < SLO_PING_MS,
+        "KV ping SLO violated: {:?} >= {SLO_PING_MS}ms",
+        elapsed
+    );
+}
+
+#[tokio::test]
+async fn test_keys_with_prefix_slo_and_correctness() {
+    let (state, _, _, _) = setup_app_with_workspace().await;
+    let doc_id = "perf-doc-0000";
+    let prefix = format!("{doc_id}-chunk-");
+
+    let start = Instant::now();
+    let keys = state.kv_storage.keys_with_prefix(&prefix).await.unwrap();
+    let elapsed = start.elapsed();
+
+    assert_eq!(keys.len(), SEED_CHUNKS_PER_DOC);
+    assert!(
+        elapsed.as_millis() < SLO_PREFIX_SCAN_MS,
+        "keys_with_prefix SLO violated: {:?} >= {SLO_PREFIX_SCAN_MS}ms",
+        elapsed
+    );
+}
+
+#[tokio::test]
+async fn test_keys_like_metadata_count_matches_seed() {
+    let (state, _, _, _) = setup_app_with_workspace().await;
+
+    let metadata_keys = state.kv_storage.keys_like("%-metadata").await.unwrap();
+    assert_eq!(
+        metadata_keys.len(),
+        SEED_DOC_COUNT,
+        "metadata key count must match seeded documents"
+    );
+}
+
+#[tokio::test]
+async fn test_document_list_slo_with_large_kv() {
+    let (_state, app, ws_id, tenant_id) = setup_app_with_workspace().await;
+
+    let start = Instant::now();
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/api/v1/documents")
+                .header("X-Tenant-ID", tenant_id.to_string())
+                .header("X-Workspace-ID", ws_id.to_string())
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let elapsed = start.elapsed();
+
+    assert_eq!(resp.status(), 200, "list documents must succeed");
+    assert!(
+        elapsed.as_millis() < SLO_LIST_DOCUMENTS_MS,
+        "list documents SLO violated: {:?} >= {SLO_LIST_DOCUMENTS_MS}ms",
+        elapsed
+    );
+}
+
+#[tokio::test]
+async fn test_count_still_exact_under_load() {
+    let (state, _, _, _) = setup_app_with_workspace().await;
+    let expected = SEED_DOC_COUNT * (SEED_CHUNKS_PER_DOC + 1);
+    assert_eq!(state.kv_storage.count().await.unwrap(), expected);
+}
+
+/// Regression: the 13s production query was `SELECT COUNT(*) FROM eq_eq_default_kv`
+/// triggered from `/health` via `kv_storage.count()`.
+#[test]
+fn test_health_handler_never_calls_kv_count() {
+    let health_src = include_str!("../src/handlers/health.rs");
+    assert!(
+        !health_src.contains("kv_storage.count()"),
+        "health must not call kv_storage.count() — use ping() (SPEC-011)"
+    );
+    assert!(
+        health_src.contains("kv_storage.ping()"),
+        "health must call kv_storage.ping()"
+    );
+    assert!(
+        !health_src.contains("vector_storage.count()"),
+        "health must not call vector_storage.count()"
+    );
+    assert!(
+        !health_src.contains("graph_storage.node_count()"),
+        "health must not call graph_storage.node_count()"
+    );
+}
+
+#[tokio::test]
+async fn test_document_detail_uses_prefix_not_full_scan() {
+    let (_state, app, ws_id, tenant_id) = setup_app_with_workspace().await;
+    let doc_id = "perf-doc-0042";
+
+    let start = Instant::now();
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri(format!("/api/v1/documents/{doc_id}"))
+                .header("X-Tenant-ID", tenant_id.to_string())
+                .header("X-Workspace-ID", ws_id.to_string())
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let elapsed = start.elapsed();
+
+    assert_eq!(resp.status(), 200, "document detail must succeed");
+    assert!(
+        elapsed.as_millis() < SLO_PREFIX_SCAN_MS,
+        "document detail SLO violated: {:?} >= {SLO_PREFIX_SCAN_MS}ms",
+        elapsed
+    );
+}

--- a/edgequake/crates/edgequake-pipeline/src/merger/mod.rs
+++ b/edgequake/crates/edgequake-pipeline/src/merger/mod.rs
@@ -330,14 +330,8 @@ mod tests {
         // Rust is_alphanumeric() returns true for Unicode accented chars,
         // so they are preserved (not stripped). The key insight is that
         // case variants still normalize to the same key.
-        assert_eq!(
-            normalize_entity_name("Rémi"),
-            normalize_entity_name("rémi")
-        );
-        assert_eq!(
-            normalize_entity_name("Rémi"),
-            normalize_entity_name("RÉMI")
-        );
+        assert_eq!(normalize_entity_name("Rémi"), normalize_entity_name("rémi"));
+        assert_eq!(normalize_entity_name("Rémi"), normalize_entity_name("RÉMI"));
         assert_eq!(normalize_entity_name("Rémi"), "RÉMI");
     }
 

--- a/edgequake/crates/edgequake-pipeline/src/pipeline/helpers.rs
+++ b/edgequake/crates/edgequake-pipeline/src/pipeline/helpers.rs
@@ -15,7 +15,9 @@ use crate::error::Result;
 use crate::extractor::ExtractionResult;
 use crate::lineage::{DocumentLineage, ExtractionMetadata, LineageBuilder, SourceSpan};
 
-use super::{CostBreakdownStats, EmbedProgressCallback, EmbedProgressUpdate, Pipeline, ProcessingStats};
+use super::{
+    CostBreakdownStats, EmbedProgressCallback, EmbedProgressUpdate, Pipeline, ProcessingStats,
+};
 
 // ─────────────────────────────────────────────────────────────────────────────
 //                       EXTRACTION POST-PROCESSING
@@ -293,7 +295,11 @@ async fn embed_with_token_budget(
         // Always include at least one text even if it alone exceeds the budget (single-text
         // requests are the smallest possible unit; the provider must handle them).
         if (token_overflow || count_overflow) && i > batch_start {
-            let flush_reason = if count_overflow { "count limit" } else { "token budget" };
+            let flush_reason = if count_overflow {
+                "count limit"
+            } else {
+                "token budget"
+            };
             tracing::debug!(
                 sub_batch_texts = current_count,
                 estimated_tokens = batch_tokens,
@@ -400,7 +406,11 @@ impl Pipeline {
         total: usize,
     ) {
         if let Some(cb) = progress {
-            cb(EmbedProgressUpdate { stage, current, total });
+            cb(EmbedProgressUpdate {
+                stage,
+                current,
+                total,
+            });
         }
     }
 
@@ -470,13 +480,19 @@ impl Pipeline {
             // WHY safe_embed: guards length, embeds in compliant sub-batches, and
             // warns if the provider silently drops results (zip() would otherwise
             // create orphaned graph nodes with no embedding vector).
-            let all_embeddings = safe_embed(provider, &all_entity_texts, max_chars, "Entity").await?;
+            let all_embeddings =
+                safe_embed(provider, &all_entity_texts, max_chars, "Entity").await?;
             for (embedding, (ext_idx, ent_idx)) in all_embeddings.into_iter().zip(entity_indices) {
                 extractions[ext_idx].entities[ent_idx].embedding = Some(embedding);
             }
 
             // Notify: entity embeddings complete
-            Self::emit_embed_progress(progress, "entities", all_entity_texts.len(), all_entity_texts.len());
+            Self::emit_embed_progress(
+                progress,
+                "entities",
+                all_entity_texts.len(),
+                all_entity_texts.len(),
+            );
         }
 
         // ── Relationship embeddings (batched) ──
@@ -511,7 +527,12 @@ impl Pipeline {
             }
 
             // Notify: relationship embeddings complete
-            Self::emit_embed_progress(progress, "relationships", all_relationship_texts.len(), all_relationship_texts.len());
+            Self::emit_embed_progress(
+                progress,
+                "relationships",
+                all_relationship_texts.len(),
+                all_relationship_texts.len(),
+            );
         }
 
         // ── Embedding cost calculation ──
@@ -942,7 +963,12 @@ mod tests {
             sizes.len()
         );
         for (idx, &size) in sizes.iter().enumerate() {
-            assert!(size <= 5, "Call {} sent {} items, exceeds max_batch 5", idx, size);
+            assert!(
+                size <= 5,
+                "Call {} sent {} items, exceeds max_batch 5",
+                idx,
+                size
+            );
         }
         let total: usize = sizes.iter().sum();
         assert_eq!(total, 20);
@@ -966,7 +992,11 @@ mod tests {
         // First text: 400 > 85 but i == batch_start (can't flush empty batch) → sent alone
         // Second text: 400 > 85 → flush first → each text in its own call
         let sizes = call_sizes.lock().unwrap();
-        assert_eq!(sizes.len(), 5, "Each text should be its own call due to tiny budget");
+        assert_eq!(
+            sizes.len(),
+            5,
+            "Each text should be its own call due to tiny budget"
+        );
         let total: usize = sizes.iter().sum();
         assert_eq!(total, 5);
     }

--- a/edgequake/crates/edgequake-query/src/engine.rs
+++ b/edgequake/crates/edgequake-query/src/engine.rs
@@ -144,7 +144,7 @@ pub struct QueryRequest {
     /// Optional images to include with the query (multimodal vision queries).
     /// Each entry is a base64-encoded image with its MIME type.
     /// When set, the SOTA engine forwards images to the vision-capable LLM.
-    /// @implements FEAT0203: Image attachment in chat
+    /// @implements FEAT0240: Image attachment in chat
     #[serde(default)]
     pub images: Option<Vec<edgequake_llm::traits::ImageData>>,
 }
@@ -294,7 +294,6 @@ impl QueryRequest {
     }
 
     /// Attach images for a multimodal (vision) query.
-    /// @implements FEAT0203: Image attachment in chat
     pub fn with_images(mut self, images: Vec<edgequake_llm::traits::ImageData>) -> Self {
         self.images = Some(images);
         self

--- a/edgequake/crates/edgequake-query/src/sota_engine/prompt.rs
+++ b/edgequake/crates/edgequake-query/src/sota_engine/prompt.rs
@@ -257,11 +257,15 @@ Generate a comprehensive, well-structured answer that integrates observations fr
                 Ok(r) => r,
                 Err(e) => {
                     tracing::warn!(error = %e, "Vision chat failed; retrying as text-only query");
-                    provider.complete(&self.build_prompt(query, context, system_prompt_extension)).await?
+                    provider
+                        .complete(&self.build_prompt(query, context, system_prompt_extension))
+                        .await?
                 }
             }
         } else {
-            provider.complete(&self.build_prompt(query, context, system_prompt_extension)).await?
+            provider
+                .complete(&self.build_prompt(query, context, system_prompt_extension))
+                .await?
         };
 
         Ok((response.content, response.completion_tokens))

--- a/edgequake/crates/edgequake-query/src/sota_engine/query_modes.rs
+++ b/edgequake/crates/edgequake-query/src/sota_engine/query_modes.rs
@@ -585,12 +585,7 @@ impl SOTAQueryEngine {
 
         let results = self
             .vector_storage
-            .query_filtered(
-                &embeddings.query,
-                self.config.max_chunks,
-                None,
-                mf.as_ref(),
-            )
+            .query_filtered(&embeddings.query, self.config.max_chunks, None, mf.as_ref())
             .await?;
 
         for result in results

--- a/edgequake/crates/edgequake-query/src/sota_engine/vector_queries.rs
+++ b/edgequake/crates/edgequake-query/src/sota_engine/vector_queries.rs
@@ -27,19 +27,10 @@ impl SOTAQueryEngine {
         // vectors. Without this, large graphs (60k+ entities) cause the top-k results
         // to be dominated by entity vectors, leaving 0 chunks after in-memory filtering.
         // SPEC-007: tenant/workspace/type filter pushed to storage layer via query_filtered.
-        let mf = MetadataFilter::from_tenant_workspace_type(
-            tenant_id,
-            workspace_id,
-            "chunk",
-        );
+        let mf = MetadataFilter::from_tenant_workspace_type(tenant_id, workspace_id, "chunk");
 
         let results = vector_storage
-            .query_filtered(
-                &embeddings.query,
-                self.config.max_chunks,
-                None,
-                mf.as_ref(),
-            )
+            .query_filtered(&embeddings.query, self.config.max_chunks, None, mf.as_ref())
             .await?;
 
         for result in results

--- a/edgequake/crates/edgequake-storage/src/adapters/memory/kv.rs
+++ b/edgequake/crates/edgequake-storage/src/adapters/memory/kv.rs
@@ -23,7 +23,7 @@ use std::collections::{HashMap, HashSet};
 use std::sync::RwLock;
 
 use crate::error::{Result, StorageError};
-use crate::traits::KVStorage;
+use crate::traits::{kv_key_matches_like, KVStorage};
 
 /// In-memory key-value storage implementation.
 ///
@@ -137,6 +137,39 @@ impl KVStorage for MemoryKVStorage {
             .read()
             .map_err(|e| StorageError::Database(format!("Lock error: {}", e)))?;
         Ok(data.len())
+    }
+
+    async fn ping(&self) -> Result<()> {
+        let data = self
+            .data
+            .read()
+            .map_err(|e| StorageError::Database(format!("Lock error: {}", e)))?;
+        let _reachable = data.len();
+        Ok(())
+    }
+
+    async fn keys_like(&self, pattern: &str) -> Result<Vec<String>> {
+        let data = self
+            .data
+            .read()
+            .map_err(|e| StorageError::Database(format!("Lock error: {}", e)))?;
+        Ok(data
+            .keys()
+            .filter(|key| kv_key_matches_like(key, pattern))
+            .cloned()
+            .collect())
+    }
+
+    async fn keys_with_prefix(&self, prefix: &str) -> Result<Vec<String>> {
+        let data = self
+            .data
+            .read()
+            .map_err(|e| StorageError::Database(format!("Lock error: {}", e)))?;
+        Ok(data
+            .keys()
+            .filter(|key| key.starts_with(prefix))
+            .cloned()
+            .collect())
     }
 
     async fn keys(&self) -> Result<Vec<String>> {

--- a/edgequake/crates/edgequake-storage/src/adapters/memory/vector.rs
+++ b/edgequake/crates/edgequake-storage/src/adapters/memory/vector.rs
@@ -1329,12 +1329,8 @@ mod tests {
         assert_eq!(all.len(), 4);
 
         // With vector_type = "chunk" — only chunks returned
-        let mf = MetadataFilter::from_tenant_workspace_type(
-            Some("t1".into()),
-            None,
-            "chunk",
-        )
-        .unwrap();
+        let mf =
+            MetadataFilter::from_tenant_workspace_type(Some("t1".into()), None, "chunk").unwrap();
         let chunks = storage
             .query_filtered(&[1.0, 0.0, 0.0], 10, None, Some(&mf))
             .await
@@ -1343,12 +1339,8 @@ mod tests {
         assert!(chunks.iter().all(|r| r.id.starts_with('c')));
 
         // With vector_type = "entity" — only entities returned
-        let mf_ent = MetadataFilter::from_tenant_workspace_type(
-            Some("t1".into()),
-            None,
-            "entity",
-        )
-        .unwrap();
+        let mf_ent =
+            MetadataFilter::from_tenant_workspace_type(Some("t1".into()), None, "entity").unwrap();
         let entities = storage
             .query_filtered(&[1.0, 0.0, 0.0], 10, None, Some(&mf_ent))
             .await

--- a/edgequake/crates/edgequake-storage/src/adapters/postgres/connection.rs
+++ b/edgequake/crates/edgequake-storage/src/adapters/postgres/connection.rs
@@ -41,6 +41,17 @@ impl PostgresPool {
         }
     }
 
+    /// Wrap an already-initialized `PgPool` (SPEC-011: shared pool across adapters).
+    ///
+    /// Skips lazy pool creation and extension setup — caller must have initialized
+    /// extensions on the underlying pool already.
+    pub fn from_existing(pool: PgPool, config: PostgresConfig) -> Self {
+        Self {
+            pool: Arc::new(RwLock::new(Some(pool))),
+            config,
+        }
+    }
+
     /// Get the configuration.
     pub fn config(&self) -> &PostgresConfig {
         &self.config

--- a/edgequake/crates/edgequake-storage/src/adapters/postgres/graph/mod.rs
+++ b/edgequake/crates/edgequake-storage/src/adapters/postgres/graph/mod.rs
@@ -101,12 +101,17 @@ pub struct PostgresAGEGraphStorage {
 impl PostgresAGEGraphStorage {
     /// Create a new Apache AGE graph storage.
     pub fn new(config: PostgresConfig) -> Self {
+        Self::with_pool(PostgresPool::new(config.clone()), config)
+    }
+
+    /// Create graph storage using a shared connection pool (SPEC-011).
+    pub fn with_pool(pool: PostgresPool, config: PostgresConfig) -> Self {
         let prefix = config.table_prefix();
         let graph_name = format!("eq_{}_graph", prefix);
         let namespace = config.namespace.clone();
 
         Self {
-            pool: PostgresPool::new(config),
+            pool,
             graph_name,
             namespace,
             prefix,
@@ -1146,6 +1151,27 @@ impl GraphStorage for PostgresAGEGraphStorage {
         );
         let count = self.cypher_query_count(&cypher).await?;
         Ok(count as usize)
+    }
+
+    async fn ping(&self) -> Result<()> {
+        let pool = self.pool.get().await?;
+        let mut conn = pool.acquire().await.map_err(|e| {
+            StorageError::Connection(format!("Failed to acquire connection: {}", e))
+        })?;
+
+        // Probe the Node label table — succeeds even when empty (0 rows).
+        let sql = format!(r#"SELECT 1 FROM {}."Node" LIMIT 1"#, self.graph_name);
+        if sqlx::query(&sql).fetch_optional(&mut *conn).await.is_ok() {
+            return Ok(());
+        }
+
+        // Graph may not be initialized yet — fall back to connection-level ping.
+        sqlx::query("SELECT 1")
+            .fetch_one(&mut *conn)
+            .await
+            .map_err(|e| StorageError::Database(format!("Graph ping failed: {}", e)))?;
+
+        Ok(())
     }
 
     /// Get edge count for a specific workspace (OODA-03: Fix dashboard stats).

--- a/edgequake/crates/edgequake-storage/src/adapters/postgres/kv.rs
+++ b/edgequake/crates/edgequake-storage/src/adapters/postgres/kv.rs
@@ -154,9 +154,12 @@ impl PostgresKVStorage {
             fn_insert = fn_insert,
             stats = self.stats_table_name
         );
-        sqlx::query(&create_insert_fn).execute(pool).await.map_err(|e| {
-            StorageError::Database(format!("Failed to create KV stats insert fn: {}", e))
-        })?;
+        sqlx::query(&create_insert_fn)
+            .execute(pool)
+            .await
+            .map_err(|e| {
+                StorageError::Database(format!("Failed to create KV stats insert fn: {}", e))
+            })?;
 
         let create_delete_fn = format!(
             r#"
@@ -172,9 +175,12 @@ impl PostgresKVStorage {
             fn_delete = fn_delete,
             stats = self.stats_table_name
         );
-        sqlx::query(&create_delete_fn).execute(pool).await.map_err(|e| {
-            StorageError::Database(format!("Failed to create KV stats delete fn: {}", e))
-        })?;
+        sqlx::query(&create_delete_fn)
+            .execute(pool)
+            .await
+            .map_err(|e| {
+                StorageError::Database(format!("Failed to create KV stats delete fn: {}", e))
+            })?;
 
         let trigger_insert = format!("eq_{}_kv_stats_insert_trg", self.prefix);
         let trigger_delete = format!("eq_{}_kv_stats_delete_trg", self.prefix);
@@ -196,9 +202,12 @@ impl PostgresKVStorage {
             table = self.table_name,
             fn_insert = fn_insert
         );
-        sqlx::query(&create_insert_trg).execute(pool).await.map_err(|e| {
-            StorageError::Database(format!("Failed to create KV stats insert trigger: {}", e))
-        })?;
+        sqlx::query(&create_insert_trg)
+            .execute(pool)
+            .await
+            .map_err(|e| {
+                StorageError::Database(format!("Failed to create KV stats insert trigger: {}", e))
+            })?;
 
         let drop_delete = format!(
             "DROP TRIGGER IF EXISTS {trigger_delete} ON {table}",
@@ -217,9 +226,12 @@ impl PostgresKVStorage {
             table = self.table_name,
             fn_delete = fn_delete
         );
-        sqlx::query(&create_delete_trg).execute(pool).await.map_err(|e| {
-            StorageError::Database(format!("Failed to create KV stats delete trigger: {}", e))
-        })?;
+        sqlx::query(&create_delete_trg)
+            .execute(pool)
+            .await
+            .map_err(|e| {
+                StorageError::Database(format!("Failed to create KV stats delete trigger: {}", e))
+            })?;
 
         Ok(())
     }
@@ -314,8 +326,7 @@ impl KVStorage for PostgresKVStorage {
 
         for chunk in data.chunks(BATCH_SIZE) {
             let keys: Vec<String> = chunk.iter().map(|(k, _)| k.clone()).collect();
-            let values: Vec<serde_json::Value> =
-                chunk.iter().map(|(_, v)| v.clone()).collect();
+            let values: Vec<serde_json::Value> = chunk.iter().map(|(_, v)| v.clone()).collect();
 
             let sql = format!(
                 r#"

--- a/edgequake/crates/edgequake-storage/src/adapters/postgres/kv.rs
+++ b/edgequake/crates/edgequake-storage/src/adapters/postgres/kv.rs
@@ -41,6 +41,7 @@ use crate::traits::KVStorage;
 pub struct PostgresKVStorage {
     pool: PostgresPool,
     table_name: String,
+    stats_table_name: String,
     namespace: String,
     prefix: String,
 }
@@ -48,13 +49,20 @@ pub struct PostgresKVStorage {
 impl PostgresKVStorage {
     /// Create a new PostgreSQL key-value storage.
     pub fn new(config: PostgresConfig) -> Self {
+        Self::with_pool(PostgresPool::new(config.clone()), config)
+    }
+
+    /// Create KV storage using a shared connection pool (SPEC-011).
+    pub fn with_pool(pool: PostgresPool, config: PostgresConfig) -> Self {
         let prefix = config.table_prefix();
         let table_name = format!("public.eq_{}_kv", prefix);
+        let stats_table_name = format!("public.eq_{}_kv_stats", prefix);
         let namespace = config.namespace.clone();
 
         Self {
-            pool: PostgresPool::new(config),
+            pool,
             table_name,
+            stats_table_name,
             namespace,
             prefix,
         }
@@ -94,6 +102,134 @@ impl PostgresKVStorage {
 
         sqlx::query(&gin_sql).execute(&pool).await.ok();
 
+        self.ensure_row_count_stats(&pool).await?;
+
+        Ok(())
+    }
+
+    /// O(1) row counter for `count()` — avoids `SELECT COUNT(*) FROM kv` full-table scans.
+    ///
+    /// SPEC-011: Production incident — 13s `COUNT(*)` on `eq_eq_default_kv` during health
+    /// probes. Maintained counter + triggers keep exact counts at O(1) when `count()` is
+    /// called from tests or admin tools.
+    async fn ensure_row_count_stats(&self, pool: &sqlx::PgPool) -> Result<()> {
+        let stats_sql = format!(
+            r#"
+            CREATE TABLE IF NOT EXISTS {} (
+                id SMALLINT PRIMARY KEY DEFAULT 1 CHECK (id = 1),
+                row_count BIGINT NOT NULL DEFAULT 0
+            )
+            "#,
+            self.stats_table_name
+        );
+        sqlx::query(&stats_sql).execute(pool).await.map_err(|e| {
+            StorageError::Database(format!("Failed to create KV stats table: {}", e))
+        })?;
+
+        // One-time backfill for existing tables (runs COUNT(*) once at migration).
+        let backfill_sql = format!(
+            r#"
+            INSERT INTO {} (id, row_count)
+            SELECT 1, COUNT(*)::bigint FROM {}
+            ON CONFLICT (id) DO NOTHING
+            "#,
+            self.stats_table_name, self.table_name
+        );
+        sqlx::query(&backfill_sql).execute(pool).await.ok();
+
+        let fn_insert = format!("eq_{}_kv_stats_insert", self.prefix);
+        let fn_delete = format!("eq_{}_kv_stats_delete", self.prefix);
+
+        let create_insert_fn = format!(
+            r#"
+            CREATE OR REPLACE FUNCTION {fn_insert}() RETURNS trigger AS $$
+            BEGIN
+                UPDATE {stats}
+                SET row_count = row_count + 1
+                WHERE id = 1;
+                RETURN NEW;
+            END;
+            $$ LANGUAGE plpgsql
+            "#,
+            fn_insert = fn_insert,
+            stats = self.stats_table_name
+        );
+        sqlx::query(&create_insert_fn).execute(pool).await.map_err(|e| {
+            StorageError::Database(format!("Failed to create KV stats insert fn: {}", e))
+        })?;
+
+        let create_delete_fn = format!(
+            r#"
+            CREATE OR REPLACE FUNCTION {fn_delete}() RETURNS trigger AS $$
+            BEGIN
+                UPDATE {stats}
+                SET row_count = GREATEST(row_count - 1, 0)
+                WHERE id = 1;
+                RETURN OLD;
+            END;
+            $$ LANGUAGE plpgsql
+            "#,
+            fn_delete = fn_delete,
+            stats = self.stats_table_name
+        );
+        sqlx::query(&create_delete_fn).execute(pool).await.map_err(|e| {
+            StorageError::Database(format!("Failed to create KV stats delete fn: {}", e))
+        })?;
+
+        let trigger_insert = format!("eq_{}_kv_stats_insert_trg", self.prefix);
+        let trigger_delete = format!("eq_{}_kv_stats_delete_trg", self.prefix);
+
+        let drop_insert = format!(
+            "DROP TRIGGER IF EXISTS {trigger_insert} ON {table}",
+            trigger_insert = trigger_insert,
+            table = self.table_name
+        );
+        sqlx::query(&drop_insert).execute(pool).await.ok();
+
+        let create_insert_trg = format!(
+            r#"
+            CREATE TRIGGER {trigger_insert}
+            AFTER INSERT ON {table}
+            FOR EACH ROW EXECUTE FUNCTION {fn_insert}()
+            "#,
+            trigger_insert = trigger_insert,
+            table = self.table_name,
+            fn_insert = fn_insert
+        );
+        sqlx::query(&create_insert_trg).execute(pool).await.map_err(|e| {
+            StorageError::Database(format!("Failed to create KV stats insert trigger: {}", e))
+        })?;
+
+        let drop_delete = format!(
+            "DROP TRIGGER IF EXISTS {trigger_delete} ON {table}",
+            trigger_delete = trigger_delete,
+            table = self.table_name
+        );
+        sqlx::query(&drop_delete).execute(pool).await.ok();
+
+        let create_delete_trg = format!(
+            r#"
+            CREATE TRIGGER {trigger_delete}
+            AFTER DELETE ON {table}
+            FOR EACH ROW EXECUTE FUNCTION {fn_delete}()
+            "#,
+            trigger_delete = trigger_delete,
+            table = self.table_name,
+            fn_delete = fn_delete
+        );
+        sqlx::query(&create_delete_trg).execute(pool).await.map_err(|e| {
+            StorageError::Database(format!("Failed to create KV stats delete trigger: {}", e))
+        })?;
+
+        Ok(())
+    }
+
+    async fn reset_row_count_stats(&self, pool: &sqlx::PgPool) -> Result<()> {
+        let sql = format!(
+            "UPDATE {} SET row_count = 0 WHERE id = 1",
+            self.stats_table_name
+        );
+        sqlx::query(&sql).execute(pool).await.ok();
         Ok(())
     }
 }
@@ -174,12 +310,18 @@ impl KVStorage for PostgresKVStorage {
         }
 
         let pool = self.pool.get().await?;
+        const BATCH_SIZE: usize = 1000;
 
-        for (key, value) in data {
+        for chunk in data.chunks(BATCH_SIZE) {
+            let keys: Vec<String> = chunk.iter().map(|(k, _)| k.clone()).collect();
+            let values: Vec<serde_json::Value> =
+                chunk.iter().map(|(_, v)| v.clone()).collect();
+
             let sql = format!(
                 r#"
                 INSERT INTO {} (key, value, updated_at)
-                VALUES ($1, $2, NOW())
+                SELECT k, v, NOW()
+                FROM unnest($1::text[], $2::jsonb[]) AS batch(k, v)
                 ON CONFLICT (key) DO UPDATE SET
                     value = EXCLUDED.value,
                     updated_at = NOW()
@@ -188,8 +330,8 @@ impl KVStorage for PostgresKVStorage {
             );
 
             sqlx::query(&sql)
-                .bind(key)
-                .bind(value)
+                .bind(&keys)
+                .bind(&values)
                 .execute(&pool)
                 .await
                 .map_err(|e| StorageError::Database(format!("KV upsert failed: {}", e)))?;
@@ -217,21 +359,88 @@ impl KVStorage for PostgresKVStorage {
     }
 
     async fn is_empty(&self) -> Result<bool> {
-        let count = self.count().await?;
-        Ok(count == 0)
+        let pool = self.pool.get().await?;
+
+        let sql = format!(
+            "SELECT NOT EXISTS (SELECT 1 FROM {} LIMIT 1) AS is_empty",
+            self.table_name
+        );
+
+        let row: (bool,) = sqlx::query_as(&sql)
+            .fetch_one(&pool)
+            .await
+            .map_err(|e| StorageError::Database(format!("KV is_empty failed: {}", e)))?;
+
+        Ok(row.0)
     }
 
     async fn count(&self) -> Result<usize> {
         let pool = self.pool.get().await?;
 
-        let sql = format!("SELECT COUNT(*) as count FROM {}", self.table_name);
+        // O(1): read maintained counter — never `SELECT COUNT(*) FROM kv` (SPEC-011).
+        let sql = format!(
+            "SELECT row_count FROM {} WHERE id = 1",
+            self.stats_table_name
+        );
 
-        let row: (i64,) = sqlx::query_as(&sql)
-            .fetch_one(&pool)
+        let row: Option<(i64,)> = sqlx::query_as(&sql)
+            .fetch_optional(&pool)
             .await
             .map_err(|e| StorageError::Database(format!("KV count failed: {}", e)))?;
 
+        if let Some((count,)) = row {
+            return Ok(count as usize);
+        }
+
+        // Fallback if stats table missing (should not happen after initialize).
+        let fallback = format!("SELECT COUNT(*) as count FROM {}", self.table_name);
+        let row: (i64,) = sqlx::query_as(&fallback)
+            .fetch_one(&pool)
+            .await
+            .map_err(|e| StorageError::Database(format!("KV count fallback failed: {}", e)))?;
         Ok(row.0 as usize)
+    }
+
+    async fn ping(&self) -> Result<()> {
+        let pool = self.pool.get().await?;
+
+        let sql = format!("SELECT 1 FROM {} LIMIT 1", self.table_name);
+
+        sqlx::query(&sql)
+            .fetch_optional(&pool)
+            .await
+            .map_err(|e| StorageError::Database(format!("KV ping failed: {}", e)))?;
+
+        Ok(())
+    }
+
+    async fn keys_like(&self, pattern: &str) -> Result<Vec<String>> {
+        let pool = self.pool.get().await?;
+
+        let sql = format!("SELECT key FROM {} WHERE key LIKE $1", self.table_name);
+
+        let rows: Vec<(String,)> = sqlx::query_as(&sql)
+            .bind(pattern)
+            .fetch_all(&pool)
+            .await
+            .map_err(|e| StorageError::Database(format!("KV keys_like failed: {}", e)))?;
+
+        Ok(rows.into_iter().map(|(k,)| k).collect())
+    }
+
+    async fn keys_with_prefix(&self, prefix: &str) -> Result<Vec<String>> {
+        let pool = self.pool.get().await?;
+        let like_pattern = format!("{prefix}%");
+
+        let sql = format!("SELECT key FROM {} WHERE key LIKE $1", self.table_name);
+
+        let rows: Vec<(String,)> = sqlx::query_as(&sql)
+            .bind(&like_pattern)
+            .fetch_all(&pool)
+            .await
+            .map_err(|e| StorageError::Database(format!("KV keys_with_prefix failed: {}", e)))?;
+
+        Ok(rows.into_iter().map(|(k,)| k).collect())
     }
 
     async fn keys(&self) -> Result<Vec<String>> {
@@ -250,12 +459,15 @@ impl KVStorage for PostgresKVStorage {
     async fn clear(&self) -> Result<()> {
         let pool = self.pool.get().await?;
 
-        let sql = format!("DELETE FROM {}", self.table_name);
+        // TRUNCATE is faster than DELETE; row triggers don't fire — reset stats explicitly.
+        let sql = format!("TRUNCATE {}", self.table_name);
 
         sqlx::query(&sql)
             .execute(&pool)
             .await
             .map_err(|e| StorageError::Database(format!("KV clear failed: {}", e)))?;
+
+        self.reset_row_count_stats(&pool).await?;
 
         Ok(())
     }

--- a/edgequake/crates/edgequake-storage/src/adapters/postgres/vector.rs
+++ b/edgequake/crates/edgequake-storage/src/adapters/postgres/vector.rs
@@ -49,17 +49,21 @@ pub struct PgVectorStorage {
 impl PgVectorStorage {
     /// Create a new pgvector storage.
     pub fn new(config: PostgresConfig) -> Self {
+        Self::with_pool(PostgresPool::new(config.clone()), config, 1536)
+    }
+
+    /// Create pgvector storage with a shared connection pool (SPEC-011).
+    pub fn with_pool(pool: PostgresPool, config: PostgresConfig, dimension: usize) -> Self {
         let prefix = config.table_prefix();
         let table_name = format!("public.eq_{}_vectors", prefix);
         let namespace = config.namespace.clone();
-        let dimension = 1536; // Default OpenAI embedding dimension
         let index_type = config.vector_index_type;
         let ivfflat_lists = config.ivfflat_lists;
         let hnsw_m = config.hnsw_m;
         let hnsw_ef_construction = config.hnsw_ef_construction;
 
         Self {
-            pool: PostgresPool::new(config),
+            pool,
             table_name,
             namespace,
             dimension,
@@ -73,9 +77,16 @@ impl PgVectorStorage {
 
     /// Create a new pgvector storage with a specific dimension.
     pub fn with_dimension(config: PostgresConfig, dimension: usize) -> Self {
-        let mut storage = Self::new(config);
-        storage.dimension = dimension;
-        storage
+        Self::with_pool(PostgresPool::new(config.clone()), config, dimension)
+    }
+
+    /// Create pgvector storage with shared pool and explicit dimension (SPEC-011).
+    pub fn with_pool_and_dimension(
+        pool: PostgresPool,
+        config: PostgresConfig,
+        dimension: usize,
+    ) -> Self {
+        Self::with_pool(pool, config, dimension)
     }
 
     /// Create the vectors table.
@@ -650,8 +661,19 @@ impl VectorStorage for PgVectorStorage {
     }
 
     async fn is_empty(&self) -> Result<bool> {
-        let count = self.count().await?;
-        Ok(count == 0)
+        let pool = self.pool.get().await?;
+
+        let sql = format!(
+            "SELECT NOT EXISTS (SELECT 1 FROM {} LIMIT 1) AS is_empty",
+            self.table_name
+        );
+
+        let row: (bool,) = sqlx::query_as(&sql)
+            .fetch_one(&pool)
+            .await
+            .map_err(|e| StorageError::Database(format!("is_empty failed: {}", e)))?;
+
+        Ok(row.0)
     }
 
     async fn count(&self) -> Result<usize> {
@@ -665,6 +687,19 @@ impl VectorStorage for PgVectorStorage {
             .map_err(|e| StorageError::Database(format!("Count failed: {}", e)))?;
 
         Ok(row.0 as usize)
+    }
+
+    async fn ping(&self) -> Result<()> {
+        let pool = self.pool.get().await?;
+
+        let sql = format!("SELECT 1 FROM {} LIMIT 1", self.table_name);
+
+        sqlx::query(&sql)
+            .fetch_optional(&pool)
+            .await
+            .map_err(|e| StorageError::Database(format!("Vector ping failed: {}", e)))?;
+
+        Ok(())
     }
 
     async fn clear(&self) -> Result<()> {

--- a/edgequake/crates/edgequake-storage/src/lib.rs
+++ b/edgequake/crates/edgequake-storage/src/lib.rs
@@ -75,8 +75,9 @@ pub use pdf_storage::{
 // Re-export traits
 pub use error::StorageError;
 pub use traits::{
-    GraphEdge, GraphNode, GraphStorage, KVStorage, KnowledgeGraph, MetadataFilter,
-    VectorSearchResult, VectorStorage, WorkspaceVectorConfig, WorkspaceVectorRegistry,
+    kv_key_matches_like, GraphEdge, GraphNode, GraphStorage, KVStorage, KnowledgeGraph,
+    MetadataFilter, VectorSearchResult, VectorStorage, WorkspaceVectorConfig,
+    WorkspaceVectorRegistry,
 };
 
 // Re-export adapters

--- a/edgequake/crates/edgequake-storage/src/traits/graph.rs
+++ b/edgequake/crates/edgequake-storage/src/traits/graph.rs
@@ -562,6 +562,12 @@ pub trait GraphStorage: Send + Sync {
     /// Get edge count.
     async fn edge_count(&self) -> Result<usize>;
 
+    /// Lightweight connectivity probe — must not count all graph vertices.
+    async fn ping(&self) -> Result<()> {
+        let _ = self.node_count().await?;
+        Ok(())
+    }
+
     /// Get node count for a specific workspace.
     ///
     /// WHY: Dashboard and workspace pages need accurate per-workspace statistics.

--- a/edgequake/crates/edgequake-storage/src/traits/kv.rs
+++ b/edgequake/crates/edgequake-storage/src/traits/kv.rs
@@ -129,7 +129,44 @@ pub trait KVStorage: Send + Sync {
     async fn is_empty(&self) -> Result<bool>;
 
     /// Get the count of records in storage.
+    ///
+    /// # Performance (SPEC-011)
+    ///
+    /// Exact `COUNT(*)` is **O(N)** on PostgreSQL heap tables. Use [`Self::ping`]
+    /// for connectivity checks and [`Self::keys_like`] for filtered enumeration.
     async fn count(&self) -> Result<usize>;
+
+    /// Lightweight connectivity probe — must not scan the full table.
+    ///
+    /// # WHY (SPEC-011)
+    ///
+    /// Health checks previously called `count()`, causing 10+ second sequential
+    /// scans on large KV tables. `ping()` verifies pool + table reachability in O(1).
+    async fn ping(&self) -> Result<()> {
+        let _ = self.count().await?;
+        Ok(())
+    }
+
+    /// Return keys matching a SQL LIKE pattern (e.g. `"%-metadata"`, `"%-chunk-%"`).
+    ///
+    /// Prefer this over [`Self::keys`] when only a key subset is needed.
+    /// **Note (SPEC-011)**: Leading `%` patterns are O(N) in PostgreSQL — see
+    /// [`Self::keys_with_prefix`] for index-friendly prefix scans.
+    async fn keys_like(&self, pattern: &str) -> Result<Vec<String>> {
+        let all = self.keys().await?;
+        Ok(all
+            .into_iter()
+            .filter(|key| kv_key_matches_like(key, pattern))
+            .collect())
+    }
+
+    /// Return keys with the given prefix (index-friendly: `LIKE 'prefix%'`).
+    ///
+    /// Use for document-scoped scans such as `{doc_id}-chunk-`.
+    async fn keys_with_prefix(&self, prefix: &str) -> Result<Vec<String>> {
+        let pattern = format!("{prefix}%");
+        self.keys_like(&pattern).await
+    }
 
     /// Get all keys in storage.
     async fn keys(&self) -> Result<Vec<String>>;
@@ -232,3 +269,31 @@ pub trait KVStorageExt: KVStorage {
 }
 
 impl<T: KVStorage + ?Sized> KVStorageExt for T {}
+
+/// Match a key against a SQL LIKE pattern (supports `%` wildcards only).
+pub fn kv_key_matches_like(key: &str, pattern: &str) -> bool {
+    if let Some(suffix) = pattern.strip_prefix('%').filter(|p| !p.contains('%')) {
+        return key.ends_with(suffix);
+    }
+    if let Some(prefix) = pattern.strip_suffix('%').filter(|p| !p.contains('%')) {
+        return key.starts_with(prefix);
+    }
+    if pattern.starts_with('%') && pattern.ends_with('%') && pattern.len() > 2 {
+        let needle = &pattern[1..pattern.len() - 1];
+        return key.contains(needle);
+    }
+    key == pattern
+}
+
+#[cfg(test)]
+mod kv_like_tests {
+    use super::kv_key_matches_like;
+
+    #[test]
+    fn test_kv_key_matches_like_patterns() {
+        assert!(kv_key_matches_like("abc-metadata", "%-metadata"));
+        assert!(!kv_key_matches_like("abc-content", "%-metadata"));
+        assert!(kv_key_matches_like("doc-chunk-0", "%-chunk-%"));
+        assert!(!kv_key_matches_like("doc-metadata", "%-chunk-%"));
+    }
+}

--- a/edgequake/crates/edgequake-storage/src/traits/mod.rs
+++ b/edgequake/crates/edgequake-storage/src/traits/mod.rs
@@ -28,6 +28,6 @@ mod vector;
 mod workspace_vector;
 
 pub use graph::{GraphEdge, GraphNode, GraphStorage, KnowledgeGraph};
-pub use kv::KVStorage;
+pub use kv::{kv_key_matches_like, KVStorage};
 pub use vector::{MetadataFilter, VectorSearchResult, VectorStorage};
 pub use workspace_vector::{WorkspaceVectorConfig, WorkspaceVectorRegistry};

--- a/edgequake/crates/edgequake-storage/src/traits/vector.rs
+++ b/edgequake/crates/edgequake-storage/src/traits/vector.rs
@@ -297,8 +297,7 @@ mod tests {
         // WHY: Unlike from_tenant_workspace which returns None when both IDs are None,
         // from_tenant_workspace_type ALWAYS returns Some because the type filter alone
         // is meaningful (e.g. filter to "chunk" globally across all tenants).
-        let mf =
-            MetadataFilter::from_tenant_workspace_type(None, None, "chunk").unwrap();
+        let mf = MetadataFilter::from_tenant_workspace_type(None, None, "chunk").unwrap();
         assert_eq!(mf.vector_type.as_deref(), Some("chunk"));
         assert!(mf.tenant_id.is_none());
         assert!(mf.workspace_id.is_none());

--- a/edgequake/crates/edgequake-storage/src/traits/vector.rs
+++ b/edgequake/crates/edgequake-storage/src/traits/vector.rs
@@ -178,7 +178,17 @@ pub trait VectorStorage: Send + Sync {
     async fn is_empty(&self) -> Result<bool>;
 
     /// Get count of stored vectors.
+    ///
+    /// # Performance (SPEC-011)
+    ///
+    /// Exact `COUNT(*)` is O(N). Use [`Self::ping`] for connectivity checks.
     async fn count(&self) -> Result<usize>;
+
+    /// Lightweight connectivity probe — must not scan the full vector table.
+    async fn ping(&self) -> Result<()> {
+        let _ = self.count().await?;
+        Ok(())
+    }
 
     /// Clear all vectors.
     async fn clear(&self) -> Result<()>;

--- a/edgequake/crates/edgequake-storage/tests/graph_optimized_tests.rs
+++ b/edgequake/crates/edgequake-storage/tests/graph_optimized_tests.rs
@@ -430,10 +430,7 @@ async fn test_get_nodes_with_degrees_batch_basic() {
 
     // Query subset of nodes — A (out=4,in=0), B (out=2,in=1), E (out=0,in=1)
     let ids = vec!["A".to_string(), "B".to_string(), "E".to_string()];
-    let results = storage
-        .get_nodes_with_degrees_batch(&ids)
-        .await
-        .unwrap();
+    let results = storage.get_nodes_with_degrees_batch(&ids).await.unwrap();
 
     assert_eq!(results.len(), 3, "Should return exactly the queried nodes");
 
@@ -452,7 +449,10 @@ async fn test_get_nodes_with_degrees_batch_basic() {
     assert!(a_in + a_out > 0, "Node A should have connections");
 
     let (e_in, e_out) = map["E"];
-    assert!(e_in + e_out > 0, "Node E should have at least one connection");
+    assert!(
+        e_in + e_out > 0,
+        "Node E should have at least one connection"
+    );
 }
 
 /// Verify that an empty input returns an empty result without panicking.
@@ -461,10 +461,7 @@ async fn test_get_nodes_with_degrees_batch_empty_input() {
     let storage = MemoryGraphStorage::new("test");
     storage.initialize().await.unwrap();
 
-    let results = storage
-        .get_nodes_with_degrees_batch(&[])
-        .await
-        .unwrap();
+    let results = storage.get_nodes_with_degrees_batch(&[]).await.unwrap();
 
     assert!(results.is_empty(), "Empty input must produce empty output");
 }
@@ -480,10 +477,7 @@ async fn test_get_nodes_with_degrees_batch_nonexistent_nodes() {
         "DOES_NOT_EXIST_1".to_string(),
         "DOES_NOT_EXIST_2".to_string(),
     ];
-    let results = storage
-        .get_nodes_with_degrees_batch(&ids)
-        .await
-        .unwrap();
+    let results = storage.get_nodes_with_degrees_batch(&ids).await.unwrap();
 
     assert!(
         results.is_empty(),
@@ -498,15 +492,8 @@ async fn test_get_nodes_with_degrees_batch_mixed_ids() {
     storage.initialize().await.unwrap();
     setup_test_graph(&storage).await;
 
-    let ids = vec![
-        "A".to_string(),
-        "NONEXISTENT".to_string(),
-        "C".to_string(),
-    ];
-    let results = storage
-        .get_nodes_with_degrees_batch(&ids)
-        .await
-        .unwrap();
+    let ids = vec!["A".to_string(), "NONEXISTENT".to_string(), "C".to_string()];
+    let results = storage.get_nodes_with_degrees_batch(&ids).await.unwrap();
 
     let found_ids: Vec<_> = results.iter().map(|(n, _, _)| n.id.as_str()).collect();
     assert!(
@@ -542,10 +529,7 @@ async fn test_get_nodes_with_degrees_batch_consistent_with_degrees_batch() {
         .into_iter()
         .collect::<std::collections::HashMap<_, _>>();
 
-    let with_nodes = storage
-        .get_nodes_with_degrees_batch(&ids)
-        .await
-        .unwrap();
+    let with_nodes = storage.get_nodes_with_degrees_batch(&ids).await.unwrap();
 
     // Every node returned by node_degrees_batch with degree > 0 should also appear
     // in get_nodes_with_degrees_batch with a non-zero in_deg or out_deg.
@@ -574,17 +558,10 @@ async fn test_get_nodes_with_degrees_batch_isolated_node() {
     storage.upsert_node("ISOLATED", props).await.unwrap();
 
     let ids = vec!["ISOLATED".to_string()];
-    let results = storage
-        .get_nodes_with_degrees_batch(&ids)
-        .await
-        .unwrap();
+    let results = storage.get_nodes_with_degrees_batch(&ids).await.unwrap();
 
     assert_eq!(results.len(), 1);
     let (node, in_deg, out_deg) = &results[0];
     assert_eq!(node.id, "ISOLATED");
-    assert_eq!(
-        *in_deg + *out_deg,
-        0,
-        "Isolated node must have degree 0"
-    );
+    assert_eq!(*in_deg + *out_deg, 0, "Isolated node must have degree 0");
 }

--- a/edgequake/crates/edgequake-storage/tests/performance_storage.rs
+++ b/edgequake/crates/edgequake-storage/tests/performance_storage.rs
@@ -129,10 +129,7 @@ async fn test_keys_with_prefix_subset() {
     storage.initialize().await.unwrap();
     populate_kv(&storage).await;
 
-    let keys = storage
-        .keys_with_prefix("doc-00001-chunk-")
-        .await
-        .unwrap();
+    let keys = storage.keys_with_prefix("doc-00001-chunk-").await.unwrap();
     assert_eq!(keys.len(), CHUNKS_PER_DOC);
     for key in keys {
         assert!(key.starts_with("doc-00001-chunk-"));
@@ -199,7 +196,10 @@ mod postgres_perf {
             count_time
         );
 
-        storage.delete(&["stats-row-0-metadata".to_string()]).await.unwrap();
+        storage
+            .delete(&["stats-row-0-metadata".to_string()])
+            .await
+            .unwrap();
         assert_eq!(storage.count().await.unwrap(), 4999);
 
         eprintln!(
@@ -220,10 +220,7 @@ mod postgres_perf {
 
         let mut batch = Vec::new();
         for i in 0..2000 {
-            batch.push((
-                format!("row-{i}-metadata"),
-                serde_json::json!({"i": i}),
-            ));
+            batch.push((format!("row-{i}-metadata"), serde_json::json!({"i": i})));
         }
         storage.upsert(&batch).await.unwrap();
 

--- a/edgequake/crates/edgequake-storage/tests/performance_storage.rs
+++ b/edgequake/crates/edgequake-storage/tests/performance_storage.rs
@@ -1,0 +1,252 @@
+//! SPEC-011: Storage performance regression tests.
+//!
+//! Validates O(1) probes (ping, is_empty) and keys_like filtering semantics
+//! without requiring PostgreSQL (memory backend). PostgreSQL benchmarks run
+//! when DATABASE_URL is set.
+
+use edgequake_storage::adapters::memory::MemoryKVStorage;
+use edgequake_storage::traits::{kv_key_matches_like, KVStorage};
+use std::time::{Duration, Instant};
+
+const DOC_COUNT: usize = 500;
+const CHUNKS_PER_DOC: usize = 20;
+
+async fn populate_kv(storage: &MemoryKVStorage) -> usize {
+    let mut batch = Vec::with_capacity(DOC_COUNT * (CHUNKS_PER_DOC + 1));
+    for i in 0..DOC_COUNT {
+        let doc_id = format!("doc-{i:05}");
+        batch.push((
+            format!("{doc_id}-metadata"),
+            serde_json::json!({"id": doc_id, "status": "completed"}),
+        ));
+        for c in 0..CHUNKS_PER_DOC {
+            batch.push((
+                format!("{doc_id}-chunk-{c}"),
+                serde_json::json!({"text": "chunk content", "index": c}),
+            ));
+        }
+    }
+    storage.upsert(&batch).await.unwrap();
+    batch.len()
+}
+
+#[tokio::test]
+async fn test_count_remains_exact_after_bulk_load() {
+    let storage = MemoryKVStorage::new("perf_count");
+    storage.initialize().await.unwrap();
+    let expected = populate_kv(&storage).await;
+    assert_eq!(storage.count().await.unwrap(), expected);
+}
+
+#[tokio::test]
+async fn test_is_empty_is_fast_and_correct() {
+    let storage = MemoryKVStorage::new("perf_empty");
+    storage.initialize().await.unwrap();
+    assert!(storage.is_empty().await.unwrap());
+
+    populate_kv(&storage).await;
+    assert!(!storage.is_empty().await.unwrap());
+
+    let start = Instant::now();
+    for _ in 0..100 {
+        let _ = storage.is_empty().await.unwrap();
+    }
+    assert!(
+        start.elapsed() < Duration::from_millis(50),
+        "is_empty should be O(1) in memory: {:?}",
+        start.elapsed()
+    );
+}
+
+#[tokio::test]
+async fn test_ping_does_not_require_full_count_scan() {
+    let storage = MemoryKVStorage::new("perf_ping");
+    storage.initialize().await.unwrap();
+    populate_kv(&storage).await;
+
+    let start = Instant::now();
+    for _ in 0..100 {
+        storage.ping().await.unwrap();
+    }
+    assert!(
+        start.elapsed() < Duration::from_millis(100),
+        "ping loop took {:?}",
+        start.elapsed()
+    );
+}
+
+#[tokio::test]
+async fn test_keys_like_matches_subset_of_keys() {
+    let storage = MemoryKVStorage::new("perf_like");
+    storage.initialize().await.unwrap();
+    populate_kv(&storage).await;
+
+    let all_keys = storage.keys().await.unwrap();
+    let metadata_keys = storage.keys_like("%-metadata").await.unwrap();
+    let chunk_keys = storage.keys_like("%-chunk-%").await.unwrap();
+
+    assert_eq!(metadata_keys.len(), DOC_COUNT);
+    assert_eq!(chunk_keys.len(), DOC_COUNT * CHUNKS_PER_DOC);
+    assert_eq!(metadata_keys.len() + chunk_keys.len(), all_keys.len());
+
+    for key in &metadata_keys {
+        assert!(kv_key_matches_like(key, "%-metadata"));
+    }
+    for key in &chunk_keys {
+        assert!(kv_key_matches_like(key, "%-chunk-%"));
+    }
+}
+
+#[tokio::test]
+async fn test_keys_like_faster_than_full_keys_at_scale() {
+    let storage = MemoryKVStorage::new("perf_like_scale");
+    storage.initialize().await.unwrap();
+    populate_kv(&storage).await;
+
+    let full_start = Instant::now();
+    let all = storage.keys().await.unwrap();
+    let full_time = full_start.elapsed();
+
+    let like_start = Instant::now();
+    let meta = storage.keys_like("%-metadata").await.unwrap();
+    let like_time = like_start.elapsed();
+
+    assert_eq!(meta.len(), DOC_COUNT);
+    assert!(all.len() > meta.len());
+    // Memory backend: keys_like still scans internally but returns smaller vec
+    assert!(meta.len() < all.len());
+    assert!(
+        like_time <= full_time + Duration::from_millis(5),
+        "keys_like should not be slower than keys(): like={:?} full={:?}",
+        like_time,
+        full_time
+    );
+}
+
+#[tokio::test]
+async fn test_keys_with_prefix_subset() {
+    let storage = MemoryKVStorage::new("perf_prefix");
+    storage.initialize().await.unwrap();
+    populate_kv(&storage).await;
+
+    let keys = storage
+        .keys_with_prefix("doc-00001-chunk-")
+        .await
+        .unwrap();
+    assert_eq!(keys.len(), CHUNKS_PER_DOC);
+    for key in keys {
+        assert!(key.starts_with("doc-00001-chunk-"));
+    }
+}
+
+#[cfg(feature = "postgres")]
+mod postgres_perf {
+    use super::*;
+    use edgequake_storage::adapters::postgres::{PostgresConfig, PostgresKVStorage};
+    use std::env;
+    use std::time::Duration;
+
+    fn get_test_config() -> Option<PostgresConfig> {
+        let password = env::var("POSTGRES_PASSWORD").ok()?;
+        Some(PostgresConfig {
+            host: env::var("POSTGRES_HOST").unwrap_or_else(|_| "localhost".to_string()),
+            port: env::var("POSTGRES_PORT")
+                .ok()
+                .and_then(|s| s.parse().ok())
+                .unwrap_or(5432),
+            database: env::var("POSTGRES_DB").unwrap_or_else(|_| "edgequake".to_string()),
+            user: env::var("POSTGRES_USER").unwrap_or_else(|_| "edgequake".to_string()),
+            password,
+            namespace: format!(
+                "perf_{}",
+                &uuid::Uuid::new_v4().to_string().replace('-', "")[..8]
+            ),
+            max_connections: 5,
+            min_connections: 1,
+            connect_timeout: Duration::from_secs(10),
+            idle_timeout: Duration::from_secs(60),
+            ..Default::default()
+        })
+    }
+
+    #[tokio::test]
+    async fn test_postgres_kv_count_is_o1_via_stats_table() {
+        let Some(config) = get_test_config() else {
+            eprintln!("SKIP: POSTGRES_PASSWORD not set");
+            return;
+        };
+
+        let storage = PostgresKVStorage::new(config);
+        storage.initialize().await.unwrap();
+
+        let mut batch = Vec::new();
+        for i in 0..5000 {
+            batch.push((
+                format!("stats-row-{i}-metadata"),
+                serde_json::json!({"i": i}),
+            ));
+        }
+        storage.upsert(&batch).await.unwrap();
+
+        let count_start = Instant::now();
+        let count = storage.count().await.unwrap();
+        let count_time = count_start.elapsed();
+
+        assert_eq!(count, 5000);
+        assert!(
+            count_time.as_millis() < 50,
+            "KV count() must be O(1) via stats table, took {:?}",
+            count_time
+        );
+
+        storage.delete(&["stats-row-0-metadata".to_string()]).await.unwrap();
+        assert_eq!(storage.count().await.unwrap(), 4999);
+
+        eprintln!(
+            "postgres kv count: {:?} for 5000 rows (stats table, not COUNT(*))",
+            count_time
+        );
+    }
+
+    #[tokio::test]
+    async fn test_postgres_ping_faster_than_count_on_large_table() {
+        let Some(config) = get_test_config() else {
+            eprintln!("SKIP: POSTGRES_PASSWORD not set");
+            return;
+        };
+
+        let storage = PostgresKVStorage::new(config);
+        storage.initialize().await.unwrap();
+
+        let mut batch = Vec::new();
+        for i in 0..2000 {
+            batch.push((
+                format!("row-{i}-metadata"),
+                serde_json::json!({"i": i}),
+            ));
+        }
+        storage.upsert(&batch).await.unwrap();
+
+        let count_start = Instant::now();
+        let count = storage.count().await.unwrap();
+        let count_time = count_start.elapsed();
+
+        let ping_start = Instant::now();
+        storage.ping().await.unwrap();
+        let ping_time = ping_start.elapsed();
+
+        assert_eq!(count, 2000);
+        assert!(
+            ping_time < count_time,
+            "ping ({:?}) should beat count ({:?}) on 2000 rows",
+            ping_time,
+            count_time
+        );
+        eprintln!(
+            "postgres perf: count={:?} ping={:?} speedup={:.1}x",
+            count_time,
+            ping_time,
+            count_time.as_secs_f64() / ping_time.as_secs_f64().max(1e-9)
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Replace `/health` `count()` probes with O(1) `ping()` — root cause of 13.753s `SELECT COUNT(*) FROM eq_eq_default_kv` under polling load
- Add `{prefix}_kv_stats` maintained row counter so `count()` reads `row_count` instead of full-table `COUNT(*)`
- Batch KV upserts via `unnest`, share one PostgreSQL pool across KV/vector/graph adapters
- Add `keys_like` / `keys_with_prefix` and migrate hot-path handlers off full `keys()` scans
- Add E2E SLO tests + source regression guard (`test_health_handler_never_calls_kv_count`)

## Test plan

- [x] `cargo test -p edgequake-storage --lib --features postgres` — 89 passed
- [x] `cargo test -p edgequake-storage --test performance_storage --features postgres` — 8 passed (incl. O(1) count @ 5000 rows)
- [x] `cargo test -p edgequake-storage --test e2e_storage_backends` — 35 passed
- [x] `cargo test -p edgequake-storage --test postgres_integration --features postgres` — 19 passed
- [x] `cargo test -p edgequake-api --test e2e_storage_performance_spec011` — 8 passed
- [x] `cargo test -p edgequake-api --test e2e_dashboard_stats_issue81` — 14 passed
- [x] `cargo test -p edgequake-api --lib health` — 10 passed
- [x] `cargo clippy -p edgequake-storage -p edgequake-api --features postgres -- -D warnings` — clean

## Notes

Spec docs live under `specs/11-performance-issue/` (gitignored locally). See commit message for behavior summary.


Made with [Cursor](https://cursor.com)