### PR TITLE
fix(providers): route LLM and embedding to different OpenAI-compatible endpoints

### DIFF
--- a/docker-compose.quickstart.yml
+++ b/docker-compose.quickstart.yml
@@ -70,6 +70,22 @@ services:
       # Optional model override — when unset the API picks a sensible default
       # (e.g. text-embedding-3-small for OpenAI, embeddinggemma for Ollama).
       EDGEQUAKE_EMBEDDING_MODEL:    ${EDGEQUAKE_EMBEDDING_MODEL:-}
+      # Embedding vector dimension — must match the chosen model. Required when
+      # the OpenAI-compat provider points at a non-OpenAI backend (e.g. Infinity
+      # serving BAAI/bge-base-en-v1.5 at 768d), otherwise the API defaults to
+      # OpenAI's 1536 and DB writes will fail with a dimension mismatch.
+      EDGEQUAKE_EMBEDDING_DIMENSION: ${EDGEQUAKE_EMBEDDING_DIMENSION:-}
+      # Per-role OpenAI-compat overrides. Take precedence over global OPENAI_BASE_URL
+      # / OPENAI_API_KEY. Enables routing LLM and embedding to different
+      # OpenAI-compatible endpoints (e.g. RunPod vLLM for LLM, RunPod Infinity
+      # for embedding) without colliding on a single global base URL.
+      EDGEQUAKE_CHAT_BASE_URL:       ${EDGEQUAKE_CHAT_BASE_URL:-}
+      EDGEQUAKE_CHAT_API_KEY:        ${EDGEQUAKE_CHAT_API_KEY:-}
+      EDGEQUAKE_EMBEDDING_BASE_URL:  ${EDGEQUAKE_EMBEDDING_BASE_URL:-}
+      EDGEQUAKE_EMBEDDING_API_KEY:   ${EDGEQUAKE_EMBEDDING_API_KEY:-}
+      # Cap requested max_tokens below vLLM MAX_MODEL_LEN to avoid instant 500s
+      # when the safety wrapper sends its default 16384.
+      EDGEQUAKE_LLM_MAX_TOKENS:      ${EDGEQUAKE_LLM_MAX_TOKENS:-}
       # ── Vision LLM Provider (PDF → Markdown) ────────────────────────────────
       # Used exclusively for rendering PDF pages into Markdown (multimodal LLM).
       # Default: same provider as EDGEQUAKE_LLM_PROVIDER (set by quickstart.sh).
@@ -96,6 +112,8 @@ services:
       ANTHROPIC_API_KEY:            ${ANTHROPIC_API_KEY:-}
       GEMINI_API_KEY:               ${GEMINI_API_KEY:-}
       MISTRAL_API_KEY:              ${MISTRAL_API_KEY:-}
+      OPENROUTER_API_KEY:           ${OPENROUTER_API_KEY:-}
+      OPENROUTER_MODEL:             ${OPENROUTER_MODEL:-}
       # WHY host.docker.internal (NOT localhost):
       #   Docker containers have their own network namespace. 'localhost' inside
       #   a container refers to the container itself, NOT to the host where Ollama

--- a/edgequake/crates/edgequake-api/src/safety_limits.rs
+++ b/edgequake/crates/edgequake-api/src/safety_limits.rs
@@ -701,6 +701,31 @@ pub fn is_model_provider_mismatch(provider_name: &str, model: &str) -> bool {
     }
 
     let provider = provider_name.to_lowercase();
+
+    // FORK-PATCH: when the user has explicitly pointed the openai provider at a
+    // custom OpenAI-compatible endpoint (vLLM, Infinity, LM Studio, etc.) via
+    // EDGEQUAKE_CHAT_BASE_URL or a non-default OPENAI_BASE_URL, model names like
+    // "Qwen/Qwen2.5-7B-Instruct" or "BAAI/bge-base-en-v1.5" are valid for that
+    // endpoint even though they don't match OpenAI's catalog. Trust the user's
+    // explicit configuration and skip the mismatch check.
+    if matches!(
+        provider.as_str(),
+        "openai" | "openai-compatible" | "openai_compatible"
+    ) {
+        let has_custom_base = std::env::var("EDGEQUAKE_CHAT_BASE_URL")
+            .map(|v| !v.trim().is_empty())
+            .unwrap_or(false)
+            || std::env::var("OPENAI_BASE_URL")
+                .map(|v| {
+                    let v = v.trim();
+                    !v.is_empty() && !v.contains("api.openai.com")
+                })
+                .unwrap_or(false);
+        if has_custom_base {
+            return false;
+        }
+    }
+
     let model = model.to_lowercase();
 
     // OpenAI model patterns: gpt-*, o1-*, o3-*, o4-*, text-embedding-*

--- a/edgequake/crates/edgequake-api/src/state/mod.rs
+++ b/edgequake/crates/edgequake-api/src/state/mod.rs
@@ -73,7 +73,10 @@ mod config;
 mod memory;
 #[cfg(feature = "postgres")]
 mod postgres;
-mod provider_setup;
+// FORK-PATCH: expose provider_setup so main.rs can call apply_chat_env_aliases()
+// before constructing AppState (needed to make EDGEQUAKE_CHAT_* env aliases
+// effective for the default OpenAI provider).
+pub mod provider_setup;
 
 pub use config::*;
 

--- a/edgequake/src/main.rs
+++ b/edgequake/src/main.rs
@@ -486,6 +486,13 @@ async fn main() -> Result<()> {
         clear_empty_env_var(var);
     }
 
+    // FORK-PATCH: Apply EDGEQUAKE_CHAT_* env aliases BEFORE reading OPENAI_API_KEY.
+    // Upstream FIX #166 calls apply_chat_env_aliases() inside AppState::new_postgres,
+    // which runs AFTER the api_key capture below — so the captured key is empty
+    // and the default OpenAI provider gets constructed with no credentials,
+    // causing queries that hit the default LLM to silently hang at upstream auth.
+    edgequake_api::state::provider_setup::apply_chat_env_aliases();
+
     // Get API key from environment (optional - Ollama doesn't need it)
     let api_key = std::env::var("OPENAI_API_KEY").unwrap_or_default();
 


### PR DESCRIPTION
## Description

Two related fixes that unblock running EdgeQuake's `openai` provider against arbitrary OpenAI-compatible endpoints (RunPod vLLM, RunPod Infinity, LM Studio, local vLLM, etc.) and against split LLM-vs-embedding deployments.

Both issues only manifest when a user routes the `openai` provider at a *non-OpenAI* base URL. They build directly on the per-role override surface introduced by FIX #163 (embedding base URL) and FIX #166 (`EDGEQUAKE_CHAT_*` env aliases). Those upstream fixes wired in the env vars but two call-site issues prevent them from working end-to-end. Tangentially related to closed #140 / #147 / #168 but those don't cover the specific call-path bugs fixed here.

Fixes # (no single open issue — see "Bugs fixed" below)

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## Bugs fixed

### 1. `safety_limits::is_model_provider_mismatch` rewrites valid non-OpenAI model names

The `COMPAT-GUARD` flagged any model name containing `/` or starting with `qwen`/`llama`/`mistral`/etc. as a mismatch for the `openai` provider, then rewrote it to `gpt-4.1-nano`. That makes sense when the user has `openai` provider with the default `api.openai.com` base URL, but it actively breaks the supported case where `openai` is pointed at a custom endpoint:

```
WARN edgequake_api::safety_limits: COMPAT-GUARD: LLM model/provider mismatch — auto-correcting to provider default.
  provider="openai" requested_model="Qwen/Qwen2.5-7B-Instruct" corrected_model="gpt-4.1-nano"
```

The rewritten model then 404s at the custom endpoint (which has `Qwen/Qwen2.5-7B-Instruct` loaded, not `gpt-4.1-nano`), often with 1s response → instant retry → flooded queue.

**Fix:** when `EDGEQUAKE_CHAT_BASE_URL` is set, *or* `OPENAI_BASE_URL` is set to anything other than `api.openai.com`, skip the mismatch check for `openai` / `openai-compatible` providers. The user has explicitly signaled "I'm using an OpenAI-compatible endpoint with arbitrary model names — trust me."

### 2. `apply_chat_env_aliases()` runs too late to populate the default LLM provider

`apply_chat_env_aliases()` (added by FIX #166) maps `EDGEQUAKE_CHAT_BASE_URL` → `OPENAI_BASE_URL` and `EDGEQUAKE_CHAT_API_KEY` → `OPENAI_API_KEY` when the latter pair is unset. It's currently called from `AppState::new_postgres` (and `new_memory`).

But `main.rs` captures `OPENAI_API_KEY` into a local `api_key` variable **before** `AppState::new_postgres` is invoked:

```rust
// main.rs:485
for var in ["OPENAI_BASE_URL", "OPENAI_API_KEY"] {
    clear_empty_env_var(var);
}

// main.rs:490 — captures empty string when only EDGEQUAKE_CHAT_API_KEY is set
let api_key = std::env::var("OPENAI_API_KEY").unwrap_or_default();

// main.rs:498 — apply_chat_env_aliases runs INSIDE this call,
//               but the api_key above is already empty
let mut state = AppState::new_postgres(&database_url, &api_key).await...
```

Effect: when the user supplies only `EDGEQUAKE_CHAT_API_KEY` (the documented per-role override), the default LLM provider gets constructed with an empty API key. Calls then 401 silently at the upstream and the request times out after `EDGEQUAKE_LLM_TIMEOUT_SECS`. No log line indicates the cause.

**Fix:** call `apply_chat_env_aliases()` in `main.rs` immediately after `clear_empty_env_var()`, so the chat aliases are promoted into `OPENAI_*` before the `api_key` capture.

This required making `crate::state::provider_setup` a `pub mod` (it was a private module — the function `apply_chat_env_aliases` was already `pub`).

### 3. Compose file passthroughs for env vars the binary already recognizes

`docker-compose.quickstart.yml` didn't pass through several env vars that the binary already reads:
- `EDGEQUAKE_EMBEDDING_DIMENSION` — needed when embedding model dimension differs from the OpenAI provider default of 1536 (e.g. `bge-base-en-v1.5` = 768).
- `EDGEQUAKE_CHAT_BASE_URL`, `EDGEQUAKE_CHAT_API_KEY`, `EDGEQUAKE_EMBEDDING_BASE_URL`, `EDGEQUAKE_EMBEDDING_API_KEY` — the per-role overrides from FIX #163 / #166.
- `EDGEQUAKE_LLM_MAX_TOKENS` — exposed by `SafetyLimitsConfig::from_env()`, useful when the upstream endpoint enforces a context length below the default 16384 (e.g. vLLM with `MAX_MODEL_LEN=8192`).
- `OPENROUTER_API_KEY`, `OPENROUTER_MODEL` — the native `openrouter` provider's env vars (previously only `OPENAI_*`, `ANTHROPIC_*`, `GEMINI_*`, `MISTRAL_*` were passed through).

## Reproduction (before this PR)

```bash
# .env
EDGEQUAKE_LLM_PROVIDER=openai
EDGEQUAKE_LLM_MODEL=Qwen/Qwen2.5-7B-Instruct
EDGEQUAKE_CHAT_BASE_URL=https://api.runpod.ai/v2/<vllm-endpoint>/openai/v1
EDGEQUAKE_CHAT_API_KEY=rpa_...

docker compose -f docker-compose.quickstart.yml up -d
curl -X POST http://localhost:8080/api/v1/query -H 'Content-Type: application/json' \
  -H 'X-Tenant-ID: ...' -H 'X-Workspace-ID: ...' \
  -d '{"query":"...","mode":"hybrid","max_results":5}'
```

Result: request hangs until client timeout. API logs show:
```
DEBUG edgequake_query::keywords::llm_extractor: Using default LLM for keyword extraction (no user selection)
```
…with no follow-up. Upstream LLM is `api.openai.com` (because `OPENAI_BASE_URL` was empty), credential is empty, model was rewritten to `gpt-4.1-nano`.

## After this PR

Same `.env`, same request — request completes in a few seconds with the expected RAG answer. Verified end-to-end with:
- LLM: RunPod vLLM `Qwen/Qwen2.5-7B-Instruct` via per-role `EDGEQUAKE_CHAT_BASE_URL`
- Embedding: RunPod Infinity `BAAI/bge-base-en-v1.5` (768d) via per-role `EDGEQUAKE_EMBEDDING_BASE_URL` (this already worked because of FIX #163)
- Same flow also verified with `EDGEQUAKE_LLM_PROVIDER=openrouter` and an OpenRouter key; the patch helps any custom-endpoint provider.

## Checklist

- [x] My code follows the style guidelines of this project (small, focused diff; explicit comments at each FORK-PATCH site explaining the why)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas (each patch site has a comment explaining the bug and the fix)
- [ ] I have made corresponding changes to the documentation — pending direction confirmation; happy to add an "OpenAI-compatible custom endpoints" section under `docs/operations/configuration.md` if the approach is acceptable
- [x] My changes generate no new warnings (visual inspection; I was unable to run `cargo fmt`/`clippy` in this environment — see test notes)
- [ ] I have added tests that prove my fix is effective or that my feature works — pending; would add unit tests in `safety_limits` (mismatch-with-custom-URL) and a small integration test that asserts `OPENAI_API_KEY` is non-empty after `apply_chat_env_aliases` runs in main's startup order. Easier to add once you confirm the approach.
- [x] New and existing tests pass locally with my changes — *not run*; built the patched image with `docker build -f edgequake/docker/Dockerfile -t edgequake:patched edgequake/` and ran functional end-to-end verification against the actual API. I don't have a Rust toolchain set up in this environment.

## Additional context

- Diff is intentionally minimal (54 insertions, 1 deletion across 4 files) to keep review tight.
- Happy to split into two PRs (one per source bug + the compose passthroughs) if that's preferred.
- Happy to back out the docker-compose changes if they belong in a follow-up.
- If you'd like me to write the tests + docs first before this lands, just say the word and I'll push another commit.
