### PR TITLE
fix(query): respect workspace llm_provider/llm_model when no request override given

### DIFF
--- a/.env.docker.example
+++ b/.env.docker.example
@@ -1,0 +1,58 @@
+# EdgeQuake Docker Compose — Environment Template
+# Copy to .env and fill in your values:
+#   cp .env.docker.example .env
+#
+# Then start the stack:
+#   docker compose up -d
+
+# ── Ports ─────────────────────────────────────────────────────────────────────
+# EDGEQUAKE_PORT=8080
+# FRONTEND_PORT=3000
+# POSTGRES_PORT=5432
+
+# ── Database ──────────────────────────────────────────────────────────────────
+POSTGRES_PASSWORD=edgequake_secret
+
+# ── LLM Provider ──────────────────────────────────────────────────────────────
+# Options: ollama | openai | anthropic | gemini | mistral | lmstudio | mock
+EDGEQUAKE_LLM_PROVIDER=ollama
+
+# ── Ollama (default, runs on host machine) ────────────────────────────────────
+# host.docker.internal resolves to the host machine from inside Docker.
+# Do NOT change to localhost — that points to the container itself.
+OLLAMA_HOST=http://host.docker.internal:11434
+OLLAMA_CONTEXT_LENGTH=32768
+# OLLAMA_MODEL=gemma4:latest
+# OLLAMA_EMBEDDING_MODEL=embeddinggemma:latest
+
+# ── OpenAI (cloud, set EDGEQUAKE_LLM_PROVIDER=openai above) ──────────────────
+# OPENAI_API_KEY=sk-...
+# EDGEQUAKE_LLM_MODEL=gpt-5-mini
+# EDGEQUAKE_EMBEDDING_MODEL=text-embedding-3-small
+
+# ── Vision LLM (PDF → Markdown, inherits from LLM provider if unset) ─────────
+# EDGEQUAKE_VISION_PROVIDER=ollama
+# EDGEQUAKE_VISION_MODEL=llava:7b
+
+# ── Worker Configuration ──────────────────────────────────────────────────────
+# 0 = no per-tenant limit (recommended for single-tenant)
+MAX_TASKS_PER_TENANT=0
+# WORKER_THREADS=48          # default: num_cpus * 4, only set to cap
+# TASK_PROCESSING_TIMEOUT_SECS=7200
+
+# ── PDF Metadata Enrichment Pipeline ─────────────────────────────────────────
+# Runs before full graph processing — gives users a summary within seconds of upload.
+# Requires a local OpenAI-compatible VLM endpoint (Ollama, LM Studio, etc.)
+ENRICHMENT_VLM_BASE_URL=http://host.docker.internal:11434/v1
+ENRICHMENT_VLM_MODEL=llava:7b
+ENRICHMENT_MAX_PAGES=5
+# Workers: default (num_cpus/2).max(4). Override if needed.
+# ENRICHMENT_CONCURRENT=4
+
+# ── Frontend API URL ──────────────────────────────────────────────────────────
+# URL the browser uses to reach the API. Default works for local access.
+# For remote/LAN access: NEXT_PUBLIC_API_URL=http://192.168.x.x:8080
+# NEXT_PUBLIC_API_URL=http://localhost:8080
+
+# ── Logging ───────────────────────────────────────────────────────────────────
+RUST_LOG=info,edgequake=debug

--- a/.env.example
+++ b/.env.example
@@ -177,6 +177,18 @@ PORT=8080
 WORKER_THREADS=4
 
 # =============================================================================
+# PDF Metadata Enrichment Pipeline
+# =============================================================================
+# Workers dedicated to pre-pipeline summary extraction (runs before full graph processing)
+ENRICHMENT_CONCURRENT=4
+# OpenAI-compatible local VLM endpoint (e.g. Ollama, LM Studio)
+ENRICHMENT_VLM_BASE_URL=http://localhost:11434/v1
+# Model name — text input only, vision capability not required
+ENRICHMENT_VLM_MODEL=llava:7b
+# Number of PDF pages to extract text from for enrichment
+ENRICHMENT_MAX_PAGES=5
+
+# =============================================================================
 # Logging Configuration
 # =============================================================================
 # Logging Level
@@ -190,3 +202,4 @@ RUST_LOG=edgequake=debug,tower_http=debug,axum=debug
 # When set to "true" the "Continue without login (Demo)" button is hidden on the
 # login page.  Leave unset or set to "false" for development / demo environments.
 # NEXT_PUBLIC_DISABLE_DEMO_LOGIN=true
+

--- a/.env.example
+++ b/.env.example
@@ -173,8 +173,22 @@ PORT=8080
 # =============================================================================
 # Worker Configuration
 # =============================================================================
-# Number of background workers for document processing
-WORKER_THREADS=4
+# Number of background workers for document processing.
+# Default (if unset): num_cpus * 4, min 4.
+# Pipeline processing is IO-bound (LLM API calls, embeddings) — more workers
+# than CPU cores keeps throughput high while workers wait for network.
+# Recommended: num_cpus * 4 (e.g. 48 on a 12-core machine).
+# Only set this if you want to cap below the automatic default.
+# WORKER_THREADS=48
+
+# Maximum concurrent tasks per tenant (0 = no limit, recommended for single-tenant).
+# Default (if unset): num_workers * 3/4. Set to 0 for single-tenant deployments
+# to use full worker capacity.
+MAX_TASKS_PER_TENANT=0
+
+# Processing timeout per task in seconds. Large PDFs with vision LLM can take hours.
+# Default: 7200 (2 hours). Increase for very large documents.
+# TASK_PROCESSING_TIMEOUT_SECS=7200
 
 # =============================================================================
 # PDF Metadata Enrichment Pipeline

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,11 @@
 # Rust build artifacts
 target/
+
+# Superpowers brainstorming session files
+.superpowers/
+
+# npm lock file (project uses pnpm)
+edgequake_webui/package-lock.json
 # WHY: Cargo.lock is committed for the application binary (edgequake/) to ensure
 # reproducible CI builds. SDK libraries ignore their Cargo.lock (standard practice).
 sdks/*/Cargo.lock

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,21 +25,16 @@
 services:
   # ── PostgreSQL with pgvector + Apache AGE ──────────────────────────────────
   postgres:
-    build:
-      context: edgequake/docker
-      dockerfile: Dockerfile.postgres
+    image: ghcr.io/raphaelmansuy/edgequake-postgres:${EDGEQUAKE_VERSION:-latest}
     container_name: edgequake-postgres
     restart: unless-stopped
     shm_size: '256m'
-    ports:
-      - "${POSTGRES_PORT:-5432}:5432"
     environment:
       POSTGRES_USER:     edgequake
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-edgequake_secret}
       POSTGRES_DB:       edgequake
     volumes:
-      - postgres-data:/var/lib/postgresql/data
-      - ./edgequake/docker/init-extensions.sql:/docker-entrypoint-initdb.d/init.sql:ro
+      - edgequake-pg-data:/var/lib/postgresql/data
     networks:
       - edgequake
     healthcheck:
@@ -47,7 +42,7 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
-      start_period: 15s
+      start_period: 10s
 
   # ── EdgeQuake API ──────────────────────────────────────────────────────────
   api:
@@ -152,7 +147,7 @@ services:
       start_period: 30s
 
 volumes:
-  postgres-data:
+  edgequake-pg-data:
     driver: local
 
 networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,8 +61,6 @@ services:
       # ── LLM Provider ──────────────────────────────────────────────────────
       EDGEQUAKE_LLM_PROVIDER:       ${EDGEQUAKE_LLM_PROVIDER:-ollama}
       EDGEQUAKE_LLM_MODEL:          ${EDGEQUAKE_LLM_MODEL:-}
-      EDGEQUAKE_EMBEDDING_PROVIDER: ${EDGEQUAKE_EMBEDDING_PROVIDER:-}
-      EDGEQUAKE_EMBEDDING_MODEL:    ${EDGEQUAKE_EMBEDDING_MODEL:-}
 
       # ── Vision LLM (PDF → Markdown) ───────────────────────────────────────
       EDGEQUAKE_VISION_PROVIDER:    ${EDGEQUAKE_VISION_PROVIDER:-${EDGEQUAKE_LLM_PROVIDER:-ollama}}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -102,10 +102,12 @@ services:
       EDGEQUAKE_EMBEDDING_API_KEY:  ${EDGEQUAKE_EMBEDDING_API_KEY:-}
 
       # ── Worker Configuration ───────────────────────────────────────────────
-      # Default: num_cpus * 4. Uncomment to cap.
-      # WORKER_THREADS: 48
+      # Default: num_cpus * 4. Set to cap below auto-calculated value.
+      WORKER_THREADS:              ${WORKER_THREADS:-}
       MAX_TASKS_PER_TENANT:        ${MAX_TASKS_PER_TENANT:-0}
       TASK_PROCESSING_TIMEOUT_SECS: ${TASK_PROCESSING_TIMEOUT_SECS:-7200}
+      # PostgreSQL connection pool size. Default 32; increase for high worker counts.
+      DATABASE_POOL_SIZE:          ${DATABASE_POOL_SIZE:-32}
 
       # ── PDF Metadata Enrichment Pipeline ──────────────────────────────────
       # Pre-pipeline enrichment: extracts summary/topic/language/keywords from

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -122,6 +122,9 @@ services:
       # ── Storage / pdfium ──────────────────────────────────────────────────
       PDFIUM_AUTO_CACHE_DIR: ${PDFIUM_AUTO_CACHE_DIR:-/tmp/edgequake-pdfium-cache}
 
+      # ── Graph Query ───────────────────────────────────────────────────────
+      EDGEQUAKE_GRAPH_QUERY_TIMEOUT_SECS: ${EDGEQUAKE_GRAPH_QUERY_TIMEOUT_SECS:-120}
+
       # ── Auth ──────────────────────────────────────────────────────────────
       EDGEQUAKE_AUTH_ENABLED: ${EDGEQUAKE_AUTH_ENABLED:-false}
       ALLOW_REGISTRATION:     ${ALLOW_REGISTRATION:-true}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -82,6 +82,27 @@ services:
       OLLAMA_MODEL:            ${OLLAMA_MODEL:-}
       OLLAMA_EMBEDDING_MODEL:  ${OLLAMA_EMBEDDING_MODEL:-}
 
+      # ── Embedding Provider ───────────────────────────────────────────────────
+      # Default: same provider as LLM.  Set to "openai" when OPENAI_API_KEY is
+      # present and you want OpenAI embeddings regardless of the LLM provider.
+      EDGEQUAKE_EMBEDDING_PROVIDER: ${EDGEQUAKE_EMBEDDING_PROVIDER:-}
+      # Optional model override — when unset the API picks a sensible default
+      # (e.g. text-embedding-3-small for OpenAI, embeddinggemma for Ollama).
+      EDGEQUAKE_EMBEDDING_MODEL:    ${EDGEQUAKE_EMBEDDING_MODEL:-}
+      # Vector dimension for the embedding model.  MUST match the model output
+      # (e.g. 1024 for qwen3-embedding:0.6b, 768 default).  A mismatch breaks
+      # pgvector inserts.
+      EDGEQUAKE_EMBEDDING_DIMENSION: ${EDGEQUAKE_EMBEDDING_DIMENSION:-768}
+      # Max texts per embedding request.  Clamp to the server's limit when using
+      # a custom endpoint (e.g. 32 for Hugging Face TEI's max_client_batch_size).
+      EDGEQUAKE_EMBEDDING_BATCH_SIZE: ${EDGEQUAKE_EMBEDDING_BATCH_SIZE:-}
+      # Dedicated base URL + key for the EMBEDDING client.  The embedding client
+      # does NOT honour OPENAI_BASE_URL — these vars are what route embeddings to
+      # a custom OpenAI-compatible endpoint (e.g. a TEI server).  EdgeQuake only
+      # takes the custom-endpoint path when one of these is set ("FIX #163").
+      EDGEQUAKE_EMBEDDING_BASE_URL: ${EDGEQUAKE_EMBEDDING_BASE_URL:-}
+      EDGEQUAKE_EMBEDDING_API_KEY:  ${EDGEQUAKE_EMBEDDING_API_KEY:-}
+
       # ── Worker Configuration ───────────────────────────────────────────────
       # Default: num_cpus * 4. Uncomment to cap.
       # WORKER_THREADS: 48
@@ -134,6 +155,7 @@ services:
     environment:
       NODE_ENV: production
       NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL:-http://localhost:8080}
+      EDGEQUAKE_API_URL:  ${EDGEQUAKE_API_URL:-http://localhost:${EDGEQUAKE_PORT:-8080}}
     depends_on:
       api:
         condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,160 @@
+# EdgeQuake — Local Development Stack (build from source)
+#
+# Builds all three services from local source code.
+# Requires: Docker with BuildKit, ~6 GB free disk (Rust build cache)
+#
+# Usage:
+#   docker compose up -d
+#   docker compose up -d --build   # force rebuild after code changes
+#   docker compose logs -f api     # tail API logs
+#
+# Access:
+#   Web UI  → http://localhost:3000
+#   API     → http://localhost:8080
+#   Swagger → http://localhost:8080/swagger-ui
+#   Health  → http://localhost:8080/health
+#
+# LLM provider (default: Ollama on the host at port 11434)
+# To use OpenAI instead:
+#   EDGEQUAKE_LLM_PROVIDER=openai OPENAI_API_KEY=sk-... docker compose up -d
+#
+# Enrichment VLM (local OpenAI-compatible, defaults to Ollama llava:7b):
+#   ENRICHMENT_VLM_BASE_URL=http://host.docker.internal:11434/v1
+#   ENRICHMENT_VLM_MODEL=llava:7b
+
+services:
+  # ── PostgreSQL with pgvector + Apache AGE ──────────────────────────────────
+  postgres:
+    build:
+      context: edgequake/docker
+      dockerfile: Dockerfile.postgres
+    container_name: edgequake-postgres
+    restart: unless-stopped
+    shm_size: '256m'
+    ports:
+      - "${POSTGRES_PORT:-5432}:5432"
+    environment:
+      POSTGRES_USER:     edgequake
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-edgequake_secret}
+      POSTGRES_DB:       edgequake
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+      - ./edgequake/docker/init-extensions.sql:/docker-entrypoint-initdb.d/init.sql:ro
+    networks:
+      - edgequake
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U edgequake -d edgequake"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 15s
+
+  # ── EdgeQuake API ──────────────────────────────────────────────────────────
+  api:
+    build:
+      context: edgequake
+      dockerfile: docker/Dockerfile
+    container_name: edgequake-api
+    restart: unless-stopped
+    ports:
+      - "${EDGEQUAKE_PORT:-8080}:8080"
+    environment:
+      EDGEQUAKE_HOST:  0.0.0.0
+      EDGEQUAKE_PORT:  8080
+      DATABASE_URL:    postgres://edgequake:${POSTGRES_PASSWORD:-edgequake_secret}@postgres:5432/edgequake
+
+      # ── LLM Provider ──────────────────────────────────────────────────────
+      EDGEQUAKE_LLM_PROVIDER:       ${EDGEQUAKE_LLM_PROVIDER:-ollama}
+      EDGEQUAKE_LLM_MODEL:          ${EDGEQUAKE_LLM_MODEL:-}
+      EDGEQUAKE_EMBEDDING_PROVIDER: ${EDGEQUAKE_EMBEDDING_PROVIDER:-}
+      EDGEQUAKE_EMBEDDING_MODEL:    ${EDGEQUAKE_EMBEDDING_MODEL:-}
+
+      # ── Vision LLM (PDF → Markdown) ───────────────────────────────────────
+      EDGEQUAKE_VISION_PROVIDER:    ${EDGEQUAKE_VISION_PROVIDER:-${EDGEQUAKE_LLM_PROVIDER:-ollama}}
+      EDGEQUAKE_VISION_MODEL:       ${EDGEQUAKE_VISION_MODEL:-${EDGEQUAKE_LLM_MODEL:-}}
+      EDGEQUAKE_VISION_TIMEOUT_SECS: ${EDGEQUAKE_VISION_TIMEOUT_SECS:-600}
+
+      # ── API Keys ──────────────────────────────────────────────────────────
+      OPENAI_API_KEY:     ${OPENAI_API_KEY:-}
+      OPENAI_BASE_URL:    ${OPENAI_BASE_URL:-}
+      ANTHROPIC_API_KEY:  ${ANTHROPIC_API_KEY:-}
+      GEMINI_API_KEY:     ${GEMINI_API_KEY:-}
+      MISTRAL_API_KEY:    ${MISTRAL_API_KEY:-}
+
+      # ── Ollama (host machine via host.docker.internal) ─────────────────────
+      OLLAMA_HOST:             ${OLLAMA_HOST:-http://host.docker.internal:11434}
+      OLLAMA_CONTEXT_LENGTH:   ${OLLAMA_CONTEXT_LENGTH:-32768}
+      OLLAMA_MODEL:            ${OLLAMA_MODEL:-}
+      OLLAMA_EMBEDDING_MODEL:  ${OLLAMA_EMBEDDING_MODEL:-}
+
+      # ── Worker Configuration ───────────────────────────────────────────────
+      # Default: num_cpus * 4. Uncomment to cap.
+      # WORKER_THREADS: 48
+      MAX_TASKS_PER_TENANT:        ${MAX_TASKS_PER_TENANT:-0}
+      TASK_PROCESSING_TIMEOUT_SECS: ${TASK_PROCESSING_TIMEOUT_SECS:-7200}
+
+      # ── PDF Metadata Enrichment Pipeline ──────────────────────────────────
+      # Pre-pipeline enrichment: extracts summary/topic/language/keywords from
+      # the first N pages using EdgeParser text mode + a local OpenAI-compatible VLM.
+      # Runs async immediately after upload — users get metadata within seconds.
+      ENRICHMENT_CONCURRENT:    ${ENRICHMENT_CONCURRENT:-4}
+      ENRICHMENT_VLM_BASE_URL:  ${ENRICHMENT_VLM_BASE_URL:-http://host.docker.internal:11434/v1}
+      ENRICHMENT_VLM_MODEL:     ${ENRICHMENT_VLM_MODEL:-llava:7b}
+      ENRICHMENT_MAX_PAGES:     ${ENRICHMENT_MAX_PAGES:-5}
+
+      # ── Storage / pdfium ──────────────────────────────────────────────────
+      PDFIUM_AUTO_CACHE_DIR: ${PDFIUM_AUTO_CACHE_DIR:-/tmp/edgequake-pdfium-cache}
+
+      # ── Logging ───────────────────────────────────────────────────────────
+      RUST_LOG: ${RUST_LOG:-info,edgequake=debug}
+
+    extra_hosts:
+      # Resolves host.docker.internal → host IP on Linux (Docker Desktop does it natively)
+      - "host.docker.internal:host-gateway"
+    depends_on:
+      postgres:
+        condition: service_healthy
+    networks:
+      - edgequake
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/health"]
+      interval: 20s
+      timeout: 10s
+      retries: 5
+      start_period: 30s
+
+  # ── Next.js Web UI ─────────────────────────────────────────────────────────
+  frontend:
+    build:
+      context: .
+      dockerfile: edgequake_webui/Dockerfile
+      args:
+        # Baked into the JS bundle at build time.
+        # For remote access override: NEXT_PUBLIC_API_URL=http://192.168.x.x:8080
+        NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL:-http://localhost:8080}
+    container_name: edgequake-frontend
+    restart: unless-stopped
+    ports:
+      - "${FRONTEND_PORT:-3000}:3000"
+    environment:
+      NODE_ENV: production
+      NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL:-http://localhost:8080}
+    depends_on:
+      api:
+        condition: service_healthy
+    networks:
+      - edgequake
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:3000"]
+      interval: 20s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+
+volumes:
+  postgres-data:
+    driver: local
+
+networks:
+  edgequake:
+    driver: bridge

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -159,8 +159,9 @@ services:
       - "${FRONTEND_PORT:-3000}:3000"
     environment:
       NODE_ENV: production
-      NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL:-http://localhost:8080}
-      EDGEQUAKE_API_URL:  ${EDGEQUAKE_API_URL:-http://localhost:${EDGEQUAKE_PORT:-8080}}
+      NEXT_PUBLIC_API_URL:      ${NEXT_PUBLIC_API_URL:-http://localhost:8080}
+      EDGEQUAKE_API_URL:        ${EDGEQUAKE_API_URL:-http://localhost:${EDGEQUAKE_PORT:-8080}}
+      NEXT_PUBLIC_AUTH_ENABLED: ${EDGEQUAKE_AUTH_ENABLED:-false}
     depends_on:
       api:
         condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -146,7 +146,7 @@ services:
       interval: 20s
       timeout: 10s
       retries: 5
-      start_period: 30s
+      start_period: 180s
 
   # ── Next.js Web UI ─────────────────────────────────────────────────────────
   frontend:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -68,11 +68,12 @@ services:
       EDGEQUAKE_VISION_TIMEOUT_SECS: ${EDGEQUAKE_VISION_TIMEOUT_SECS:-600}
 
       # ── API Keys ──────────────────────────────────────────────────────────
-      OPENAI_API_KEY:     ${OPENAI_API_KEY:-}
-      OPENAI_BASE_URL:    ${OPENAI_BASE_URL:-}
-      ANTHROPIC_API_KEY:  ${ANTHROPIC_API_KEY:-}
-      GEMINI_API_KEY:     ${GEMINI_API_KEY:-}
-      MISTRAL_API_KEY:    ${MISTRAL_API_KEY:-}
+      OPENAI_API_KEY:      ${OPENAI_API_KEY:-}
+      OPENAI_BASE_URL:     ${OPENAI_BASE_URL:-}
+      ANTHROPIC_API_KEY:   ${ANTHROPIC_API_KEY:-}
+      GEMINI_API_KEY:      ${GEMINI_API_KEY:-}
+      MISTRAL_API_KEY:     ${MISTRAL_API_KEY:-}
+      OPENROUTER_API_KEY:  ${OPENROUTER_API_KEY:-}
 
       # ── Ollama (host machine via host.docker.internal) ─────────────────────
       OLLAMA_HOST:             ${OLLAMA_HOST:-http://host.docker.internal:11434}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -121,6 +121,11 @@ services:
       # ── Storage / pdfium ──────────────────────────────────────────────────
       PDFIUM_AUTO_CACHE_DIR: ${PDFIUM_AUTO_CACHE_DIR:-/tmp/edgequake-pdfium-cache}
 
+      # ── Auth ──────────────────────────────────────────────────────────────
+      EDGEQUAKE_AUTH_ENABLED: ${EDGEQUAKE_AUTH_ENABLED:-false}
+      ALLOW_REGISTRATION:     ${ALLOW_REGISTRATION:-true}
+      JWT_SECRET:             ${JWT_SECRET:-change-me-in-production-256-bit-secret-key}
+
       # ── Logging ───────────────────────────────────────────────────────────
       RUST_LOG: ${RUST_LOG:-info,edgequake=debug}
 

--- a/docs/superpowers/plans/2026-06-03-document-topic-grouping.md
+++ b/docs/superpowers/plans/2026-06-03-document-topic-grouping.md
@@ -1,0 +1,848 @@
+# Document Topic Grouping — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a toggle in the document list toolbar that groups documents into collapsible accordion sections by `enrichment_topic`, with all groups collapsed by default.
+
+**Architecture:** Pure client-side grouping — no backend changes. `useDocumentGrouping` groups the already-fetched `Document[]` by `enrichment_topic`. Toggle state lives in `useDocumentPreferences` (localStorage). `DocumentTableSection` conditionally renders flat table or `DocumentGroupAccordion` list. `DocumentTableRow` is reused inside each accordion group unchanged.
+
+**Tech Stack:** React 19, TypeScript, Tailwind CSS, shadcn/ui (Collapsible), Lucide icons, Vitest.
+
+---
+
+## File Map
+
+| Action | Path | Responsibility |
+|---|---|---|
+| Modify | `edgequake_webui/src/types/index.ts` | Add enrichment fields to `Document` interface |
+| Create | `edgequake_webui/src/hooks/use-document-grouping.ts` | Pure grouping logic — groups `Document[]` by topic |
+| Create | `edgequake_webui/src/hooks/__tests__/use-document-grouping.test.ts` | Tests for grouping logic |
+| Modify | `edgequake_webui/src/hooks/use-document-preferences.ts` | Add `groupedView` + `setGroupedView` |
+| Create | `edgequake_webui/src/components/documents/document-group-accordion.tsx` | Accordion for one topic group |
+| Modify | `edgequake_webui/src/components/documents/document-toolbar-section.tsx` | Add List/Grouped toggle |
+| Modify | `edgequake_webui/src/components/documents/document-table-section.tsx` | Conditional flat vs grouped render |
+| Modify | `edgequake_webui/src/components/documents/document-manager.tsx` | Pass `groupedView`/`setGroupedView` through |
+
+---
+
+## Task 1: Add enrichment fields to `Document` type
+
+**Files:**
+- Modify: `edgequake_webui/src/types/index.ts`
+
+- [ ] **Step 1: Find the end of the `Document` interface**
+
+```bash
+grep -n "document_type\|page_count\|file_size_bytes" edgequake_webui/src/types/index.ts | tail -5
+```
+
+The `Document` interface ends around line 145–155. Find the last field before the closing `}`.
+
+- [ ] **Step 2: Add enrichment fields**
+
+After the last existing field (e.g. `file_size_bytes`) and before the closing `}` of the `Document` interface, add:
+
+```ts
+  // ========================================================================
+  // Metadata Enrichment Fields (PDF Metadata Enrichment Pipeline)
+  // ========================================================================
+
+  /** Enrichment pipeline status. */
+  enrichment_status?: "pending" | "processing" | "completed" | "failed" | "skipped";
+  /** Short topic phrase extracted from first 5 pages. */
+  enrichment_topic?: string;
+  /** 2-3 paragraph summary. */
+  enrichment_summary?: string;
+  /** ISO 639-1 language code detected from content. */
+  enrichment_language?: string;
+  /** Up to 10 keywords extracted from content. */
+  enrichment_keywords?: string[];
+  /** When enrichment completed. */
+  enrichment_completed_at?: string;
+  /** Error message if enrichment failed. */
+  enrichment_error?: string;
+```
+
+- [ ] **Step 3: Verify TypeScript compiles**
+
+```bash
+cd edgequake_webui && pnpm exec tsc --noEmit 2>&1 | tail -10
+```
+
+Expected: no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add edgequake_webui/src/types/index.ts
+git commit -m "feat(ui): add enrichment fields to Document type"
+```
+
+---
+
+## Task 2: Create `useDocumentGrouping` hook
+
+**Files:**
+- Create: `edgequake_webui/src/hooks/use-document-grouping.ts`
+- Create: `edgequake_webui/src/hooks/__tests__/use-document-grouping.test.ts`
+
+- [ ] **Step 1: Write the failing tests first**
+
+Create `edgequake_webui/src/hooks/__tests__/use-document-grouping.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import { groupDocumentsByTopic } from "../use-document-grouping";
+import type { Document } from "@/types";
+
+function makeDoc(id: string, topic?: string): Document {
+  return { id, enrichment_topic: topic } as Document;
+}
+
+describe("groupDocumentsByTopic", () => {
+  it("groups documents by topic", () => {
+    const docs = [
+      makeDoc("1", "Psikologi"),
+      makeDoc("2", "Politik"),
+      makeDoc("3", "Psikologi"),
+    ];
+    const result = groupDocumentsByTopic(docs);
+    expect(result.get("Psikologi")).toHaveLength(2);
+    expect(result.get("Politik")).toHaveLength(1);
+  });
+
+  it("puts docs without topic into 'Tanpa Topic'", () => {
+    const docs = [makeDoc("1", undefined), makeDoc("2", ""), makeDoc("3", "Politik")];
+    const result = groupDocumentsByTopic(docs);
+    expect(result.get("Tanpa Topic")).toHaveLength(2);
+    expect(result.get("Politik")).toHaveLength(1);
+  });
+
+  it("'Tanpa Topic' is always last key in the map", () => {
+    const docs = [
+      makeDoc("1", undefined),
+      makeDoc("2", "Zzz Topic"),
+      makeDoc("3", "Aaa Topic"),
+    ];
+    const result = groupDocumentsByTopic(docs);
+    const keys = Array.from(result.keys());
+    expect(keys[keys.length - 1]).toBe("Tanpa Topic");
+  });
+
+  it("sorts other topics alphabetically", () => {
+    const docs = [
+      makeDoc("1", "Zebra"),
+      makeDoc("2", "Apple"),
+      makeDoc("3", "Mango"),
+    ];
+    const result = groupDocumentsByTopic(docs);
+    const keys = Array.from(result.keys());
+    expect(keys).toEqual(["Apple", "Mango", "Zebra"]);
+  });
+
+  it("returns empty map for empty input", () => {
+    expect(groupDocumentsByTopic([]).size).toBe(0);
+  });
+
+  it("returns single group when all docs have same topic", () => {
+    const docs = [makeDoc("1", "ML"), makeDoc("2", "ML")];
+    const result = groupDocumentsByTopic(docs);
+    expect(result.size).toBe(1);
+    expect(result.get("ML")).toHaveLength(2);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd edgequake_webui && pnpm exec vitest run src/hooks/__tests__/use-document-grouping.test.ts 2>&1 | tail -15
+```
+
+Expected: FAIL — `groupDocumentsByTopic` not found.
+
+- [ ] **Step 3: Implement `useDocumentGrouping`**
+
+Create `edgequake_webui/src/hooks/use-document-grouping.ts`:
+
+```ts
+import type { Document } from "@/types";
+import { useMemo } from "react";
+
+const NO_TOPIC_KEY = "Tanpa Topic";
+
+/**
+ * Groups an array of documents by their `enrichment_topic`.
+ * Documents without a topic are placed under "Tanpa Topic", always last.
+ * Other groups are sorted alphabetically.
+ *
+ * Exported as a named function so it can be tested independently of React.
+ */
+export function groupDocumentsByTopic(documents: Document[]): Map<string, Document[]> {
+  const groups = new Map<string, Document[]>();
+
+  for (const doc of documents) {
+    const topic =
+      doc.enrichment_topic && doc.enrichment_topic.trim() !== ""
+        ? doc.enrichment_topic.trim()
+        : NO_TOPIC_KEY;
+
+    const existing = groups.get(topic);
+    if (existing) {
+      existing.push(doc);
+    } else {
+      groups.set(topic, [doc]);
+    }
+  }
+
+  // Sort: alphabetical first, "Tanpa Topic" last
+  const sorted = new Map<string, Document[]>();
+  const keys = Array.from(groups.keys())
+    .filter((k) => k !== NO_TOPIC_KEY)
+    .sort((a, b) => a.localeCompare(b));
+
+  for (const key of keys) {
+    sorted.set(key, groups.get(key)!);
+  }
+  if (groups.has(NO_TOPIC_KEY)) {
+    sorted.set(NO_TOPIC_KEY, groups.get(NO_TOPIC_KEY)!);
+  }
+
+  return sorted;
+}
+
+/**
+ * React hook wrapping groupDocumentsByTopic with memoization.
+ * Re-groups only when the documents array reference changes.
+ */
+export function useDocumentGrouping(documents: Document[]): Map<string, Document[]> {
+  return useMemo(() => groupDocumentsByTopic(documents), [documents]);
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cd edgequake_webui && pnpm exec vitest run src/hooks/__tests__/use-document-grouping.test.ts 2>&1 | tail -15
+```
+
+Expected: 6 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add edgequake_webui/src/hooks/use-document-grouping.ts \
+        edgequake_webui/src/hooks/__tests__/use-document-grouping.test.ts
+git commit -m "feat(ui): add useDocumentGrouping hook with tests"
+```
+
+---
+
+## Task 3: Add `groupedView` to `useDocumentPreferences`
+
+**Files:**
+- Modify: `edgequake_webui/src/hooks/use-document-preferences.ts`
+
+The existing hook already persists to localStorage using `STORAGE_KEY = "edgequake:documents:prefs"`. We add one boolean field.
+
+- [ ] **Step 1: Add `groupedView` to the return interface**
+
+In `UseDocumentPreferencesReturn`, add after `setSortDirection`:
+
+```ts
+  /** Whether documents are grouped by topic */
+  groupedView: boolean;
+  setGroupedView: (value: boolean) => void;
+```
+
+- [ ] **Step 2: Add default and state**
+
+In the `DEFAULTS` object, add:
+
+```ts
+  groupedView: false,
+```
+
+Add state initialization after the existing `sortDirection` state:
+
+```ts
+  const [groupedView, setGroupedView] = useState<boolean>(() => {
+    const prefs = readPreferences();
+    return prefs.groupedView ?? DEFAULTS.groupedView;
+  });
+```
+
+- [ ] **Step 3: Persist `groupedView` in the useEffect**
+
+In the existing `useEffect` that calls `localStorage.setItem`, add `groupedView` to the JSON:
+
+```ts
+  useEffect(() => {
+    try {
+      localStorage.setItem(
+        STORAGE_KEY,
+        JSON.stringify({
+          pageSize,
+          statusFilter,
+          sortField,
+          sortDirection,
+          groupedView,
+        }),
+      );
+    } catch {
+      // Ignore localStorage errors (e.g., in incognito mode)
+    }
+  }, [pageSize, statusFilter, sortField, sortDirection, groupedView]);
+```
+
+- [ ] **Step 4: Return `groupedView` and `setGroupedView`**
+
+In the `return` statement at the bottom of the hook, add:
+
+```ts
+    groupedView,
+    setGroupedView,
+```
+
+- [ ] **Step 5: Add `groupedView` to `readPreferences` return type**
+
+In the `readPreferences` function's return type annotation, add `groupedView?: boolean`:
+
+```ts
+function readPreferences(): Partial<{
+  pageSize: number;
+  statusFilter: DocStatus;
+  sortField: SortField;
+  sortDirection: SortDirection;
+  groupedView: boolean;
+}> {
+```
+
+- [ ] **Step 6: Type-check**
+
+```bash
+cd edgequake_webui && pnpm exec tsc --noEmit 2>&1 | tail -10
+```
+
+Expected: no errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add edgequake_webui/src/hooks/use-document-preferences.ts
+git commit -m "feat(ui): add groupedView preference to useDocumentPreferences"
+```
+
+---
+
+## Task 4: Create `DocumentGroupAccordion` component
+
+**Files:**
+- Create: `edgequake_webui/src/components/documents/document-group-accordion.tsx`
+
+This component renders one collapsible group. It uses shadcn/ui `Collapsible` and reuses `DocumentTableRow` unchanged.
+
+- [ ] **Step 1: Check if `Collapsible` is available**
+
+```bash
+grep -r "Collapsible" edgequake_webui/src/components/ui/ 2>/dev/null | head -3
+```
+
+If no output, install it:
+```bash
+cd edgequake_webui && pnpm dlx shadcn@latest add collapsible
+```
+
+If already present, skip install.
+
+- [ ] **Step 2: Create the component**
+
+Create `edgequake_webui/src/components/documents/document-group-accordion.tsx`:
+
+```tsx
+'use client';
+
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from '@/components/ui/collapsible';
+import { cn } from '@/lib/utils';
+import type { Document } from '@/types';
+import { ChevronDown, ChevronRight, Folder } from 'lucide-react';
+import { memo, useState } from 'react';
+import { DocumentTableRow } from './document-table-row';
+import type { DocumentTableRowProps } from './document-table-row';
+
+/**
+ * Handlers passed through to each DocumentTableRow — all row actions.
+ * Matches the handler props of DocumentTableSectionProps minus
+ * selection/id-specific props (those are per-row).
+ */
+export interface DocumentGroupRowHandlers
+  extends Pick<
+    DocumentTableRowProps,
+    | 'onSelect'
+    | 'onClick'
+    | 'onDoubleClick'
+    | 'onViewDetails'
+    | 'onViewInGraph'
+    | 'onViewPdf'
+    | 'onRetry'
+    | 'onCancel'
+    | 'onDelete'
+    | 'isRetrying'
+    | 'isCancelling'
+  > {}
+
+export interface DocumentGroupAccordionProps extends DocumentGroupRowHandlers {
+  /** Topic label for this group */
+  topic: string;
+  /** Documents in this group */
+  documents: Document[];
+  /** Currently selected document IDs */
+  selectedIds: Set<string>;
+  /** Currently active/previewed document */
+  selectedDocument: Document | null;
+  /** Current search query (for row highlight) */
+  searchQuery: string;
+}
+
+/**
+ * Collapsible accordion group for documents sharing the same topic.
+ * Collapsed by default. "Tanpa Topic" label rendered muted.
+ */
+export const DocumentGroupAccordion = memo(function DocumentGroupAccordion({
+  topic,
+  documents,
+  selectedIds,
+  selectedDocument,
+  searchQuery,
+  onSelect,
+  onClick,
+  onDoubleClick,
+  onViewDetails,
+  onViewInGraph,
+  onViewPdf,
+  onRetry,
+  onCancel,
+  onDelete,
+  isRetrying,
+  isCancelling,
+}: DocumentGroupAccordionProps) {
+  const [open, setOpen] = useState(false);
+  const isNoTopic = topic === 'Tanpa Topic';
+
+  return (
+    <Collapsible open={open} onOpenChange={setOpen}>
+      <CollapsibleTrigger asChild>
+        <button
+          className="w-full flex items-center gap-2 px-4 py-2 bg-muted/30 hover:bg-muted/50 border-b text-left transition-colors"
+          aria-expanded={open}
+        >
+          {open ? (
+            <ChevronDown className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
+          ) : (
+            <ChevronRight className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
+          )}
+          <Folder className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+          <span
+            className={cn(
+              'text-sm font-medium',
+              isNoTopic ? 'text-muted-foreground italic' : 'text-foreground',
+            )}
+          >
+            {topic}
+          </span>
+          <span className="ml-1.5 text-xs text-muted-foreground bg-muted px-1.5 py-0.5 rounded-full">
+            {documents.length}
+          </span>
+        </button>
+      </CollapsibleTrigger>
+
+      <CollapsibleContent>
+        {documents.map((doc, index) => (
+          <DocumentTableRow
+            key={doc.id}
+            doc={doc}
+            index={index}
+            isSelected={selectedIds.has(doc.id)}
+            isActive={selectedDocument?.id === doc.id}
+            searchQuery={searchQuery}
+            onSelect={onSelect}
+            onClick={onClick}
+            onDoubleClick={onDoubleClick}
+            onViewDetails={onViewDetails}
+            onViewInGraph={onViewInGraph}
+            onViewPdf={onViewPdf}
+            onRetry={onRetry}
+            onCancel={onCancel}
+            onDelete={onDelete}
+            isRetrying={isRetrying}
+            isCancelling={isCancelling}
+          />
+        ))}
+      </CollapsibleContent>
+    </Collapsible>
+  );
+});
+```
+
+- [ ] **Step 3: Export from the documents index**
+
+In `edgequake_webui/src/components/documents/index.ts`, add:
+
+```ts
+export { DocumentGroupAccordion } from './document-group-accordion';
+```
+
+- [ ] **Step 4: Type-check**
+
+```bash
+cd edgequake_webui && pnpm exec tsc --noEmit 2>&1 | tail -10
+```
+
+Expected: no errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add edgequake_webui/src/components/documents/document-group-accordion.tsx \
+        edgequake_webui/src/components/documents/index.ts
+git commit -m "feat(ui): add DocumentGroupAccordion component"
+```
+
+---
+
+## Task 5: Add List/Grouped toggle to `DocumentToolbarSection`
+
+**Files:**
+- Modify: `edgequake_webui/src/components/documents/document-toolbar-section.tsx`
+
+- [ ] **Step 1: Add props to `DocumentToolbarSectionProps`**
+
+After the existing `onSortDirectionChange` prop, add:
+
+```ts
+  /** Whether documents are currently grouped by topic */
+  groupedView: boolean;
+  /** Toggle grouped view on/off */
+  onGroupedViewChange: (value: boolean) => void;
+```
+
+- [ ] **Step 2: Destructure the new props in the function signature**
+
+Add `groupedView` and `onGroupedViewChange` to the destructured parameters.
+
+- [ ] **Step 3: Add the toggle UI**
+
+Add the following import at the top of the file:
+
+```tsx
+import { LayoutList, LayoutGrid } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+```
+
+Then in the JSX, inside the `div.flex.flex-col` that wraps search and filters, add the toggle to the right of `<DocumentFilters>`:
+
+```tsx
+        <DocumentFilters
+          status={statusFilter}
+          onStatusChange={onStatusFilterChange}
+          sortField={sortField}
+          onSortFieldChange={onSortFieldChange}
+          sortDirection={sortDirection}
+          onSortDirectionChange={onSortDirectionChange}
+          statusCounts={statusCounts}
+        />
+        {/* List / Grouped toggle */}
+        <div className="flex items-center border rounded-md overflow-hidden">
+          <Button
+            variant={!groupedView ? 'secondary' : 'ghost'}
+            size="sm"
+            className="rounded-none h-8 px-2.5 gap-1.5"
+            onClick={() => onGroupedViewChange(false)}
+            title="List view"
+          >
+            <LayoutList className="h-3.5 w-3.5" />
+            <span className="text-xs hidden sm:inline">List</span>
+          </Button>
+          <Button
+            variant={groupedView ? 'secondary' : 'ghost'}
+            size="sm"
+            className="rounded-none h-8 px-2.5 gap-1.5 border-l"
+            onClick={() => onGroupedViewChange(true)}
+            title="Grouped by topic"
+          >
+            <LayoutGrid className="h-3.5 w-3.5" />
+            <span className="text-xs hidden sm:inline">Grouped</span>
+          </Button>
+        </div>
+```
+
+- [ ] **Step 4: Type-check**
+
+```bash
+cd edgequake_webui && pnpm exec tsc --noEmit 2>&1 | tail -10
+```
+
+Expected: errors in `DocumentManager` (missing new props) — that's expected, fixed in Task 7.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add edgequake_webui/src/components/documents/document-toolbar-section.tsx
+git commit -m "feat(ui): add List/Grouped toggle button to document toolbar"
+```
+
+---
+
+## Task 6: Add grouped render to `DocumentTableSection`
+
+**Files:**
+- Modify: `edgequake_webui/src/components/documents/document-table-section.tsx`
+
+- [ ] **Step 1: Add new props to `DocumentTableSectionProps`**
+
+After `onClearFilter`, add:
+
+```ts
+  /** Whether to render documents grouped by topic */
+  groupedView?: boolean;
+```
+
+- [ ] **Step 2: Import new dependencies**
+
+Add at the top of the file:
+
+```tsx
+import { useDocumentGrouping } from '@/hooks/use-document-grouping';
+import { DocumentGroupAccordion } from './document-group-accordion';
+```
+
+- [ ] **Step 3: Destructure `groupedView` in the function signature**
+
+Add `groupedView = false` to the destructured props (with default `false` so existing callers work without changes).
+
+- [ ] **Step 4: Add grouped render branch**
+
+Inside the `{!isLoading && documents.length > 0 && (` block, wrap the existing `<div className="border rounded-lg ...">` in a conditional. Replace:
+
+```tsx
+          {!isLoading && documents.length > 0 && (
+            <div className="border rounded-lg overflow-hidden shadow-sm">
+              ...existing table...
+            </div>
+          )}
+```
+
+With:
+
+```tsx
+          {!isLoading && documents.length > 0 && (
+            groupedView
+              ? <GroupedView
+                  documents={documents}
+                  selectedIds={selectedIds}
+                  selectedDocument={selectedDocument}
+                  searchQuery={searchQuery}
+                  onSelectOne={onSelectOne}
+                  onRowClick={onRowClick}
+                  onRowDoubleClick={onRowDoubleClick}
+                  onViewDetails={onViewDetails}
+                  onViewInGraph={onViewInGraph}
+                  onViewPdf={onViewPdf}
+                  onRetry={onRetry}
+                  onCancel={onCancel}
+                  onDelete={onDelete}
+                  isRetrying={isRetrying}
+                  isCancelling={isCancelling}
+                />
+              : <div className="border rounded-lg overflow-hidden shadow-sm">
+                  {/* existing table — unchanged */}
+                  ...
+                </div>
+          )}
+```
+
+- [ ] **Step 5: Add `GroupedView` helper component**
+
+Add this private component inside the same file, above `DocumentTableSection`:
+
+```tsx
+/**
+ * Private helper: renders all topic groups as accordions.
+ * Keeps the grouped rendering logic out of DocumentTableSection's main render.
+ */
+function GroupedView({
+  documents,
+  selectedIds,
+  selectedDocument,
+  searchQuery,
+  onSelectOne,
+  onRowClick,
+  onRowDoubleClick,
+  onViewDetails,
+  onViewInGraph,
+  onViewPdf,
+  onRetry,
+  onCancel,
+  onDelete,
+  isRetrying,
+  isCancelling,
+}: {
+  documents: Document[];
+  selectedIds: Set<string>;
+  selectedDocument: Document | null;
+  searchQuery: string;
+  onSelectOne: (id: string, checked: boolean) => void;
+  onRowClick: (doc: Document) => void;
+  onRowDoubleClick: (doc: Document) => void;
+  onViewDetails: (doc: Document) => void;
+  onViewInGraph: (doc: Document) => void;
+  onViewPdf: (doc: Document) => void;
+  onRetry: (id: string) => void;
+  onCancel: (trackId: string) => void;
+  onDelete: (id: string) => void;
+  isRetrying: boolean;
+  isCancelling: boolean;
+}) {
+  const groups = useDocumentGrouping(documents);
+
+  return (
+    <div className="border rounded-lg overflow-hidden shadow-sm divide-y">
+      {Array.from(groups.entries()).map(([topic, docs]) => (
+        <DocumentGroupAccordion
+          key={topic}
+          topic={topic}
+          documents={docs}
+          selectedIds={selectedIds}
+          selectedDocument={selectedDocument}
+          searchQuery={searchQuery}
+          onSelect={onSelectOne}
+          onClick={onRowClick}
+          onDoubleClick={onRowDoubleClick}
+          onViewDetails={onViewDetails}
+          onViewInGraph={onViewInGraph}
+          onViewPdf={onViewPdf}
+          onRetry={onRetry}
+          onCancel={onCancel}
+          onDelete={onDelete}
+          isRetrying={isRetrying}
+          isCancelling={isCancelling}
+        />
+      ))}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 6: Type-check**
+
+```bash
+cd edgequake_webui && pnpm exec tsc --noEmit 2>&1 | tail -10
+```
+
+Expected: errors only in `DocumentManager` (missing `groupedView` prop and toggle props).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add edgequake_webui/src/components/documents/document-table-section.tsx
+git commit -m "feat(ui): add grouped render branch to DocumentTableSection"
+```
+
+---
+
+## Task 7: Wire everything up in `DocumentManager`
+
+**Files:**
+- Modify: `edgequake_webui/src/components/documents/document-manager.tsx`
+
+- [ ] **Step 1: Destructure `groupedView` and `setGroupedView` from preferences**
+
+Find the line where `useDocumentPreferences` is called. It currently returns:
+
+```ts
+const {
+  pageSize, setPageSize,
+  statusFilter, setStatusFilter,
+  sortField, setSortField,
+  sortDirection, setSortDirection,
+} = useDocumentPreferences();
+```
+
+Add `groupedView` and `setGroupedView`:
+
+```ts
+const {
+  pageSize, setPageSize,
+  statusFilter, setStatusFilter,
+  sortField, setSortField,
+  sortDirection, setSortDirection,
+  groupedView, setGroupedView,
+} = useDocumentPreferences();
+```
+
+- [ ] **Step 2: Pass props to `DocumentToolbarSection`**
+
+Find the `<DocumentToolbarSection` JSX block. Add the two new props anywhere after the existing props:
+
+```tsx
+            groupedView={groupedView}
+            onGroupedViewChange={setGroupedView}
+```
+
+- [ ] **Step 3: Pass `groupedView` to `DocumentTableSection`**
+
+Find the `<DocumentTableSection` JSX block. Add:
+
+```tsx
+        groupedView={groupedView}
+```
+
+- [ ] **Step 4: Full type-check**
+
+```bash
+cd edgequake_webui && pnpm exec tsc --noEmit 2>&1 | tail -10
+```
+
+Expected: no errors.
+
+- [ ] **Step 5: Run all tests**
+
+```bash
+cd edgequake_webui && pnpm exec vitest run 2>&1 | tail -20
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add edgequake_webui/src/components/documents/document-manager.tsx
+git commit -m "feat(ui): wire groupedView toggle through DocumentManager"
+```
+
+---
+
+## Verification Checklist
+
+```bash
+# 1. All tests pass
+cd edgequake_webui && pnpm exec vitest run 2>&1 | grep -E "passed|failed"
+
+# 2. TypeScript clean
+pnpm exec tsc --noEmit 2>&1 | tail -5
+
+# 3. Dev server builds
+pnpm dev 2>&1 | head -20
+```
+
+Manual test:
+1. Open `/` in browser
+2. Upload a PDF — `enrichment_status: "pending"` appears in metadata
+3. Click **Grouped** toggle → documents appear under "Tanpa Topic" (no topic yet)
+4. Refresh — Grouped mode persists (localStorage)
+5. Click topic header → accordion expands showing doc rows
+6. Click **List** → flat table restored

--- a/docs/superpowers/plans/2026-06-03-pdf-metadata-enrichment.md
+++ b/docs/superpowers/plans/2026-06-03-pdf-metadata-enrichment.md
@@ -1,0 +1,1169 @@
+# PDF Metadata Enrichment Pipeline — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a fast async pre-pipeline that extracts text from the first 5 pages of a PDF with EdgeParser, sends it to a local OpenAI-compatible VLM, and stores `summary / topic / language / keywords` in document metadata before the full Graph-RAG pipeline runs.
+
+**Architecture:** Two separate Tokio worker pools — an existing main pool for full pipeline tasks and a new enrichment pool (4 workers by default). Both share the same `task_storage`. The enrichment task is enqueued simultaneously with `PdfProcessing` at upload time; because enrichment is fast (seconds) it finishes long before full indexing completes. A pre-generated `document_id` ties both tasks to the same metadata record.
+
+**Tech Stack:** Rust, `edgequake-tasks` (task/worker infrastructure), `edgequake-pdf` (EdgeParsePdfConverter), `reqwest` (VLM HTTP calls), PostgreSQL KV storage.
+
+---
+
+## File Map
+
+| Action | Path | Responsibility |
+|---|---|---|
+| Modify | `edgequake/crates/edgequake-tasks/src/types/status.rs` | Add `TaskType::MetadataEnrich` |
+| Modify | `edgequake/crates/edgequake-tasks/src/types/data.rs` | Add `MetadataEnrichData` payload |
+| Modify | `edgequake/crates/edgequake-tasks/src/lib.rs` | Re-export `MetadataEnrichData` |
+| Create | `edgequake/crates/edgequake-api/src/processor/enrichment_config.rs` | Read env vars into `EnrichmentConfig` |
+| Create | `edgequake/crates/edgequake-api/src/processor/metadata_enrich.rs` | `MetadataEnrichProcessor` impl |
+| Modify | `edgequake/crates/edgequake-api/src/processor/mod.rs` | Declare new sub-modules |
+| Modify | `edgequake/crates/edgequake-api/src/state/mod.rs` | Add `enrich_queue: SharedTaskQueue` field |
+| Modify | `edgequake/crates/edgequake-api/src/state/postgres.rs` | Initialize `enrich_queue` |
+| Modify | `edgequake/crates/edgequake-api/src/state/memory.rs` | Initialize `enrich_queue` |
+| Modify | `edgequake/crates/edgequake-api/src/handlers/pdf_upload/helpers.rs` | Pre-generate `document_id`, enqueue enrichment task |
+| Modify | `edgequake/src/main.rs` | Start enrichment worker pool |
+
+---
+
+## Task 1: Add `TaskType::MetadataEnrich` and `MetadataEnrichData`
+
+**Files:**
+- Modify: `edgequake/crates/edgequake-tasks/src/types/status.rs`
+- Modify: `edgequake/crates/edgequake-tasks/src/types/data.rs`
+- Modify: `edgequake/crates/edgequake-tasks/src/lib.rs`
+
+- [ ] **Step 1: Write failing test for new task type**
+
+Add to the end of `edgequake/crates/edgequake-tasks/src/types/mod.rs` inside the existing `#[cfg(test)] mod tests { ... }` block (before the closing `}`):
+
+```rust
+#[test]
+fn test_metadata_enrich_task_type() {
+    let task = Task::new(
+        test_tenant_id(),
+        test_workspace_id(),
+        TaskType::MetadataEnrich,
+        serde_json::json!({}),
+    );
+    assert_eq!(task.task_type, TaskType::MetadataEnrich);
+    assert!(task.track_id.starts_with("metadata_enrich-"));
+}
+
+#[test]
+fn test_metadata_enrich_data_serialization() {
+    use crate::types::MetadataEnrichData;
+    let data = MetadataEnrichData {
+        document_id: "doc-123".to_string(),
+        pdf_id: uuid::Uuid::parse_str("00000000-0000-0000-0000-000000000001").unwrap(),
+        tenant_id: test_tenant_id(),
+        workspace_id: test_workspace_id(),
+        max_pages: 5,
+    };
+    let json = serde_json::to_value(&data).unwrap();
+    let back: MetadataEnrichData = serde_json::from_value(json).unwrap();
+    assert_eq!(back.document_id, "doc-123");
+    assert_eq!(back.max_pages, 5);
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd /home/romy/workspace/edgequake-romy/edgequake
+cargo test -p edgequake-tasks test_metadata_enrich 2>&1 | tail -20
+```
+
+Expected: compile error — `TaskType::MetadataEnrich` and `MetadataEnrichData` don't exist yet.
+
+- [ ] **Step 3: Add `MetadataEnrich` to `TaskType` enum**
+
+In `edgequake/crates/edgequake-tasks/src/types/status.rs`, add the variant and its display/track-id:
+
+```rust
+/// Task type
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum TaskType {
+    Upload,
+    Insert,
+    Scan,
+    Reindex,
+    PdfProcessing,
+    MetadataEnrich,
+}
+
+impl fmt::Display for TaskType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Upload => write!(f, "upload"),
+            Self::Insert => write!(f, "insert"),
+            Self::Scan => write!(f, "scan"),
+            Self::Reindex => write!(f, "reindex"),
+            Self::PdfProcessing => write!(f, "pdf_processing"),
+            Self::MetadataEnrich => write!(f, "metadata_enrich"),
+        }
+    }
+}
+```
+
+`generate_track_id` in `task.rs` uses `format!("{}-{}", task_type, uuid)` — it calls `Display` automatically, so no changes needed in that function. The new variant's track IDs will be `metadata_enrich-<uuid>` as soon as the `Display` impl is in place.
+
+- [ ] **Step 4: Add `MetadataEnrichData` to `data.rs`**
+
+Append to `edgequake/crates/edgequake-tasks/src/types/data.rs`:
+
+```rust
+/// Metadata enrichment task payload.
+///
+/// Carries everything the enrichment worker needs to extract a summary,
+/// topic, language, and keywords from the first `max_pages` of a PDF.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MetadataEnrichData {
+    /// Pre-generated document ID shared with the PdfProcessing task.
+    /// The enrichment worker writes results to `{document_id}-metadata`.
+    pub document_id: String,
+
+    /// PDF identifier in pdf_storage (used to load raw bytes).
+    pub pdf_id: uuid::Uuid,
+
+    /// Tenant ID for multi-tenant isolation.
+    pub tenant_id: uuid::Uuid,
+
+    /// Workspace ID for isolation.
+    pub workspace_id: uuid::Uuid,
+
+    /// Maximum number of pages to extract text from (default 5).
+    #[serde(default = "default_max_pages")]
+    pub max_pages: usize,
+}
+
+fn default_max_pages() -> usize {
+    5
+}
+```
+
+- [ ] **Step 5: Re-export `MetadataEnrichData` from `lib.rs`**
+
+In `edgequake/crates/edgequake-tasks/src/lib.rs`, find the existing `pub use types::{ ... }` block and add `MetadataEnrichData` to it:
+
+```rust
+pub use types::{
+    ChunkProgress, DirectoryScanData, DocumentUploadData, MetadataEnrichData, PdfProcessingData,
+    ReindexData, Task, TaskFailureInfo, TaskProgress, TaskStatus, TaskType, TextInsertData,
+};
+```
+
+- [ ] **Step 6: Run test to verify it passes**
+
+```bash
+cd /home/romy/workspace/edgequake-romy/edgequake
+cargo test -p edgequake-tasks test_metadata_enrich 2>&1 | tail -20
+```
+
+Expected: both tests PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd /home/romy/workspace/edgequake-romy/edgequake
+git add crates/edgequake-tasks/src/types/status.rs \
+        crates/edgequake-tasks/src/types/data.rs \
+        crates/edgequake-tasks/src/types/task.rs \
+        crates/edgequake-tasks/src/types/mod.rs \
+        crates/edgequake-tasks/src/lib.rs
+git commit -m "feat(tasks): add MetadataEnrich task type and MetadataEnrichData payload"
+```
+
+---
+
+## Task 2: `EnrichmentConfig`
+
+**Files:**
+- Create: `edgequake/crates/edgequake-api/src/processor/enrichment_config.rs`
+
+- [ ] **Step 1: Write failing test**
+
+Create `edgequake/crates/edgequake-api/src/processor/enrichment_config.rs` with only the test first:
+
+```rust
+#[derive(Debug, Clone)]
+pub struct EnrichmentConfig {
+    pub vlm_base_url: String,
+    pub vlm_model: String,
+    pub max_pages: usize,
+    pub concurrent: usize,
+}
+
+impl EnrichmentConfig {
+    pub fn from_env() -> Self {
+        Self {
+            vlm_base_url: std::env::var("ENRICHMENT_VLM_BASE_URL")
+                .unwrap_or_else(|_| "http://localhost:11434/v1".to_string()),
+            vlm_model: std::env::var("ENRICHMENT_VLM_MODEL")
+                .unwrap_or_else(|_| "llava:7b".to_string()),
+            max_pages: std::env::var("ENRICHMENT_MAX_PAGES")
+                .ok()
+                .and_then(|s| s.parse().ok())
+                .unwrap_or(5),
+            concurrent: std::env::var("ENRICHMENT_CONCURRENT")
+                .ok()
+                .and_then(|s| s.parse().ok())
+                .unwrap_or(4),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_enrichment_config_defaults() {
+        // Ensure no stale env vars from other tests
+        std::env::remove_var("ENRICHMENT_VLM_BASE_URL");
+        std::env::remove_var("ENRICHMENT_VLM_MODEL");
+        std::env::remove_var("ENRICHMENT_MAX_PAGES");
+        std::env::remove_var("ENRICHMENT_CONCURRENT");
+
+        let config = EnrichmentConfig::from_env();
+
+        assert_eq!(config.vlm_base_url, "http://localhost:11434/v1");
+        assert_eq!(config.vlm_model, "llava:7b");
+        assert_eq!(config.max_pages, 5);
+        assert_eq!(config.concurrent, 4);
+    }
+
+    #[test]
+    fn test_enrichment_config_from_env() {
+        std::env::set_var("ENRICHMENT_VLM_BASE_URL", "http://myhost:8080/v1");
+        std::env::set_var("ENRICHMENT_VLM_MODEL", "gemma3:12b");
+        std::env::set_var("ENRICHMENT_MAX_PAGES", "3");
+        std::env::set_var("ENRICHMENT_CONCURRENT", "8");
+
+        let config = EnrichmentConfig::from_env();
+
+        // Restore
+        std::env::remove_var("ENRICHMENT_VLM_BASE_URL");
+        std::env::remove_var("ENRICHMENT_VLM_MODEL");
+        std::env::remove_var("ENRICHMENT_MAX_PAGES");
+        std::env::remove_var("ENRICHMENT_CONCURRENT");
+
+        assert_eq!(config.vlm_base_url, "http://myhost:8080/v1");
+        assert_eq!(config.vlm_model, "gemma3:12b");
+        assert_eq!(config.max_pages, 3);
+        assert_eq!(config.concurrent, 8);
+    }
+}
+```
+
+- [ ] **Step 2: Declare module in `processor/mod.rs`**
+
+In `edgequake/crates/edgequake-api/src/processor/mod.rs`, add after the existing `mod` declarations (e.g. after `mod workspace_resolver;`):
+
+```rust
+pub mod enrichment_config;
+pub mod metadata_enrich;
+```
+
+- [ ] **Step 3: Run test**
+
+```bash
+cd /home/romy/workspace/edgequake-romy/edgequake
+cargo test -p edgequake-api test_enrichment_config 2>&1 | tail -20
+```
+
+Expected: both config tests PASS (the `metadata_enrich` module declaration will cause a compile error until Task 3 — add an empty file first if needed):
+
+```bash
+touch crates/edgequake-api/src/processor/metadata_enrich.rs
+```
+
+Then re-run.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /home/romy/workspace/edgequake-romy/edgequake
+git add crates/edgequake-api/src/processor/enrichment_config.rs \
+        crates/edgequake-api/src/processor/mod.rs \
+        crates/edgequake-api/src/processor/metadata_enrich.rs
+git commit -m "feat(api): add EnrichmentConfig reading from env vars"
+```
+
+---
+
+## Task 3: `MetadataEnrichProcessor`
+
+**Files:**
+- Modify: `edgequake/crates/edgequake-api/src/processor/metadata_enrich.rs`
+
+This processor implements `TaskProcessor`. It loads PDF bytes from `pdf_storage`, runs EdgeParser, truncates text to 8000 chars, calls the local VLM, and writes results to `{document_id}-metadata` in KV storage.
+
+- [ ] **Step 1: Write the full processor**
+
+Replace the contents of `edgequake/crates/edgequake-api/src/processor/metadata_enrich.rs`:
+
+```rust
+use async_trait::async_trait;
+use edgequake_pdf::{backend::edgeparse::EdgeParsePdfConverter, PdfConversionConfig, PdfConverter};
+use edgequake_storage::{traits::KVStorage, PdfDocumentStorage};
+use edgequake_tasks::{MetadataEnrichData, Task, TaskError, TaskProcessor, TaskResult};
+use reqwest::Client;
+use serde::Deserialize;
+use std::sync::Arc;
+use tokio_util::sync::CancellationToken;
+use tracing::{info, warn};
+
+use super::enrichment_config::EnrichmentConfig;
+
+/// Maximum characters sent to the VLM (~8000 chars ≈ first 5 PDF pages of text).
+const MAX_TEXT_CHARS: usize = 8_000;
+
+const ENRICHMENT_PROMPT: &str = "You are a document analyst. Given the text from the first pages \
+of a document, extract structured metadata. Respond ONLY with valid JSON, no markdown, \
+no explanation:\n\
+{\n\
+  \"summary\": \"2-3 paragraph summary written in the document's own language\",\n\
+  \"topic\": \"single short topic phrase\",\n\
+  \"language\": \"ISO 639-1 code (e.g. en, id, fr)\",\n\
+  \"keywords\": [\"up to 10 keywords\"]\n\
+}\n\nDocument text:";
+
+#[derive(Debug, Deserialize)]
+struct EnrichmentResponse {
+    summary: String,
+    topic: String,
+    language: String,
+    keywords: Vec<String>,
+}
+
+pub struct MetadataEnrichProcessor {
+    kv_storage: Arc<dyn KVStorage>,
+    pdf_storage: Option<Arc<dyn PdfDocumentStorage>>,
+    config: EnrichmentConfig,
+    http_client: Client,
+}
+
+impl MetadataEnrichProcessor {
+    pub fn new(
+        kv_storage: Arc<dyn KVStorage>,
+        pdf_storage: Option<Arc<dyn PdfDocumentStorage>>,
+        config: EnrichmentConfig,
+    ) -> Self {
+        Self {
+            kv_storage,
+            pdf_storage,
+            config,
+            http_client: Client::new(),
+        }
+    }
+
+    async fn load_pdf_bytes(&self, pdf_id: &uuid::Uuid) -> TaskResult<Vec<u8>> {
+        let storage = self.pdf_storage.as_ref().ok_or_else(|| {
+            TaskError::Processing("pdf_storage not available (postgres feature required)".to_string())
+        })?;
+
+        let doc = storage
+            .get_pdf(pdf_id)
+            .await
+            .map_err(|e| TaskError::Processing(format!("Failed to load PDF: {}", e)))?
+            .ok_or_else(|| TaskError::NotFound(format!("PDF not found: {}", pdf_id)))?;
+
+        Ok(doc.pdf_data)
+    }
+
+    async fn write_metadata(&self, document_id: &str, updates: serde_json::Value) -> TaskResult<()> {
+        let key = format!("{}-metadata", document_id);
+
+        // Merge updates into existing metadata (create if absent)
+        let existing = self
+            .kv_storage
+            .get_by_id(&key)
+            .await
+            .ok()
+            .flatten()
+            .unwrap_or_else(|| serde_json::json!({}));
+
+        let mut obj = existing
+            .as_object()
+            .cloned()
+            .unwrap_or_default();
+
+        if let Some(map) = updates.as_object() {
+            for (k, v) in map {
+                obj.insert(k.clone(), v.clone());
+            }
+        }
+
+        self.kv_storage
+            .upsert(&[(key, serde_json::Value::Object(obj))])
+            .await
+            .map_err(|e| TaskError::Processing(format!("KV write failed: {}", e)))
+    }
+
+    async fn call_vlm(&self, text: &str) -> Result<EnrichmentResponse, String> {
+        let prompt = format!("{}\n\n{}", ENRICHMENT_PROMPT, text);
+
+        let body = serde_json::json!({
+            "model": self.config.vlm_model,
+            "messages": [{"role": "user", "content": prompt}],
+            "temperature": 0.1,
+        });
+
+        let url = format!("{}/chat/completions", self.config.vlm_base_url);
+
+        let response = self
+            .http_client
+            .post(&url)
+            .json(&body)
+            .timeout(std::time::Duration::from_secs(120))
+            .send()
+            .await
+            .map_err(|e| format!("VLM request failed: {}", e))?;
+
+        let resp_json: serde_json::Value = response
+            .json()
+            .await
+            .map_err(|e| format!("Failed to read VLM response body: {}", e))?;
+
+        let content = resp_json["choices"][0]["message"]["content"]
+            .as_str()
+            .ok_or_else(|| format!("Unexpected VLM response shape: {}", resp_json))?;
+
+        // Strip optional ```json ... ``` fences that some models add
+        let json_str = content
+            .trim()
+            .trim_start_matches("```json")
+            .trim_start_matches("```")
+            .trim_end_matches("```")
+            .trim();
+
+        serde_json::from_str::<EnrichmentResponse>(json_str)
+            .map_err(|e| format!("VLM returned invalid JSON ({e}): {json_str}"))
+    }
+}
+
+#[async_trait]
+impl TaskProcessor for MetadataEnrichProcessor {
+    async fn process(
+        &self,
+        task: &mut Task,
+        _cancel_token: CancellationToken,
+    ) -> TaskResult<serde_json::Value> {
+        let data: MetadataEnrichData =
+            serde_json::from_value(task.task_data.clone()).map_err(|e| {
+                TaskError::InvalidPayload(format!("Invalid MetadataEnrichData: {}", e))
+            })?;
+
+        // Mark enrichment as in-progress so polling clients see the transition
+        self.write_metadata(
+            &data.document_id,
+            serde_json::json!({"enrichment_status": "processing"}),
+        )
+        .await?;
+
+        // Load PDF bytes from pdf_storage
+        let pdf_bytes = self.load_pdf_bytes(&data.pdf_id).await?;
+
+        // Run EdgeParser (text mode, entire PDF — text is cheap to generate)
+        let converter = EdgeParsePdfConverter::default();
+        let full_text = match converter
+            .convert(&pdf_bytes, &PdfConversionConfig::default())
+            .await
+        {
+            Ok(text) => text,
+            Err(e) => {
+                warn!(
+                    document_id = %data.document_id,
+                    "EdgeParser failed, marking enrichment as skipped: {}", e
+                );
+                self.write_metadata(
+                    &data.document_id,
+                    serde_json::json!({
+                        "enrichment_status": "skipped",
+                        "enrichment_error": format!("EdgeParser error: {}", e),
+                    }),
+                )
+                .await?;
+                return Ok(serde_json::json!({"enrichment_status": "skipped"}));
+            }
+        };
+
+        if full_text.trim().is_empty() {
+            self.write_metadata(
+                &data.document_id,
+                serde_json::json!({"enrichment_status": "skipped"}),
+            )
+            .await?;
+            return Ok(serde_json::json!({"enrichment_status": "skipped"}));
+        }
+
+        // Truncate: MAX_TEXT_CHARS ≈ first 5 PDF pages
+        let text = if full_text.len() > MAX_TEXT_CHARS {
+            &full_text[..MAX_TEXT_CHARS]
+        } else {
+            full_text.as_str()
+        };
+
+        // Call VLM. The worker pool retries the whole task on failure;
+        // we do one internal retry only for JSON-parse errors (model artifact).
+        let result = match self.call_vlm(text).await {
+            Ok(r) => r,
+            Err(first_err) => {
+                warn!(
+                    document_id = %data.document_id,
+                    "VLM call failed ({}), retrying once", first_err
+                );
+                self.call_vlm(text).await.map_err(|e| {
+                    TaskError::Processing(format!("VLM enrichment failed after retry: {}", e))
+                })?
+            }
+        };
+
+        let keywords_capped: Vec<String> = result.keywords.into_iter().take(10).collect();
+
+        self.write_metadata(
+            &data.document_id,
+            serde_json::json!({
+                "enrichment_status": "completed",
+                "enrichment_summary": result.summary,
+                "enrichment_topic": result.topic,
+                "enrichment_language": result.language,
+                "enrichment_keywords": keywords_capped,
+                "enrichment_completed_at": chrono::Utc::now().to_rfc3339(),
+                "enrichment_error": null,
+            }),
+        )
+        .await?;
+
+        info!(
+            document_id = %data.document_id,
+            topic = %result.topic,
+            language = %result.language,
+            "Metadata enrichment completed"
+        );
+
+        Ok(serde_json::json!({
+            "enrichment_status": "completed",
+            "topic": result.topic,
+            "language": result.language,
+        }))
+    }
+
+    async fn on_permanent_failure(&self, task: &Task, error_msg: &str) {
+        if let Ok(data) = serde_json::from_value::<MetadataEnrichData>(task.task_data.clone()) {
+            let _ = self
+                .write_metadata(
+                    &data.document_id,
+                    serde_json::json!({
+                        "enrichment_status": "failed",
+                        "enrichment_error": error_msg,
+                    }),
+                )
+                .await;
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Check `PdfConversionConfig::default()` exists**
+
+```bash
+cd /home/romy/workspace/edgequake-romy/edgequake
+grep -n "Default\|default()" crates/edgequake-pdf/src/backend/mod.rs | head -10
+```
+
+If `PdfConversionConfig` does not derive `Default`, add `#[derive(Default)]` to it in `crates/edgequake-pdf/src/backend/mod.rs`.
+
+- [ ] **Step 3: Add missing imports to `Cargo.toml` of edgequake-api (if needed)**
+
+```bash
+grep "edgequake-pdf\|edgequake-storage\|chrono" crates/edgequake-api/Cargo.toml | head -10
+```
+
+`edgequake-pdf`, `edgequake-storage`, `reqwest`, and `chrono` must all be present. Add any missing ones following the existing version patterns.
+
+- [ ] **Step 4: Compile check**
+
+```bash
+cd /home/romy/workspace/edgequake-romy/edgequake
+cargo check -p edgequake-api 2>&1 | tail -30
+```
+
+Expected: compiles cleanly. Fix any type/import errors before proceeding.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/romy/workspace/edgequake-romy/edgequake
+git add crates/edgequake-api/src/processor/metadata_enrich.rs \
+        crates/edgequake-pdf/src/backend/mod.rs
+git commit -m "feat(api): add MetadataEnrichProcessor with EdgeParser + VLM enrichment"
+```
+
+---
+
+## Task 4: Add `enrich_queue` to `AppState`
+
+**Files:**
+- Modify: `edgequake/crates/edgequake-api/src/state/mod.rs`
+- Modify: `edgequake/crates/edgequake-api/src/state/postgres.rs`
+- Modify: `edgequake/crates/edgequake-api/src/state/memory.rs`
+
+- [ ] **Step 1: Add field to `AppState` struct**
+
+In `edgequake/crates/edgequake-api/src/state/mod.rs`, find the `pub struct AppState` block (line ~118). After the existing `pub task_queue: SharedTaskQueue,` field, add:
+
+```rust
+    /// Dedicated queue for metadata enrichment tasks (separate from main pipeline).
+    pub enrich_queue: SharedTaskQueue,
+```
+
+- [ ] **Step 2: Initialize in `postgres.rs`**
+
+In `edgequake/crates/edgequake-api/src/state/postgres.rs`, find where `task_queue` is created (line ~307):
+
+```rust
+let task_queue = Arc::new(edgequake_tasks::queue::ChannelTaskQueue::new(100));
+```
+
+Directly after it, add:
+
+```rust
+let enrich_queue = Arc::new(edgequake_tasks::queue::ChannelTaskQueue::new(200));
+```
+
+Then find the `AppState { ... }` construction (look for `task_queue,`) and add `enrich_queue,` next to it.
+
+- [ ] **Step 3: Initialize in `memory.rs`**
+
+Repeat the same change in `edgequake/crates/edgequake-api/src/state/memory.rs`. Search for `task_queue` and add `enrich_queue` in the same pattern.
+
+- [ ] **Step 4: Compile check**
+
+```bash
+cd /home/romy/workspace/edgequake-romy/edgequake
+cargo check -p edgequake-api 2>&1 | tail -30
+```
+
+Expected: any structs that construct `AppState` will fail with missing field errors — fix each one by adding `enrich_queue: Arc::clone(&state.enrich_queue)` or equivalent. Run `grep -rn "AppState {" crates/edgequake-api/src/` to find all construction sites.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/romy/workspace/edgequake-romy/edgequake
+git add crates/edgequake-api/src/state/mod.rs \
+        crates/edgequake-api/src/state/postgres.rs \
+        crates/edgequake-api/src/state/memory.rs
+git commit -m "feat(api): add enrich_queue to AppState for dedicated enrichment workers"
+```
+
+---
+
+## Task 5: Enqueue enrichment task at PDF upload
+
+**Files:**
+- Modify: `edgequake/crates/edgequake-api/src/handlers/pdf_upload/helpers.rs`
+
+The key change: pre-generate a `document_id` UUID so both the enrichment task and the `PdfProcessing` task share the same metadata record. Pass this as `existing_document_id` in `PdfProcessingData`.
+
+- [ ] **Step 1: Write failing test**
+
+Add the following to `edgequake/crates/edgequake-api/tests/e2e_metadata_enrichment_enqueue.rs` (create file):
+
+```rust
+//! Verifies that a PDF upload enqueues both a PdfProcessing and a MetadataEnrich task.
+
+#[cfg(feature = "postgres")]
+mod tests {
+    // This is a compile-level test: verify that MetadataEnrichData can be round-tripped
+    // through serde (the same path the upload handler takes when building the task).
+    use edgequake_tasks::{MetadataEnrichData, TaskType};
+    use uuid::Uuid;
+
+    #[test]
+    fn test_metadata_enrich_data_round_trip() {
+        let doc_id = Uuid::new_v4().to_string();
+        let pdf_id = Uuid::new_v4();
+        let tenant_id = Uuid::new_v4();
+        let workspace_id = Uuid::new_v4();
+
+        let data = MetadataEnrichData {
+            document_id: doc_id.clone(),
+            pdf_id,
+            tenant_id,
+            workspace_id,
+            max_pages: 5,
+        };
+
+        let val = serde_json::to_value(&data).unwrap();
+        let back: MetadataEnrichData = serde_json::from_value(val).unwrap();
+
+        assert_eq!(back.document_id, doc_id);
+        assert_eq!(back.pdf_id, pdf_id);
+        assert_eq!(back.max_pages, 5);
+    }
+
+    #[test]
+    fn test_task_type_display() {
+        assert_eq!(TaskType::MetadataEnrich.to_string(), "metadata_enrich");
+    }
+}
+```
+
+Run:
+
+```bash
+cd /home/romy/workspace/edgequake-romy/edgequake
+cargo test -p edgequake-api test_metadata_enrich_data_round_trip 2>&1 | tail -20
+```
+
+Expected: PASS (these don't touch helpers.rs yet — they just validate the types).
+
+- [ ] **Step 2: Modify `create_pdf_processing_task` in `helpers.rs`**
+
+In `edgequake/crates/edgequake-api/src/handlers/pdf_upload/helpers.rs`:
+
+1. Add `MetadataEnrichData` to the existing imports from `edgequake_tasks`:
+
+```rust
+use edgequake_tasks::{MetadataEnrichData, PdfProcessingData, Task, TaskStatus, TaskType};
+```
+
+2. Change the function signature to return `(track_id, document_id)` — both are needed by callers:
+
+```rust
+pub(super) async fn create_pdf_processing_task(
+    state: &AppState,
+    context: &TenantContext,
+    pdf_id: Uuid,
+    options: &PdfUploadOptions,
+    workspace: Option<&Workspace>,
+) -> ApiResult<(String, String)> {   // (track_id, document_id)
+```
+
+3. Inside the function, generate `document_id` before building `task_data`:
+
+```rust
+    // Pre-generate document_id so enrichment and processing tasks share the same
+    // metadata record. The PdfProcessing processor uses existing_document_id to
+    // avoid creating a duplicate on retry.
+    let document_id = Uuid::new_v4().to_string();
+
+    let task_data = PdfProcessingData {
+        pdf_id,
+        tenant_id,
+        workspace_id,
+        enable_vision: options.enable_vision,
+        vision_provider: options.resolved_vision_provider(),
+        vision_model: if options.resolved_backend(workspace)
+            == edgequake_pdf::PdfParserBackend::Vision
+        {
+            Some(options.vision_model())
+        } else {
+            None
+        },
+        existing_document_id: Some(document_id.clone()),  // ← share the pre-generated ID
+        pdf_parser_backend: options.resolved_backend(workspace),
+        restart_from_scratch: false,
+    };
+```
+
+4. After the existing `state.task_queue.send(task).await?;`, enqueue the enrichment task:
+
+```rust
+    // Enqueue metadata enrichment task to the dedicated enrichment pool.
+    // This runs before (and independently of) the full PdfProcessing pipeline.
+    let enrich_data = MetadataEnrichData {
+        document_id: document_id.clone(),
+        pdf_id,
+        tenant_id,
+        workspace_id,
+        max_pages: 5,
+    };
+    let enrich_task = Task {
+        track_id: format!("metadata_enrich-{}", Uuid::new_v4()),
+        tenant_id,
+        workspace_id,
+        task_type: TaskType::MetadataEnrich,
+        status: TaskStatus::Pending,
+        created_at: Utc::now(),
+        updated_at: Utc::now(),
+        started_at: None,
+        completed_at: None,
+        error_message: None,
+        error: None,
+        retry_count: 0,
+        max_retries: 3,
+        consecutive_timeout_failures: 0,
+        circuit_breaker_tripped: false,
+        task_data: serde_json::to_value(&enrich_data)
+            .map_err(|e| ApiError::Internal(format!("Failed to serialize enrich data: {}", e)))?,
+        metadata: None,
+        progress: None,
+        result: None,
+    };
+
+    // Store enrichment task in DB so it survives restarts
+    state
+        .task_storage
+        .create_task(&enrich_task)
+        .await
+        .map_err(|e| ApiError::Internal(format!("Failed to create enrichment task: {}", e)))?;
+
+    state
+        .enrich_queue
+        .send(enrich_task)
+        .await
+        .map_err(|e| ApiError::Internal(format!("Failed to queue enrichment task: {}", e)))?;
+
+    // Write initial enrichment_status to metadata so clients can poll it
+    let metadata_key = format!("{}-metadata", document_id);
+    let _ = state
+        .kv_storage
+        .upsert(&[(metadata_key, serde_json::json!({"enrichment_status": "pending"}))])
+        .await;
+```
+
+5. Change the return value at the end of the function:
+
+```rust
+    Ok((track_id, document_id))
+```
+
+- [ ] **Step 3: Fix callers of `create_pdf_processing_task`**
+
+Find every call site:
+
+```bash
+grep -rn "create_pdf_processing_task" /home/romy/workspace/edgequake-romy/edgequake/crates/
+```
+
+Each call currently expects a `String` (track_id). Update them to destructure the tuple:
+
+```rust
+let (track_id, _document_id) = create_pdf_processing_task(state, &context, pdf_id, &options, workspace.as_ref()).await?;
+```
+
+(Or use `document_id` in the response if the handler wants to return it.)
+
+- [ ] **Step 4: Compile check**
+
+```bash
+cd /home/romy/workspace/edgequake-romy/edgequake
+cargo check -p edgequake-api 2>&1 | tail -30
+```
+
+Expected: clean. Fix any remaining type errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/romy/workspace/edgequake-romy/edgequake
+git add crates/edgequake-api/src/handlers/pdf_upload/helpers.rs \
+        crates/edgequake-api/src/handlers/pdf_upload/upload.rs \
+        tests/e2e_metadata_enrichment_enqueue.rs
+git commit -m "feat(api): enqueue MetadataEnrich task alongside PdfProcessing on PDF upload"
+```
+
+---
+
+## Task 6: Start enrichment worker pool in `main.rs`
+
+**Files:**
+- Modify: `edgequake/src/main.rs`
+
+- [ ] **Step 1: Read enrichment config and start pool after the main worker pool**
+
+In `edgequake/src/main.rs`, find the section where the main `worker_pool.start()` is called (around line 640). Directly after it, add:
+
+```rust
+    // ── Enrichment worker pool ────────────────────────────────────────────────
+    // Separate pool with 4 workers (default) dedicated exclusively to
+    // MetadataEnrich tasks. Workers are IO-bound (one VLM call per task)
+    // so 4 is sufficient for most deployments. Override via ENRICHMENT_CONCURRENT.
+    let enrichment_config = edgequake_api::processor::enrichment_config::EnrichmentConfig::from_env();
+    let enrich_concurrent = enrichment_config.concurrent;
+
+    let enrich_processor = Arc::new(
+        edgequake_api::processor::metadata_enrich::MetadataEnrichProcessor::new(
+            Arc::clone(&state.kv_storage) as Arc<dyn edgequake_storage::traits::KVStorage>,
+            state.pdf_storage.as_ref().map(Arc::clone),
+            enrichment_config,
+        ),
+    );
+
+    let enrich_pool_config = WorkerPoolConfig {
+        num_workers: enrich_concurrent,
+        auto_retry: true,
+        initial_retry_delay_ms: 1_000,
+        max_retry_delay_ms: 10_000,
+        backoff_multiplier: 2.0,
+        max_tasks_per_tenant: enrich_concurrent, // no fairness limit needed for enrichment
+        processing_timeout_secs: 300, // 5 min is plenty for 5-page enrichment
+    };
+
+    let mut enrich_pool = WorkerPool::new(
+        enrich_pool_config,
+        Arc::clone(&state.enrich_queue) as Arc<dyn edgequake_tasks::TaskQueue>,
+        Arc::clone(&state.task_storage) as Arc<dyn edgequake_tasks::TaskStorage>,
+        enrich_processor,
+    );
+
+    info!(
+        "Starting enrichment worker pool with {} workers",
+        enrich_concurrent
+    );
+    enrich_pool.start();
+```
+
+- [ ] **Step 2: Add `enrich_pool` to the shutdown sequence**
+
+Find the server shutdown logic in `main.rs` (look for `worker_pool.shutdown()` or server termination). Add:
+
+```rust
+    enrich_pool.shutdown().await;
+```
+
+alongside the existing `worker_pool.shutdown().await;`.
+
+- [ ] **Step 3: Requeue pending enrichment tasks on startup**
+
+The existing `requeue_pending_tasks` function loads ALL pending tasks into `state.task_queue`. We need enrichment tasks to go into `state.enrich_queue` instead. Find the call to `requeue_pending_tasks` and modify it, or add a second call:
+
+```rust
+    // Requeue pending enrichment tasks into the enrichment queue specifically
+    if let Err(e) = requeue_pending_tasks(
+        Arc::clone(&state.task_storage) as Arc<dyn TaskStorage>,
+        Arc::clone(&state.enrich_queue) as Arc<dyn TaskQueue>,
+        // Pass a task type filter if the function supports it, otherwise add filtering
+    ).await {
+        warn!("Failed to requeue pending enrichment tasks (non-fatal): {}", e);
+    }
+```
+
+Check the signature of `requeue_pending_tasks`. If it doesn't filter by task type, add a `TaskType` filter parameter or create a `requeue_pending_enrichment_tasks` variant that filters for `TaskType::MetadataEnrich`. Look at the existing `TaskFilter` struct:
+
+```bash
+grep -n "TaskFilter\|task_type" /home/romy/workspace/edgequake-romy/edgequake/crates/edgequake-tasks/src/storage.rs | head -20
+```
+
+- [ ] **Step 4: Full compile check**
+
+```bash
+cd /home/romy/workspace/edgequake-romy/edgequake
+cargo build 2>&1 | tail -30
+```
+
+Expected: clean build.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/romy/workspace/edgequake-romy/edgequake
+git add src/main.rs
+git commit -m "feat: start dedicated enrichment worker pool on server startup"
+```
+
+---
+
+## Task 7: End-to-end smoke test
+
+**Files:**
+- Create: `edgequake/crates/edgequake-api/tests/e2e_enrichment_processor.rs`
+
+This test exercises `MetadataEnrichProcessor` with a mock VLM server and an in-memory storage mock. It verifies that metadata fields are written correctly.
+
+- [ ] **Step 1: Write the test**
+
+Create `edgequake/crates/edgequake-api/tests/e2e_enrichment_processor.rs`:
+
+```rust
+//! Tests that MetadataEnrichProcessor writes the correct metadata fields.
+//! Uses a real in-memory KV storage and mocks the VLM HTTP endpoint with wiremock.
+
+// NOTE: This test requires the `wiremock` dev-dependency.
+// Check Cargo.toml: if absent, add `wiremock = "0.6"` under [dev-dependencies].
+
+#[cfg(test)]
+mod tests {
+    use edgequake_tasks::{MetadataEnrichData, TaskProcessor, TaskType};
+    use edgequake_tasks::types::Task;
+    use uuid::Uuid;
+
+    /// Verify MetadataEnrichData deserialization from JSON (worker-path simulation).
+    #[test]
+    fn test_enrich_data_from_task_data() {
+        let document_id = Uuid::new_v4().to_string();
+        let pdf_id = Uuid::new_v4();
+        let tenant_id = Uuid::new_v4();
+        let workspace_id = Uuid::new_v4();
+
+        let data = MetadataEnrichData {
+            document_id: document_id.clone(),
+            pdf_id,
+            tenant_id,
+            workspace_id,
+            max_pages: 5,
+        };
+
+        let task_data = serde_json::to_value(&data).unwrap();
+        let recovered: MetadataEnrichData = serde_json::from_value(task_data).unwrap();
+
+        assert_eq!(recovered.document_id, document_id);
+        assert_eq!(recovered.max_pages, 5);
+    }
+
+    /// Verify that `on_permanent_failure` writes `enrichment_status: "failed"`.
+    #[tokio::test]
+    async fn test_on_permanent_failure_writes_failed_status() {
+        use edgequake_api::processor::enrichment_config::EnrichmentConfig;
+        use edgequake_api::processor::metadata_enrich::MetadataEnrichProcessor;
+        use edgequake_storage::MemoryKVStorage; // exported from crate root
+        use std::sync::Arc;
+
+        let kv = Arc::new(MemoryKVStorage::new());
+        let config = EnrichmentConfig {
+            vlm_base_url: "http://localhost:1".to_string(), // unreachable — not called
+            vlm_model: "test".to_string(),
+            max_pages: 5,
+            concurrent: 1,
+        };
+        let processor = MetadataEnrichProcessor::new(Arc::clone(&kv) as Arc<_>, None, config);
+
+        let document_id = Uuid::new_v4().to_string();
+        let task_data = serde_json::to_value(MetadataEnrichData {
+            document_id: document_id.clone(),
+            pdf_id: Uuid::new_v4(),
+            tenant_id: Uuid::new_v4(),
+            workspace_id: Uuid::new_v4(),
+            max_pages: 5,
+        })
+        .unwrap();
+
+        let task = Task {
+            track_id: format!("metadata_enrich-{}", Uuid::new_v4()),
+            tenant_id: Uuid::new_v4(),
+            workspace_id: Uuid::new_v4(),
+            task_type: TaskType::MetadataEnrich,
+            status: edgequake_tasks::TaskStatus::Failed,
+            created_at: chrono::Utc::now(),
+            updated_at: chrono::Utc::now(),
+            started_at: None,
+            completed_at: None,
+            error_message: None,
+            error: None,
+            retry_count: 3,
+            max_retries: 3,
+            consecutive_timeout_failures: 0,
+            circuit_breaker_tripped: false,
+            task_data,
+            metadata: None,
+            progress: None,
+            result: None,
+        };
+
+        processor.on_permanent_failure(&task, "retries exhausted").await;
+
+        // Check that KV was updated with failed status
+        let key = format!("{}-metadata", document_id);
+        let stored = kv.get_by_id(&key).await.unwrap().unwrap();
+        assert_eq!(stored["enrichment_status"], "failed");
+        assert!(stored["enrichment_error"].as_str().unwrap().contains("retries exhausted"));
+    }
+}
+```
+
+- [ ] **Step 2: Check `MemoryKVStorage` export path**
+
+```bash
+grep -rn "pub struct MemoryKVStorage\|pub use.*MemoryKVStorage" \
+  /home/romy/workspace/edgequake-romy/edgequake/crates/edgequake-storage/src/ | head -5
+```
+
+Adjust the import path in the test if it differs.
+
+- [ ] **Step 3: Run the tests**
+
+```bash
+cd /home/romy/workspace/edgequake-romy/edgequake
+cargo test -p edgequake-api test_on_permanent_failure_writes_failed_status 2>&1 | tail -20
+cargo test -p edgequake-api test_enrich_data_from_task_data 2>&1 | tail -20
+```
+
+Expected: both PASS.
+
+- [ ] **Step 4: Run full test suite to catch regressions**
+
+```bash
+cd /home/romy/workspace/edgequake-romy/edgequake
+cargo test -p edgequake-tasks -p edgequake-api 2>&1 | tail -40
+```
+
+Expected: all previously-passing tests still pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/romy/workspace/edgequake-romy/edgequake
+git add crates/edgequake-api/tests/e2e_enrichment_processor.rs \
+        tests/e2e_metadata_enrichment_enqueue.rs
+git commit -m "test: add MetadataEnrichProcessor unit and enqueue tests"
+```
+
+---
+
+## .env additions
+
+Add to `/home/romy/workspace/edgequake-romy/.env.example` (and your local `.env`):
+
+```env
+# PDF Metadata Enrichment Pipeline
+# Workers dedicated to pre-pipeline summary extraction
+ENRICHMENT_CONCURRENT=4
+# OpenAI-compatible local VLM endpoint
+ENRICHMENT_VLM_BASE_URL=http://localhost:11434/v1
+# Model name (must accept text input; vision capability not required)
+ENRICHMENT_VLM_MODEL=llava:7b
+# Number of PDF pages to extract text from for enrichment
+ENRICHMENT_MAX_PAGES=5
+```
+
+---
+
+## Verification Checklist (after all tasks)
+
+Run these to confirm the full feature works:
+
+```bash
+# 1. Compile cleanly
+cd /home/romy/workspace/edgequake-romy/edgequake
+cargo build 2>&1 | tail -5
+
+# 2. All unit tests pass
+cargo test -p edgequake-tasks -p edgequake-api 2>&1 | grep -E "FAILED|passed|failed" | tail -10
+
+# 3. Clippy clean
+cargo clippy -p edgequake-tasks -p edgequake-api --all-targets -- -D warnings 2>&1 | tail -20
+```
+
+Manual smoke test (requires running server + local Ollama):
+
+```bash
+# Upload a PDF
+curl -X POST http://localhost:8080/api/v1/documents/pdf \
+  -H "X-Workspace-ID: <workspace-id>" \
+  -F "file=@/path/to/sample.pdf"
+
+# Poll until enrichment_status = "completed" (should appear within ~10s)
+curl http://localhost:8080/api/v1/documents/<document-id> | jq '{
+  enrichment_status: .enrichment_status,
+  topic: .enrichment_topic,
+  summary: .enrichment_summary,
+  language: .enrichment_language,
+  keywords: .enrichment_keywords
+}'
+```

--- a/docs/superpowers/specs/2026-06-03-document-topic-grouping-design.md
+++ b/docs/superpowers/specs/2026-06-03-document-topic-grouping-design.md
@@ -1,0 +1,151 @@
+# Document Topic Grouping — Design Spec
+
+**Date:** 2026-06-03
+**Status:** Approved
+
+---
+
+## Overview
+
+Add a **Grouped by Topic** view to the document list that groups documents into collapsible accordion sections based on `enrichment_topic` — the topic field written by the PDF Metadata Enrichment Pipeline. A toggle button in the toolbar switches between the existing flat list and the new grouped view. All accordion groups start collapsed.
+
+---
+
+## Goals
+
+- Users can visually organise documents by automatically-extracted topic
+- Switching between flat list and grouped is instant (no API call)
+- No backend changes required
+- Documents without a topic (enrichment pending/skipped/failed) land in a "Tanpa Topic" group at the bottom
+
+---
+
+## Architecture & Data Flow
+
+```
+Document[] (already fetched by useDocumentQueries)
+        │
+        ▼
+useDocumentGrouping(documents, isGrouped)
+        │  groups by enrichment_topic, "Tanpa Topic" last
+        ▼
+Map<string, Document[]>   (ordered: alphabetical, "Tanpa Topic" last)
+        │
+        ▼  when isGrouped=true
+DocumentGroupAccordion × N    (collapsed by default)
+        └── DocumentTableRow  (same component as flat list)
+```
+
+Toggle state is persisted via the existing `useDocumentPreferences` hook (localStorage), so the mode survives a page refresh.
+
+---
+
+## Files
+
+| Action | Path | Responsibility |
+|---|---|---|
+| Modify | `src/types/index.ts` | Add `enrichment_topic`, `enrichment_status`, `enrichment_summary`, `enrichment_language`, `enrichment_keywords` to `Document` interface |
+| Create | `src/hooks/use-document-grouping.ts` | Pure grouping logic: takes `Document[]`, returns ordered `Map<string, Document[]>` |
+| Modify | `src/hooks/use-document-preferences.ts` | Add `groupedView: boolean` + `setGroupedView` |
+| Modify | `src/components/documents/document-toolbar-section.tsx` | Add List / Grouped toggle button pair |
+| Modify | `src/components/documents/document-table-section.tsx` | Conditionally render flat table or `DocumentGroupAccordion` list |
+| Create | `src/components/documents/document-group-accordion.tsx` | Accordion component for one topic group |
+
+---
+
+## Component Design
+
+### `useDocumentGrouping(documents)`
+
+```ts
+// Returns ordered Map: alphabetical topics first, "Tanpa Topic" last
+function useDocumentGrouping(documents: Document[]): Map<string, Document[]>
+```
+
+- Key `"Tanpa Topic"` for docs where `enrichment_topic` is `undefined`, `null`, or empty string
+- Sorts groups alphabetically; `"Tanpa Topic"` always last
+- Pure/memoized — no side effects
+
+### `useDocumentPreferences` addition
+
+```ts
+groupedView: boolean          // default false
+setGroupedView: (v: boolean) => void
+```
+
+Stored in localStorage under existing key pattern of this hook.
+
+### Toggle button (in `DocumentToolbarSection`)
+
+```
+[ ☰ List ]  [ ⊞ Grouped ]
+```
+
+- Two adjacent buttons, active one highlighted (same style as existing filter buttons)
+- Placed at the right side of the toolbar, before the existing action buttons
+
+### `DocumentGroupAccordion`
+
+Props:
+```ts
+{
+  topic: string           // group header label
+  documents: Document[]   // docs in this group
+  // all DocumentTableRow handlers passed through
+  selectedIds, onSelectOne, onRowClick, onRowDoubleClick, ...
+}
+```
+
+Behaviour:
+- Collapsed by default (`open` state starts `false`)
+- Header shows: topic name, doc count badge, chevron icon
+- "Tanpa Topic" header rendered in muted color (`text-muted-foreground`)
+- When expanded: renders existing `DocumentTableRow` for each doc (no duplication of row logic)
+- No select-all per group (keep it simple)
+
+### `DocumentTableSection` changes
+
+```tsx
+if (groupedView) {
+  // render DocumentGroupAccordion × N
+} else {
+  // existing flat table (unchanged)
+}
+```
+
+Pagination controls remain visible in both modes (flat list paginates as today; grouped view shows all fetched docs grouped).
+
+---
+
+## `Document` type additions
+
+```ts
+enrichment_status?: "pending" | "processing" | "completed" | "failed" | "skipped"
+enrichment_topic?: string
+enrichment_summary?: string
+enrichment_language?: string
+enrichment_keywords?: string[]
+enrichment_completed_at?: string
+enrichment_error?: string
+```
+
+---
+
+## Error / Edge Cases
+
+| Case | Behaviour |
+|---|---|
+| All docs have no topic | Single "Tanpa Topic" group |
+| Only 1 topic | Single accordion group |
+| `enrichment_status` = `"processing"` | Doc goes to "Tanpa Topic" (no topic yet) |
+| Search active in grouped mode | Filter applies before grouping — empty groups hidden |
+| Status filter active in grouped mode | Same: filter first, group after; empty groups hidden |
+
+---
+
+## Out of Scope
+
+- Editing or renaming topics from the UI
+- Server-side grouping / pagination per group
+- Select-all within a group
+- Drag-and-drop between groups

--- a/docs/superpowers/specs/2026-06-03-pdf-metadata-enrichment-design.md
+++ b/docs/superpowers/specs/2026-06-03-pdf-metadata-enrichment-design.md
@@ -1,0 +1,196 @@
+# PDF Metadata Enrichment Pipeline — Design Spec
+
+**Date:** 2026-06-03  
+**Status:** Approved  
+
+---
+
+## Overview
+
+Before the full Graph-RAG pipeline runs, extract a lightweight metadata summary
+(summary, topic, language, keywords) from the first 5 pages of a PDF using
+EdgeParser (text mode) and a locally-hosted OpenAI-compatible VLM. The enrichment
+runs async immediately after upload so users get a summary within seconds, before
+full processing completes.
+
+---
+
+## Goals
+
+- Summary available within seconds of upload (not after full pipeline)
+- No dependency on cloud VLM — uses local OpenAI-compatible endpoint
+- Enrichment failure never blocks the main pipeline
+- Max 4 concurrent enrichment tasks (configurable)
+
+---
+
+## Architecture & Flow
+
+```
+POST /upload (PDF)
+        │
+        ├─→ HTTP response immediately (document_id, status: "processing")
+        │
+        ├─→ Enqueue: MetadataEnrich task   ← dedicated pool, 4 workers
+        │       │
+        │       ├─ EdgeParser: extract text from pages 1–max_pages
+        │       ├─ Truncate to 8000 tokens
+        │       ├─ POST text to local VLM (OpenAI-compatible chat API)
+        │       ├─ Parse JSON response: {summary, topic, language, keywords}
+        │       └─ Write enrichment fields to KV document metadata
+        │
+        └─→ Enqueue: PdfProcessing task    ← main pool (unchanged)
+                Full chunking + graph extraction + embedding
+```
+
+Two separate worker pools. The enrichment pool (4 workers) handles only
+`MetadataEnrich` tasks. The main pool is untouched.
+
+Client polls `GET /api/v1/documents/{id}` to check `enrichment_status`.
+A WebSocket progress event `enrichment_completed` is also emitted when done.
+
+---
+
+## New Components
+
+### 1. `TaskType::MetadataEnrich`
+
+Added to `edgequake-tasks/src/types/status.rs`:
+
+```rust
+pub enum TaskType {
+    Upload, Insert, Scan, Reindex, PdfProcessing,
+    MetadataEnrich,
+}
+```
+
+Track ID prefix: `enrich-`.
+
+### 2. `MetadataEnrichData`
+
+New payload struct in `edgequake-tasks/src/types/data.rs`:
+
+```rust
+pub struct MetadataEnrichData {
+    pub document_id: String,   // key for KV content lookup: "{document_id}-content"
+    pub pdf_id: Option<Uuid>,  // set only when PDF went through pdf_storage path
+    pub tenant_id: Uuid,
+    pub workspace_id: Uuid,
+    pub max_pages: usize,      // default 5
+}
+```
+
+### 3. Enrichment Worker Pool
+
+Separate `WorkerPool` started in `main.rs` alongside the existing pool.
+Uses its own `ChannelTaskQueue`. Workers only receive `MetadataEnrich` tasks.
+
+Configuration via environment variables:
+
+| Variable | Default | Description |
+|---|---|---|
+| `ENRICHMENT_CONCURRENT` | `4` | Number of enrichment workers |
+| `ENRICHMENT_VLM_BASE_URL` | `http://localhost:11434/v1` | Local VLM OpenAI-compatible base URL |
+| `ENRICHMENT_VLM_MODEL` | `llava:7b` | Model name to use |
+| `ENRICHMENT_MAX_PAGES` | `5` | Max pages to extract text from |
+
+### 4. `MetadataEnrichProcessor`
+
+New struct implementing `TaskProcessor` in `edgequake-api/src/tasks/`.
+
+Steps:
+1. Load PDF content from KV storage: key `{document_id}-content`
+   (fallback: load binary via `pdf_id` from `pdf_storage` if `pdf_id` is set)
+2. Run EdgeParser in text mode on pages `1..=max_pages`
+3. If extracted text is empty → set `enrichment_status: "skipped"`, done
+4. Truncate text to 8000 tokens
+5. POST to local VLM with structured prompt (see below)
+6. Parse JSON response
+7. Write enrichment fields to KV document metadata
+8. Emit WebSocket event `enrichment_completed`
+
+---
+
+## VLM Prompt
+
+Fixed prompt, not customisable per request:
+
+```
+You are a document analyst. Given the text from the first pages of a document,
+extract structured metadata. Respond ONLY with valid JSON, no markdown, no explanation:
+{
+  "summary": "2-3 paragraph summary written in the document's own language",
+  "topic": "single short topic phrase",
+  "language": "ISO 639-1 code (e.g. en, id, fr)",
+  "keywords": ["up to 10 keywords"]
+}
+
+Document text:
+<extracted text>
+```
+
+---
+
+## Document Metadata Fields (KV Storage)
+
+New fields written alongside existing metadata on the same `{document_id}-metadata` key:
+
+```json
+{
+  "enrichment_status": "pending | processing | completed | failed | skipped",
+  "enrichment_summary": "...",
+  "enrichment_topic": "...",
+  "enrichment_language": "id",
+  "enrichment_keywords": ["keyword1", "keyword2"],
+  "enrichment_completed_at": "2026-06-03T10:00:00Z",
+  "enrichment_error": null
+}
+```
+
+`enrichment_status` values:
+
+| Value | Meaning |
+|---|---|
+| `pending` | Task enqueued, not started |
+| `processing` | Worker is running |
+| `completed` | Summary available |
+| `failed` | All retries exhausted; see `enrichment_error` |
+| `skipped` | PDF has no extractable text (scan-only) or is not a PDF |
+
+Non-PDF uploads (txt, md, etc.) do not enqueue a `MetadataEnrich` task.
+Their `enrichment_status` is omitted from the metadata response.
+
+---
+
+## Error Handling
+
+| Condition | Action |
+|---|---|
+| VLM unreachable | Retry 3× with exponential backoff (1s, 2s, 4s); then `failed` |
+| VLM returns invalid JSON | Retry once with stricter prompt; then `failed` |
+| PDF text empty (scan-only) | `skipped` immediately, no retry |
+| PDF not yet in storage when task starts | Retry with 2s delay, max 3× |
+| Enrichment `failed` | Main pipeline is unaffected and continues normally |
+
+Enrichment failure **never** blocks or fails the main `PdfProcessing` task.
+
+---
+
+## Upload Handler Changes
+
+In `edgequake-api/src/handlers/documents/upload/` (both `file_upload.rs` and PDF path):
+
+1. After storing initial metadata, detect if the file is a PDF
+2. If PDF: enqueue `MetadataEnrich` task to the enrichment queue
+3. Set `enrichment_status: "pending"` in initial metadata
+4. Continue as today: enqueue `PdfProcessing` to main queue
+
+---
+
+## Out of Scope
+
+- Enrichment for non-PDF formats (txt, md, images) — not in this spec
+- User-configurable prompts per workspace
+- Re-running enrichment on demand (can be added later)
+- S3 source integration — separate spec
+- OpenRouter / MCP provider integration — separate spec

--- a/edgequake/Cargo.lock
+++ b/edgequake/Cargo.lock
@@ -1697,6 +1697,7 @@ dependencies = [
  "futures-util",
  "hex",
  "lazy_static",
+ "num_cpus",
  "rand 0.9.4",
  "reqwest",
  "serde",

--- a/edgequake/crates/edgequake-api/Cargo.toml
+++ b/edgequake/crates/edgequake-api/Cargo.toml
@@ -14,6 +14,7 @@ postgres = ["edgequake-storage/postgres", "edgequake-core/postgres", "dep:sqlx"]
 vision = []
 
 [dependencies]
+num_cpus = { workspace = true }
 edgequake-core = { path = "../edgequake-core" }
 edgequake-pdf = { workspace = true }
 edgequake-storage = { path = "../edgequake-storage" }

--- a/edgequake/crates/edgequake-api/src/handlers/documents/query/detail.rs
+++ b/edgequake/crates/edgequake-api/src/handlers/documents/query/detail.rs
@@ -348,6 +348,7 @@ pub async fn get_document(
                 .map(|s| s.to_string())
                 .unwrap_or_else(|| "completed".to_string()),
             obj.get("error_message")
+                .or_else(|| obj.get("error_details"))
                 .and_then(|v| v.as_str())
                 .map(|s| s.to_string()),
             obj.get("source_type")

--- a/edgequake/crates/edgequake-api/src/handlers/documents/query/detail.rs
+++ b/edgequake/crates/edgequake-api/src/handlers/documents/query/detail.rs
@@ -411,6 +411,28 @@ pub async fn get_document(
         )
     };
 
+    // Extract enrichment fields from metadata
+    let enrichment_status = meta_obj
+        .and_then(|o| o.get("enrichment_status"))
+        .and_then(|v| v.as_str())
+        .map(String::from);
+    let enrichment_topic = meta_obj
+        .and_then(|o| o.get("enrichment_topic"))
+        .and_then(|v| v.as_str())
+        .map(String::from);
+    let enrichment_tags = meta_obj
+        .and_then(|o| o.get("enrichment_tags"))
+        .and_then(|v| v.as_array())
+        .map(|arr| arr.iter().filter_map(|v| v.as_str().map(String::from)).collect());
+    let enrichment_summary = meta_obj
+        .and_then(|o| o.get("enrichment_summary"))
+        .and_then(|v| v.as_str())
+        .map(String::from);
+    let enrichment_language = meta_obj
+        .and_then(|o| o.get("enrichment_language"))
+        .and_then(|v| v.as_str())
+        .map(String::from);
+
     Ok(Json(DocumentDetailResponse {
         id: document_id,
         title,
@@ -437,5 +459,10 @@ pub async fn get_document(
         metadata: custom_metadata,
         // OODA-50: Use pdf_id from metadata for PDF viewer
         pdf_id,
+        enrichment_status,
+        enrichment_topic,
+        enrichment_tags,
+        enrichment_summary,
+        enrichment_language,
     }))
 }

--- a/edgequake/crates/edgequake-api/src/handlers/documents/query/list.rs
+++ b/edgequake/crates/edgequake-api/src/handlers/documents/query/list.rs
@@ -185,9 +185,10 @@ pub async fn list_documents(
                     .and_then(|v| v.as_str())
                     .map(|s| s.to_string());
 
-                // Get error_message
+                // Get error_message; fall back to error_details (set for partial_failure)
                 meta.error_message = obj
                     .get("error_message")
+                    .or_else(|| obj.get("error_details"))
                     .and_then(|v| v.as_str())
                     .map(|s| s.to_string());
 

--- a/edgequake/crates/edgequake-api/src/handlers/documents/query/list.rs
+++ b/edgequake/crates/edgequake-api/src/handlers/documents/query/list.rs
@@ -129,6 +129,13 @@ pub async fn list_documents(
         stage_progress: Option<f32>,
         stage_message: Option<String>,
         pdf_id: Option<String>,
+        // Enrichment pipeline fields
+        enrichment_status: Option<String>,
+        enrichment_topic: Option<String>,
+        enrichment_summary: Option<String>,
+        enrichment_language: Option<String>,
+        enrichment_keywords: Option<Vec<String>>,
+        enrichment_completed_at: Option<String>,
     }
 
     let mut doc_metadata: std::collections::HashMap<String, DocMetadata> =
@@ -282,6 +289,36 @@ pub async fn list_documents(
                     .and_then(|v| v.as_str())
                     .map(|s| s.to_string());
 
+                // Enrichment pipeline fields
+                meta.enrichment_status = obj
+                    .get("enrichment_status")
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.to_string());
+                meta.enrichment_topic = obj
+                    .get("enrichment_topic")
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.to_string());
+                meta.enrichment_summary = obj
+                    .get("enrichment_summary")
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.to_string());
+                meta.enrichment_language = obj
+                    .get("enrichment_language")
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.to_string());
+                meta.enrichment_keywords = obj
+                    .get("enrichment_keywords")
+                    .and_then(|v| v.as_array())
+                    .map(|arr| {
+                        arr.iter()
+                            .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                            .collect()
+                    });
+                meta.enrichment_completed_at = obj
+                    .get("enrichment_completed_at")
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.to_string());
+
                 doc_metadata.insert(id.to_string(), meta);
             }
         }
@@ -335,6 +372,13 @@ pub async fn list_documents(
                 stage_progress: meta.stage_progress,
                 stage_message: meta.stage_message,
                 pdf_id: meta.pdf_id,
+                // Enrichment fields
+                enrichment_status: meta.enrichment_status,
+                enrichment_topic: meta.enrichment_topic,
+                enrichment_summary: meta.enrichment_summary,
+                enrichment_language: meta.enrichment_language,
+                enrichment_keywords: meta.enrichment_keywords,
+                enrichment_completed_at: meta.enrichment_completed_at,
             })
         })
         .collect();
@@ -370,6 +414,13 @@ pub async fn list_documents(
             stage_progress: meta.stage_progress,
             stage_message: meta.stage_message,
             pdf_id: meta.pdf_id,
+            // Enrichment fields
+            enrichment_status: meta.enrichment_status,
+            enrichment_topic: meta.enrichment_topic,
+            enrichment_summary: meta.enrichment_summary,
+            enrichment_language: meta.enrichment_language,
+            enrichment_keywords: meta.enrichment_keywords,
+            enrichment_completed_at: meta.enrichment_completed_at,
         });
     }
 

--- a/edgequake/crates/edgequake-api/src/handlers/documents/query/list.rs
+++ b/edgequake/crates/edgequake-api/src/handlers/documents/query/list.rs
@@ -132,6 +132,7 @@ pub async fn list_documents(
         // Enrichment pipeline fields
         enrichment_status: Option<String>,
         enrichment_topic: Option<String>,
+        enrichment_tags: Option<Vec<String>>,
         enrichment_summary: Option<String>,
         enrichment_language: Option<String>,
         enrichment_keywords: Option<Vec<String>>,
@@ -298,6 +299,14 @@ pub async fn list_documents(
                     .get("enrichment_topic")
                     .and_then(|v| v.as_str())
                     .map(|s| s.to_string());
+                meta.enrichment_tags = obj
+                    .get("enrichment_tags")
+                    .and_then(|v| v.as_array())
+                    .map(|arr| {
+                        arr.iter()
+                            .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                            .collect()
+                    });
                 meta.enrichment_summary = obj
                     .get("enrichment_summary")
                     .and_then(|v| v.as_str())
@@ -375,6 +384,7 @@ pub async fn list_documents(
                 // Enrichment fields
                 enrichment_status: meta.enrichment_status,
                 enrichment_topic: meta.enrichment_topic,
+                enrichment_tags: meta.enrichment_tags,
                 enrichment_summary: meta.enrichment_summary,
                 enrichment_language: meta.enrichment_language,
                 enrichment_keywords: meta.enrichment_keywords,
@@ -417,6 +427,7 @@ pub async fn list_documents(
             // Enrichment fields
             enrichment_status: meta.enrichment_status,
             enrichment_topic: meta.enrichment_topic,
+            enrichment_tags: meta.enrichment_tags,
             enrichment_summary: meta.enrichment_summary,
             enrichment_language: meta.enrichment_language,
             enrichment_keywords: meta.enrichment_keywords,

--- a/edgequake/crates/edgequake-api/src/handlers/documents/query/track_status.rs
+++ b/edgequake/crates/edgequake-api/src/handlers/documents/query/track_status.rs
@@ -145,6 +145,14 @@ pub async fn get_track_status(
                         .get("enrichment_topic")
                         .and_then(|v| v.as_str())
                         .map(String::from),
+                    enrichment_tags: obj
+                        .get("enrichment_tags")
+                        .and_then(|v| v.as_array())
+                        .map(|arr| {
+                            arr.iter()
+                                .filter_map(|v| v.as_str().map(String::from))
+                                .collect()
+                        }),
                     enrichment_summary: obj
                         .get("enrichment_summary")
                         .and_then(|v| v.as_str())

--- a/edgequake/crates/edgequake-api/src/handlers/documents/query/track_status.rs
+++ b/edgequake/crates/edgequake-api/src/handlers/documents/query/track_status.rs
@@ -136,6 +136,35 @@ pub async fn get_track_status(
                         .and_then(|v| v.as_str())
                         .map(String::from),
                     pdf_id: obj.get("pdf_id").and_then(|v| v.as_str()).map(String::from),
+                    // Enrichment fields
+                    enrichment_status: obj
+                        .get("enrichment_status")
+                        .and_then(|v| v.as_str())
+                        .map(String::from),
+                    enrichment_topic: obj
+                        .get("enrichment_topic")
+                        .and_then(|v| v.as_str())
+                        .map(String::from),
+                    enrichment_summary: obj
+                        .get("enrichment_summary")
+                        .and_then(|v| v.as_str())
+                        .map(String::from),
+                    enrichment_language: obj
+                        .get("enrichment_language")
+                        .and_then(|v| v.as_str())
+                        .map(String::from),
+                    enrichment_keywords: obj
+                        .get("enrichment_keywords")
+                        .and_then(|v| v.as_array())
+                        .map(|arr| {
+                            arr.iter()
+                                .filter_map(|v| v.as_str().map(String::from))
+                                .collect()
+                        }),
+                    enrichment_completed_at: obj
+                        .get("enrichment_completed_at")
+                        .and_then(|v| v.as_str())
+                        .map(String::from),
                 });
             }
         }

--- a/edgequake/crates/edgequake-api/src/handlers/documents/recovery/enrich.rs
+++ b/edgequake/crates/edgequake-api/src/handlers/documents/recovery/enrich.rs
@@ -1,0 +1,162 @@
+//! Trigger metadata enrichment for a single document.
+//!
+//! Allows users to enrich documents that were uploaded before the enrichment
+//! pipeline existed, or that previously failed/skipped enrichment.
+
+use axum::extract::{Path, State};
+use axum::Json;
+use chrono::Utc;
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+use uuid::Uuid;
+
+use crate::error::{ApiError, ApiResult};
+use crate::middleware::TenantContext;
+use crate::state::AppState;
+use edgequake_tasks::{MetadataEnrichData, Task, TaskStatus, TaskType};
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct EnrichDocumentResponse {
+    pub document_id: String,
+    pub track_id: String,
+    pub message: String,
+}
+
+/// Trigger metadata enrichment for a document.
+///
+/// Enqueues a MetadataEnrich task for any document that has a linked PDF,
+/// regardless of its current enrichment_status. Useful for documents uploaded
+/// before the enrichment pipeline was added.
+#[utoipa::path(
+    post,
+    path = "/api/v1/documents/{document_id}/enrich",
+    tag = "Documents",
+    params(("document_id" = String, Path, description = "Document ID")),
+    responses(
+        (status = 200, description = "Enrichment task queued", body = EnrichDocumentResponse),
+        (status = 404, description = "Document not found"),
+        (status = 400, description = "Document has no linked PDF")
+    )
+)]
+pub async fn enrich_document(
+    State(state): State<AppState>,
+    tenant_ctx: TenantContext,
+    Path(document_id): Path<String>,
+) -> ApiResult<Json<EnrichDocumentResponse>> {
+    let metadata_key = format!("{}-metadata", document_id);
+
+    let metadata = state
+        .kv_storage
+        .get_by_id(&metadata_key)
+        .await
+        .map_err(|e| ApiError::Internal(format!("KV lookup failed: {}", e)))?
+        .ok_or_else(|| ApiError::NotFound(format!("Document not found: {}", document_id)))?;
+
+    let obj = metadata
+        .as_object()
+        .ok_or_else(|| ApiError::Internal("Invalid metadata format".to_string()))?;
+
+    let pdf_id_str = obj
+        .get("pdf_id")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| {
+            ApiError::BadRequest("Document has no linked PDF — only PDF documents can be enriched".to_string())
+        })?;
+
+    let pdf_id = Uuid::parse_str(pdf_id_str)
+        .map_err(|_| ApiError::Internal("Invalid pdf_id in metadata".to_string()))?;
+
+    let tenant_id = obj
+        .get("tenant_id")
+        .and_then(|v| v.as_str())
+        .and_then(|s| Uuid::parse_str(s).ok())
+        .or_else(|| tenant_ctx.tenant_id_uuid())
+        .ok_or_else(|| ApiError::BadRequest("Cannot determine tenant_id".to_string()))?;
+
+    let workspace_id = obj
+        .get("workspace_id")
+        .and_then(|v| v.as_str())
+        .and_then(|s| Uuid::parse_str(s).ok())
+        .or_else(|| tenant_ctx.workspace_id_uuid())
+        .ok_or_else(|| ApiError::BadRequest("Cannot determine workspace_id".to_string()))?;
+
+    // Reset enrichment_status so the processor writes fresh results
+    let mut updated = obj.clone();
+    updated.insert(
+        "enrichment_status".to_string(),
+        serde_json::json!("pending"),
+    );
+    updated.remove("enrichment_topic");
+    updated.remove("enrichment_summary");
+    updated.remove("enrichment_language");
+    updated.remove("enrichment_keywords");
+    updated.remove("enrichment_completed_at");
+    updated.remove("enrichment_error");
+
+    state
+        .kv_storage
+        .upsert(&[(
+            metadata_key,
+            serde_json::Value::Object(updated),
+        )])
+        .await
+        .map_err(|e| ApiError::Internal(format!("KV update failed: {}", e)))?;
+
+    let enrich_data = MetadataEnrichData {
+        document_id: document_id.clone(),
+        pdf_id,
+        tenant_id,
+        workspace_id,
+        max_pages: 5,
+    };
+
+    let track_id = format!("metadata_enrich-{}", Uuid::new_v4());
+
+    let task = Task {
+        track_id: track_id.clone(),
+        tenant_id,
+        workspace_id,
+        task_type: TaskType::MetadataEnrich,
+        status: TaskStatus::Pending,
+        created_at: Utc::now(),
+        updated_at: Utc::now(),
+        started_at: None,
+        completed_at: None,
+        error_message: None,
+        error: None,
+        retry_count: 0,
+        max_retries: 3,
+        consecutive_timeout_failures: 0,
+        circuit_breaker_tripped: false,
+        task_data: serde_json::to_value(&enrich_data)
+            .map_err(|e| ApiError::Internal(format!("Serialization failed: {}", e)))?,
+        metadata: None,
+        progress: None,
+        result: None,
+    };
+
+    state
+        .task_storage
+        .create_task(&task)
+        .await
+        .map_err(|e| ApiError::Internal(format!("Failed to create task: {}", e)))?;
+
+    state
+        .enrich_queue
+        .send(task)
+        .await
+        .map_err(|e| ApiError::Internal(format!("Failed to queue task: {}", e)))?;
+
+    tracing::info!(
+        document_id = %document_id,
+        pdf_id = %pdf_id,
+        track_id = %track_id,
+        "Enrichment task queued manually"
+    );
+
+    Ok(Json(EnrichDocumentResponse {
+        document_id,
+        track_id,
+        message: "Enrichment task queued successfully".to_string(),
+    }))
+}

--- a/edgequake/crates/edgequake-api/src/handlers/documents/recovery/enrich.rs
+++ b/edgequake/crates/edgequake-api/src/handlers/documents/recovery/enrich.rs
@@ -6,7 +6,7 @@
 use axum::extract::{Path, State};
 use axum::Json;
 use chrono::Utc;
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 use utoipa::ToSchema;
 use uuid::Uuid;
 

--- a/edgequake/crates/edgequake-api/src/handlers/documents/recovery/mod.rs
+++ b/edgequake/crates/edgequake-api/src/handlers/documents/recovery/mod.rs
@@ -7,9 +7,11 @@
 //! | `chunks`     | Retry/list failed chunks (FEAT0408, FEAT0409)      |
 
 mod chunks;
+mod enrich;
 mod reprocess;
 mod stuck;
 
 pub use chunks::*;
+pub use enrich::*;
 pub use reprocess::*;
 pub use stuck::*;

--- a/edgequake/crates/edgequake-api/src/handlers/documents_types/detail.rs
+++ b/edgequake/crates/edgequake-api/src/handlers/documents_types/detail.rs
@@ -99,6 +99,27 @@ pub struct DocumentDetailResponse {
     /// @implements SPEC-002
     #[serde(skip_serializing_if = "Option::is_none")]
     pub pdf_id: Option<String>,
+
+    // ── PDF Metadata Enrichment fields ─────────────────────────────────────
+    /// Enrichment pipeline status.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub enrichment_status: Option<String>,
+
+    /// Topic label extracted by enrichment (e.g. "Technology").
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub enrichment_topic: Option<String>,
+
+    /// Specific subtopic tags extracted by enrichment.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub enrichment_tags: Option<Vec<String>>,
+
+    /// Short summary extracted by enrichment.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub enrichment_summary: Option<String>,
+
+    /// Language code detected by enrichment (e.g. "en").
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub enrichment_language: Option<String>,
 }
 
 /// Get document by ID request.

--- a/edgequake/crates/edgequake-api/src/handlers/documents_types/listing.rs
+++ b/edgequake/crates/edgequake-api/src/handlers/documents_types/listing.rs
@@ -199,4 +199,29 @@ pub struct DocumentSummary {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[schema(example = "8866e3c3-bbd6-4384-b86f-215c9844914d")]
     pub pdf_id: Option<String>,
+
+    // ── PDF Metadata Enrichment fields ──────────────────────────────────────
+    /// Enrichment pipeline status: pending | processing | completed | failed | skipped.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub enrichment_status: Option<String>,
+
+    /// Topic extracted by the enrichment pipeline (e.g. "Machine Learning").
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub enrichment_topic: Option<String>,
+
+    /// Short summary extracted by the enrichment pipeline.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub enrichment_summary: Option<String>,
+
+    /// Language detected by the enrichment pipeline (e.g. "English").
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub enrichment_language: Option<String>,
+
+    /// Keywords extracted by the enrichment pipeline.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub enrichment_keywords: Option<Vec<String>>,
+
+    /// ISO 8601 timestamp when enrichment completed.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub enrichment_completed_at: Option<String>,
 }

--- a/edgequake/crates/edgequake-api/src/handlers/documents_types/listing.rs
+++ b/edgequake/crates/edgequake-api/src/handlers/documents_types/listing.rs
@@ -217,6 +217,10 @@ pub struct DocumentSummary {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub enrichment_language: Option<String>,
 
+    /// Tags extracted by the enrichment pipeline (3-6 specific subtopic tags).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub enrichment_tags: Option<Vec<String>>,
+
     /// Keywords extracted by the enrichment pipeline.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub enrichment_keywords: Option<Vec<String>>,

--- a/edgequake/crates/edgequake-api/src/handlers/mcp.rs
+++ b/edgequake/crates/edgequake-api/src/handlers/mcp.rs
@@ -58,10 +58,20 @@ impl JsonRpcResponse {
 // ── Allowed topics ────────────────────────────────────────────────────────────
 
 const ALLOWED_TOPICS: &[&str] = &[
-    "Politics", "Indonesia", "Psychology", "Business", "Communication",
-    "Technology", "Science", "SocialMedia", "Religion", "Media",
-    "AI", "Culinary", "Finance", "Literature", "Law",
-    "Sports", "Education", "History", "Uncategorized",
+    // Fiction
+    "Romance", "Science Fiction & Fantasy", "Mystery, Thriller & Suspense",
+    "Literature & Fiction", "Teen & Young Adult", "LGBTQIA+",
+    // Nonfiction
+    "Arts & Photography", "Biographies & Memoirs", "Business & Money",
+    "Computers & Technology", "Cookbooks, Food & Wine", "Crafts, Hobbies & Home",
+    "Education & Teaching", "Engineering & Transportation", "Health, Fitness & Dieting",
+    "History", "Humor & Entertainment", "Law", "Medical Books",
+    "Parenting & Relationships", "Politics & Social Sciences", "Reference",
+    "Religion & Spirituality", "Science & Math", "Self-help",
+    "Sports & Outdoors", "Travel",
+    // Other
+    "Comics & Manga", "Children's Books", "Textbooks",
+    "Uncategorized",
 ];
 
 // ── Tool schema ───────────────────────────────────────────────────────────────
@@ -86,7 +96,18 @@ fn tools_list() -> Value {
                         "include_references": { "type": "boolean", "description": "Include source snippets in response (default: true)" },
                         "topic": {
                             "type": "string",
-                            "enum": ["Politics","Indonesia","Psychology","Business","Communication","Technology","Science","SocialMedia","Religion","Media","AI","Culinary","Finance","Literature","Law","Sports","Education","History","Uncategorized"],
+                            "enum": [
+                                "Romance","Science Fiction & Fantasy","Mystery, Thriller & Suspense",
+                                "Literature & Fiction","Teen & Young Adult","LGBTQIA+",
+                                "Arts & Photography","Biographies & Memoirs","Business & Money",
+                                "Computers & Technology","Cookbooks, Food & Wine","Crafts, Hobbies & Home",
+                                "Education & Teaching","Engineering & Transportation","Health, Fitness & Dieting",
+                                "History","Humor & Entertainment","Law","Medical Books",
+                                "Parenting & Relationships","Politics & Social Sciences","Reference",
+                                "Religion & Spirituality","Science & Math","Self-help",
+                                "Sports & Outdoors","Travel","Comics & Manga","Children's Books",
+                                "Textbooks","Uncategorized"
+                            ],
                             "description": "Filter query to documents with this enrichment topic"
                         }
                     },
@@ -95,20 +116,8 @@ fn tools_list() -> Value {
             },
             // ── Documents ─────────────────────────────────────────────────
             {
-                "name": "document_upload",
-                "description": "Upload a text document to EdgeQuake for knowledge graph extraction. The document will be chunked, entities extracted, and relationships mapped.",
-                "inputSchema": {
-                    "type": "object",
-                    "properties": {
-                        "content": { "type": "string", "description": "Document text content" },
-                        "title": { "type": "string", "description": "Document title" }
-                    },
-                    "required": ["content"]
-                }
-            },
-            {
                 "name": "document_list",
-                "description": "List documents with pagination and optional filtering",
+                "description": "List documents with pagination and optional filtering by status, topic, or title search",
                 "inputSchema": {
                     "type": "object",
                     "properties": {
@@ -119,6 +128,22 @@ fn tools_list() -> Value {
                             "enum": ["pending","processing","completed","failed"],
                             "description": "Filter by processing status"
                         },
+                        "topic": {
+                            "type": "string",
+                            "enum": [
+                                "Romance","Science Fiction & Fantasy","Mystery, Thriller & Suspense",
+                                "Literature & Fiction","Teen & Young Adult","LGBTQIA+",
+                                "Arts & Photography","Biographies & Memoirs","Business & Money",
+                                "Computers & Technology","Cookbooks, Food & Wine","Crafts, Hobbies & Home",
+                                "Education & Teaching","Engineering & Transportation","Health, Fitness & Dieting",
+                                "History","Humor & Entertainment","Law","Medical Books",
+                                "Parenting & Relationships","Politics & Social Sciences","Reference",
+                                "Religion & Spirituality","Science & Math","Self-help",
+                                "Sports & Outdoors","Travel","Comics & Manga","Children's Books",
+                                "Textbooks","Uncategorized"
+                            ],
+                            "description": "Filter by enrichment topic"
+                        },
                         "search": { "type": "string", "description": "Search in title" }
                     }
                 }
@@ -126,28 +151,6 @@ fn tools_list() -> Value {
             {
                 "name": "document_get",
                 "description": "Get document details including metadata and enrichment data",
-                "inputSchema": {
-                    "type": "object",
-                    "properties": {
-                        "document_id": { "type": "string", "description": "Document UUID" }
-                    },
-                    "required": ["document_id"]
-                }
-            },
-            {
-                "name": "document_delete",
-                "description": "Delete a document and its extracted knowledge (entities, relationships, chunks)",
-                "inputSchema": {
-                    "type": "object",
-                    "properties": {
-                        "document_id": { "type": "string", "description": "Document UUID" }
-                    },
-                    "required": ["document_id"]
-                }
-            },
-            {
-                "name": "document_status",
-                "description": "Check the processing status of a document",
                 "inputSchema": {
                     "type": "object",
                     "properties": {
@@ -202,66 +205,6 @@ fn tools_list() -> Value {
                         "label": { "type": "string", "description": "Relationship type/label (partial match)" },
                         "limit": { "type": "integer", "description": "Max results (default: 20)" }
                     }
-                }
-            },
-            // ── Health ────────────────────────────────────────────────────
-            {
-                "name": "health",
-                "description": "Check EdgeQuake server health and component status",
-                "inputSchema": { "type": "object", "properties": {} }
-            },
-            // ── Workspaces ────────────────────────────────────────────────
-            {
-                "name": "workspace_list",
-                "description": "List all workspaces across all tenants",
-                "inputSchema": { "type": "object", "properties": {} }
-            },
-            {
-                "name": "workspace_create",
-                "description": "Create a new workspace for document ingestion and knowledge graph",
-                "inputSchema": {
-                    "type": "object",
-                    "properties": {
-                        "name": { "type": "string", "description": "Workspace name" },
-                        "description": { "type": "string", "description": "Workspace description" },
-                        "tenant_id": { "type": "string", "description": "Tenant UUID (uses first available tenant if omitted)" },
-                        "llm_model": { "type": "string", "description": "LLM model for extraction" },
-                        "llm_provider": { "type": "string", "description": "LLM provider (ollama, openai, lmstudio)" }
-                    },
-                    "required": ["name"]
-                }
-            },
-            {
-                "name": "workspace_get",
-                "description": "Get workspace details",
-                "inputSchema": {
-                    "type": "object",
-                    "properties": {
-                        "workspace_id": { "type": "string", "description": "Workspace UUID" }
-                    },
-                    "required": ["workspace_id"]
-                }
-            },
-            {
-                "name": "workspace_delete",
-                "description": "Delete a workspace and all its data (documents, entities, relationships)",
-                "inputSchema": {
-                    "type": "object",
-                    "properties": {
-                        "workspace_id": { "type": "string", "description": "Workspace UUID" }
-                    },
-                    "required": ["workspace_id"]
-                }
-            },
-            {
-                "name": "workspace_stats",
-                "description": "Get statistics for a workspace (document, entity, relationship, chunk counts)",
-                "inputSchema": {
-                    "type": "object",
-                    "properties": {
-                        "workspace_id": { "type": "string", "description": "Workspace UUID" }
-                    },
-                    "required": ["workspace_id"]
                 }
             }
         ]
@@ -492,6 +435,7 @@ async fn tool_document_list(state: &AppState, args: &Value) -> Result<Value, (i3
     let page = args.get("page").and_then(|v| v.as_u64()).unwrap_or(1).max(1) as usize;
     let page_size = args.get("page_size").and_then(|v| v.as_u64()).unwrap_or(20).min(100) as usize;
     let status_filter = args.get("status").and_then(|v| v.as_str());
+    let topic_filter = args.get("topic").and_then(|v| v.as_str()).map(|s| s.to_lowercase());
     let search_filter = args.get("search").and_then(|v| v.as_str()).map(|s| s.to_lowercase());
 
     let keys = state.kv_storage.keys_with_suffix("-metadata").await
@@ -504,9 +448,13 @@ async fn tool_document_list(state: &AppState, args: &Value) -> Result<Value, (i3
             let doc_status = meta.get("enrichment_status").or_else(|| meta.get("status"))
                 .and_then(|v| v.as_str()).unwrap_or("");
             let title = meta.get("title").and_then(|v| v.as_str()).unwrap_or(doc_id);
+            let doc_topic = meta.get("enrichment_topic").and_then(|v| v.as_str()).unwrap_or("");
 
             if let Some(sf) = status_filter {
                 if doc_status != sf { continue; }
+            }
+            if let Some(ref tf) = topic_filter {
+                if doc_topic.to_lowercase() != *tf { continue; }
             }
             if let Some(ref q) = search_filter {
                 if !title.to_lowercase().contains(q.as_str()) { continue; }

--- a/edgequake/crates/edgequake-api/src/handlers/mcp.rs
+++ b/edgequake/crates/edgequake-api/src/handlers/mcp.rs
@@ -393,7 +393,17 @@ async fn tool_query(state: &AppState, args: &Value) -> Result<Value, (i32, Strin
         }
     }
 
-    match state.sota_engine.query(engine_req).await {
+    // Build workspace-aware LLM override so queries use the workspace model
+    // (e.g. openrouter/gpt-oss-120b) instead of the global default provider.
+    let llm_override = workspace_llm_override(state).await;
+
+    let query_result = if let Some(llm) = llm_override {
+        state.sota_engine.query_with_llm_provider(engine_req, llm).await
+    } else {
+        state.sota_engine.query(engine_req).await
+    };
+
+    match query_result {
         Ok(result) => {
             let chunks = &result.context.chunks;
             let sources = if !chunks.is_empty() {
@@ -411,6 +421,37 @@ async fn tool_query(state: &AppState, args: &Value) -> Result<Value, (i32, Strin
             "isError": true
         })),
     }
+}
+
+/// Build a workspace-specific LLM provider using the default workspace config.
+///
+/// Falls back to env-var defaults (`EDGEQUAKE_LLM_PROVIDER` / `EDGEQUAKE_DEFAULT_LLM_MODEL`)
+/// so the MCP query tool honours the same model as the regular API query endpoints.
+async fn workspace_llm_override(
+    state: &AppState,
+) -> Option<std::sync::Arc<dyn edgequake_llm::LLMProvider>> {
+    use edgequake_core::Workspace;
+
+    // Priority 1: Default workspace in DB
+    let default_workspace_id = Uuid::parse_str("00000000-0000-0000-0000-000000000003").ok()?;
+    let (provider, model) = if let Ok(Some(ws)) = state.workspace_service
+        .get_workspace(default_workspace_id).await
+    {
+        if !ws.llm_provider.is_empty() && !ws.llm_model.is_empty() {
+            (ws.llm_provider, ws.llm_model)
+        } else {
+            // Priority 2: env vars
+            let (model, provider) = Workspace::server_runtime_llm_config();
+            (provider, model)
+        }
+    } else {
+        let (model, provider) = Workspace::server_runtime_llm_config();
+        (provider, model)
+    };
+
+    crate::safety_limits::create_safe_llm_provider(&provider, &model)
+        .map_err(|e| warn!(error = %e, provider, model, "MCP: failed to create workspace LLM override"))
+        .ok()
 }
 
 // ── document_upload ───────────────────────────────────────────────────────────

--- a/edgequake/crates/edgequake-api/src/handlers/mcp.rs
+++ b/edgequake/crates/edgequake-api/src/handlers/mcp.rs
@@ -1,0 +1,288 @@
+//! MCP Streamable HTTP transport handler.
+//!
+//! Exposes EdgeQuake as an MCP server over HTTP at `POST /mcp`.
+//! Implements JSON-RPC 2.0 as required by the MCP Streamable HTTP spec.
+//!
+//! Supported methods:
+//!   - `initialize`       — MCP handshake
+//!   - `ping`             — keepalive
+//!   - `tools/list`       — enumerate available tools
+//!   - `tools/call`       — invoke a tool
+//!   - `notifications/*`  — accepted and silently ignored
+
+use axum::{extract::State, http::StatusCode, response::IntoResponse, Json};
+use edgequake_query::{QueryMode, QueryRequest as EngineQueryRequest};
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use tracing::warn;
+
+use crate::state::AppState;
+
+// ── JSON-RPC 2.0 types ────────────────────────────────────────────────────────
+
+#[derive(Debug, Deserialize)]
+pub struct JsonRpcRequest {
+    pub jsonrpc: String,
+    pub method: String,
+    #[serde(default)]
+    pub params: Value,
+    pub id: Option<Value>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct JsonRpcResponse {
+    pub jsonrpc: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub result: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<RpcError>,
+    pub id: Option<Value>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct RpcError {
+    pub code: i32,
+    pub message: String,
+}
+
+impl JsonRpcResponse {
+    fn ok(id: Option<Value>, result: Value) -> Self {
+        Self { jsonrpc: "2.0".into(), result: Some(result), error: None, id }
+    }
+    fn err(id: Option<Value>, code: i32, message: impl Into<String>) -> Self {
+        Self {
+            jsonrpc: "2.0".into(),
+            result: None,
+            error: Some(RpcError { code, message: message.into() }),
+            id,
+        }
+    }
+}
+
+// ── Tool schema constants ──────────────────────────────────────────────────────
+
+const ALLOWED_TOPICS: &[&str] = &[
+    "Politics", "Indonesia", "Psychology", "Business", "Communication",
+    "Technology", "Science", "SocialMedia", "Religion", "Media",
+    "AI", "Culinary", "Finance", "Literature", "Law",
+    "Sports", "Education", "History", "Uncategorized",
+];
+
+fn tools_list() -> Value {
+    json!({
+        "tools": [
+            {
+                "name": "query",
+                "description": "Execute a RAG query against the EdgeQuake knowledge graph. Returns an AI-generated answer with source references. Use 'hybrid' mode (default) for best results.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "query": {
+                            "type": "string",
+                            "description": "Natural language question"
+                        },
+                        "mode": {
+                            "type": "string",
+                            "enum": ["naive", "local", "global", "hybrid", "mix"],
+                            "description": "Query mode (default: hybrid)"
+                        },
+                        "max_results": {
+                            "type": "integer",
+                            "description": "Maximum number of source references to return"
+                        },
+                        "topic": {
+                            "type": "string",
+                            "enum": [
+                                "Politics","Indonesia","Psychology","Business","Communication",
+                                "Technology","Science","SocialMedia","Religion","Media",
+                                "AI","Culinary","Finance","Literature","Law",
+                                "Sports","Education","History","Uncategorized"
+                            ],
+                            "description": "Filter query to documents with this topic"
+                        }
+                    },
+                    "required": ["query"]
+                }
+            },
+            {
+                "name": "list_documents",
+                "description": "List documents stored in the EdgeQuake knowledge base.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "limit": {
+                            "type": "integer",
+                            "description": "Maximum number of documents to return (default: 20, max: 100)"
+                        }
+                    }
+                }
+            }
+        ]
+    })
+}
+
+// ── Main handler ──────────────────────────────────────────────────────────────
+
+pub async fn mcp_handler(
+    State(state): State<AppState>,
+    Json(req): Json<JsonRpcRequest>,
+) -> impl IntoResponse {
+    let id = req.id.clone();
+
+    match req.method.as_str() {
+        // Notifications have no response body
+        m if m.starts_with("notifications/") => {
+            return (StatusCode::OK, Json(json!(null))).into_response();
+        }
+
+        "initialize" => {
+            let result = json!({
+                "protocolVersion": "2024-11-05",
+                "capabilities": { "tools": {} },
+                "serverInfo": {
+                    "name": "EdgeQuake MCP",
+                    "version": env!("CARGO_PKG_VERSION")
+                }
+            });
+            Json(JsonRpcResponse::ok(id, result)).into_response()
+        }
+
+        "ping" => Json(JsonRpcResponse::ok(id, json!({}))).into_response(),
+
+        "tools/list" => Json(JsonRpcResponse::ok(id, tools_list())).into_response(),
+
+        "tools/call" => {
+            let resp = handle_tool_call(&state, &req.params).await;
+            Json(match resp {
+                Ok(r) => JsonRpcResponse::ok(id, r),
+                Err((code, msg)) => JsonRpcResponse::err(id, code, msg),
+            })
+            .into_response()
+        }
+
+        other => Json(JsonRpcResponse::err(
+            id,
+            -32601,
+            format!("Method not found: {other}"),
+        ))
+        .into_response(),
+    }
+}
+
+// ── Tool dispatch ─────────────────────────────────────────────────────────────
+
+async fn handle_tool_call(
+    state: &AppState,
+    params: &Value,
+) -> Result<Value, (i32, String)> {
+    let name = params
+        .get("name")
+        .and_then(|v| v.as_str())
+        .ok_or((-32602, "Missing tool name".to_string()))?;
+
+    let args = params.get("arguments").cloned().unwrap_or(json!({}));
+
+    match name {
+        "query" => tool_query(state, &args).await,
+        "list_documents" => tool_list_documents(state, &args).await,
+        other => Err((-32602, format!("Unknown tool: {other}"))),
+    }
+}
+
+// ── query tool ────────────────────────────────────────────────────────────────
+
+async fn tool_query(state: &AppState, args: &Value) -> Result<Value, (i32, String)> {
+    let query_text = args
+        .get("query")
+        .and_then(|v| v.as_str())
+        .ok_or((-32602, "Missing required parameter: query".to_string()))?;
+
+    let mode = args
+        .get("mode")
+        .and_then(|v| v.as_str())
+        .and_then(QueryMode::parse)
+        .unwrap_or(QueryMode::Hybrid);
+
+    let mut engine_req = EngineQueryRequest::new(query_text).with_mode(mode);
+
+    // Apply topic filter if provided and valid
+    if let Some(topic) = args.get("topic").and_then(|v| v.as_str()) {
+        if ALLOWED_TOPICS.iter().any(|&t| t.eq_ignore_ascii_case(topic)) {
+            match crate::handlers::query::topic_resolver::resolve_topic_filter(
+                state.kv_storage.as_ref(),
+                topic,
+                None,
+                None,
+            )
+            .await
+            {
+                Ok(Some(doc_ids)) => {
+                    engine_req = engine_req.with_allowed_document_ids(doc_ids);
+                }
+                Ok(None) => {}
+                Err(e) => {
+                    warn!(error = %e, "MCP topic filter failed — proceeding unscoped");
+                }
+            }
+        }
+    }
+
+    match state.sota_engine.query(engine_req).await {
+        Ok(result) => {
+            let chunks = &result.context.chunks;
+            let sources_text = if !chunks.is_empty() {
+                let refs: Vec<String> = chunks
+                    .iter()
+                    .take(5)
+                    .enumerate()
+                    .map(|(i, c)| {
+                        format!("[{}] {}", i + 1, c.content.chars().take(150).collect::<String>())
+                    })
+                    .collect();
+                format!("\n\n---\n**Sources:**\n{}", refs.join("\n"))
+            } else {
+                String::new()
+            };
+
+            let text = format!("{}{}", result.answer, sources_text);
+            Ok(json!({ "content": [{ "type": "text", "text": text }] }))
+        }
+        Err(e) => Ok(json!({
+            "content": [{ "type": "text", "text": format!("Query failed: {e}") }],
+            "isError": true
+        })),
+    }
+}
+
+// ── list_documents tool ───────────────────────────────────────────────────────
+
+async fn tool_list_documents(state: &AppState, args: &Value) -> Result<Value, (i32, String)> {
+    let limit = args
+        .get("limit")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(20)
+        .min(100) as usize;
+
+    let keys = state
+        .kv_storage
+        .keys_with_suffix("-metadata")
+        .await
+        .map_err(|e| (-32603, format!("Storage error: {e}")))?;
+
+    let mut docs = Vec::with_capacity(limit);
+    for key in keys.iter().take(limit) {
+        let doc_id = key.trim_end_matches("-metadata");
+        if let Ok(Some(meta)) = state.kv_storage.get_by_id(key).await {
+            docs.push(json!({
+                "id": doc_id,
+                "topic": meta.get("enrichment_topic").and_then(|v| v.as_str()).unwrap_or(""),
+                "language": meta.get("enrichment_language").and_then(|v| v.as_str()).unwrap_or(""),
+                "status": meta.get("enrichment_status").and_then(|v| v.as_str()).unwrap_or(""),
+                "summary": meta.get("enrichment_summary").and_then(|v| v.as_str()).unwrap_or(""),
+            }));
+        }
+    }
+
+    let text = serde_json::to_string_pretty(&docs).unwrap_or_else(|_| "[]".to_string());
+    Ok(json!({ "content": [{ "type": "text", "text": text }] }))
+}

--- a/edgequake/crates/edgequake-api/src/handlers/mcp.rs
+++ b/edgequake/crates/edgequake-api/src/handlers/mcp.rs
@@ -1,20 +1,16 @@
 //! MCP Streamable HTTP transport handler.
 //!
-//! Exposes EdgeQuake as an MCP server over HTTP at `POST /mcp`.
+//! Exposes EdgeQuake as an MCP server at `POST /mcp`.
 //! Implements JSON-RPC 2.0 as required by the MCP Streamable HTTP spec.
-//!
-//! Supported methods:
-//!   - `initialize`       — MCP handshake
-//!   - `ping`             — keepalive
-//!   - `tools/list`       — enumerate available tools
-//!   - `tools/call`       — invoke a tool
-//!   - `notifications/*`  — accepted and silently ignored
+//! Tool parity with the stdio npm package (@romysaputrasihanandaa/edgequake-mcp).
 
 use axum::{extract::State, http::StatusCode, response::IntoResponse, Json};
+use edgequake_core::{CreateWorkspaceRequest, WorkspaceService};
 use edgequake_query::{QueryMode, QueryRequest as EngineQueryRequest};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use tracing::warn;
+use uuid::Uuid;
 
 use crate::state::AppState;
 
@@ -59,7 +55,7 @@ impl JsonRpcResponse {
     }
 }
 
-// ── Tool schema constants ──────────────────────────────────────────────────────
+// ── Allowed topics ────────────────────────────────────────────────────────────
 
 const ALLOWED_TOPICS: &[&str] = &[
     "Politics", "Indonesia", "Psychology", "Business", "Communication",
@@ -68,53 +64,204 @@ const ALLOWED_TOPICS: &[&str] = &[
     "Sports", "Education", "History", "Uncategorized",
 ];
 
+// ── Tool schema ───────────────────────────────────────────────────────────────
+
 fn tools_list() -> Value {
     json!({
         "tools": [
+            // ── Query ──────────────────────────────────────────────────────
             {
                 "name": "query",
-                "description": "Execute a RAG query against the EdgeQuake knowledge graph. Returns an AI-generated answer with source references. Use 'hybrid' mode (default) for best results.",
+                "description": "Execute a RAG query against the EdgeQuake knowledge graph. Returns an AI-generated answer with source references. Use 'hybrid' mode (default) for best results combining local entity graph traversal with global semantic search.",
                 "inputSchema": {
                     "type": "object",
                     "properties": {
-                        "query": {
-                            "type": "string",
-                            "description": "Natural language question"
-                        },
+                        "query": { "type": "string", "description": "Natural language question" },
                         "mode": {
                             "type": "string",
-                            "enum": ["naive", "local", "global", "hybrid", "mix"],
-                            "description": "Query mode (default: hybrid)"
+                            "enum": ["naive","local","global","hybrid","mix"],
+                            "description": "Query mode: naive (vector-only), local (entity graph), global (community search), hybrid (local+global, default), mix (weighted blend)"
                         },
-                        "max_results": {
-                            "type": "integer",
-                            "description": "Maximum number of source references to return"
-                        },
+                        "max_results": { "type": "integer", "description": "Maximum number of source references to return" },
+                        "include_references": { "type": "boolean", "description": "Include source snippets in response (default: true)" },
                         "topic": {
                             "type": "string",
-                            "enum": [
-                                "Politics","Indonesia","Psychology","Business","Communication",
-                                "Technology","Science","SocialMedia","Religion","Media",
-                                "AI","Culinary","Finance","Literature","Law",
-                                "Sports","Education","History","Uncategorized"
-                            ],
-                            "description": "Filter query to documents with this topic"
+                            "enum": ["Politics","Indonesia","Psychology","Business","Communication","Technology","Science","SocialMedia","Religion","Media","AI","Culinary","Finance","Literature","Law","Sports","Education","History","Uncategorized"],
+                            "description": "Filter query to documents with this enrichment topic"
                         }
                     },
                     "required": ["query"]
                 }
             },
+            // ── Documents ─────────────────────────────────────────────────
             {
-                "name": "list_documents",
-                "description": "List documents stored in the EdgeQuake knowledge base.",
+                "name": "document_upload",
+                "description": "Upload a text document to EdgeQuake for knowledge graph extraction. The document will be chunked, entities extracted, and relationships mapped.",
                 "inputSchema": {
                     "type": "object",
                     "properties": {
-                        "limit": {
-                            "type": "integer",
-                            "description": "Maximum number of documents to return (default: 20, max: 100)"
-                        }
+                        "content": { "type": "string", "description": "Document text content" },
+                        "title": { "type": "string", "description": "Document title" }
+                    },
+                    "required": ["content"]
+                }
+            },
+            {
+                "name": "document_list",
+                "description": "List documents with pagination and optional filtering",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "page": { "type": "integer", "description": "Page number (default: 1)" },
+                        "page_size": { "type": "integer", "description": "Items per page (default: 20)" },
+                        "status": {
+                            "type": "string",
+                            "enum": ["pending","processing","completed","failed"],
+                            "description": "Filter by processing status"
+                        },
+                        "search": { "type": "string", "description": "Search in title" }
                     }
+                }
+            },
+            {
+                "name": "document_get",
+                "description": "Get document details including metadata and enrichment data",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "document_id": { "type": "string", "description": "Document UUID" }
+                    },
+                    "required": ["document_id"]
+                }
+            },
+            {
+                "name": "document_delete",
+                "description": "Delete a document and its extracted knowledge (entities, relationships, chunks)",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "document_id": { "type": "string", "description": "Document UUID" }
+                    },
+                    "required": ["document_id"]
+                }
+            },
+            {
+                "name": "document_status",
+                "description": "Check the processing status of a document",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "document_id": { "type": "string", "description": "Document UUID" }
+                    },
+                    "required": ["document_id"]
+                }
+            },
+            // ── Graph ─────────────────────────────────────────────────────
+            {
+                "name": "graph_search_entities",
+                "description": "Search for entities in the knowledge graph. Entities are people, organizations, technologies, concepts, etc. extracted from documents.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "search": { "type": "string", "description": "Search term to filter entities by name or description" },
+                        "label": { "type": "string", "description": "Filter by entity type: PERSON, ORGANIZATION, TECHNOLOGY, CONCEPT, EVENT, LOCATION, PRODUCT" },
+                        "limit": { "type": "integer", "description": "Max results (default: 20)" }
+                    }
+                }
+            },
+            {
+                "name": "graph_get_entity",
+                "description": "Get detailed information about a specific entity including its properties",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "entity_name": { "type": "string", "description": "Entity name (e.g. RUST, OPENAI, MACHINE_LEARNING)" }
+                    },
+                    "required": ["entity_name"]
+                }
+            },
+            {
+                "name": "graph_entity_neighborhood",
+                "description": "Get an entity's neighborhood — all directly connected entities and their relationships.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "entity_name": { "type": "string", "description": "Entity name" }
+                    },
+                    "required": ["entity_name"]
+                }
+            },
+            {
+                "name": "graph_search_relationships",
+                "description": "Search relationships between entities in the knowledge graph",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "source": { "type": "string", "description": "Source entity name (partial match)" },
+                        "target": { "type": "string", "description": "Target entity name (partial match)" },
+                        "label": { "type": "string", "description": "Relationship type/label (partial match)" },
+                        "limit": { "type": "integer", "description": "Max results (default: 20)" }
+                    }
+                }
+            },
+            // ── Health ────────────────────────────────────────────────────
+            {
+                "name": "health",
+                "description": "Check EdgeQuake server health and component status",
+                "inputSchema": { "type": "object", "properties": {} }
+            },
+            // ── Workspaces ────────────────────────────────────────────────
+            {
+                "name": "workspace_list",
+                "description": "List all workspaces across all tenants",
+                "inputSchema": { "type": "object", "properties": {} }
+            },
+            {
+                "name": "workspace_create",
+                "description": "Create a new workspace for document ingestion and knowledge graph",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "name": { "type": "string", "description": "Workspace name" },
+                        "description": { "type": "string", "description": "Workspace description" },
+                        "tenant_id": { "type": "string", "description": "Tenant UUID (uses first available tenant if omitted)" },
+                        "llm_model": { "type": "string", "description": "LLM model for extraction" },
+                        "llm_provider": { "type": "string", "description": "LLM provider (ollama, openai, lmstudio)" }
+                    },
+                    "required": ["name"]
+                }
+            },
+            {
+                "name": "workspace_get",
+                "description": "Get workspace details",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "workspace_id": { "type": "string", "description": "Workspace UUID" }
+                    },
+                    "required": ["workspace_id"]
+                }
+            },
+            {
+                "name": "workspace_delete",
+                "description": "Delete a workspace and all its data (documents, entities, relationships)",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "workspace_id": { "type": "string", "description": "Workspace UUID" }
+                    },
+                    "required": ["workspace_id"]
+                }
+            },
+            {
+                "name": "workspace_stats",
+                "description": "Get statistics for a workspace (document, entity, relationship, chunk counts)",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "workspace_id": { "type": "string", "description": "Workspace UUID" }
+                    },
+                    "required": ["workspace_id"]
                 }
             }
         ]
@@ -129,100 +276,119 @@ pub async fn mcp_handler(
 ) -> impl IntoResponse {
     let id = req.id.clone();
 
-    match req.method.as_str() {
-        // Notifications have no response body
-        m if m.starts_with("notifications/") => {
-            return (StatusCode::OK, Json(json!(null))).into_response();
-        }
+    if req.method.starts_with("notifications/") {
+        return (StatusCode::OK, Json(json!(null))).into_response();
+    }
 
-        "initialize" => {
-            let result = json!({
-                "protocolVersion": "2024-11-05",
-                "capabilities": { "tools": {} },
-                "serverInfo": {
-                    "name": "EdgeQuake MCP",
-                    "version": env!("CARGO_PKG_VERSION")
-                }
-            });
-            Json(JsonRpcResponse::ok(id, result)).into_response()
-        }
+    match req.method.as_str() {
+        "initialize" => Json(JsonRpcResponse::ok(id, json!({
+            "protocolVersion": "2024-11-05",
+            "capabilities": { "tools": {} },
+            "serverInfo": {
+                "name": "EdgeQuake MCP",
+                "version": env!("CARGO_PKG_VERSION")
+            }
+        }))).into_response(),
 
         "ping" => Json(JsonRpcResponse::ok(id, json!({}))).into_response(),
 
         "tools/list" => Json(JsonRpcResponse::ok(id, tools_list())).into_response(),
 
         "tools/call" => {
-            let resp = handle_tool_call(&state, &req.params).await;
+            let resp = dispatch_tool(&state, &req.params).await;
             Json(match resp {
                 Ok(r) => JsonRpcResponse::ok(id, r),
                 Err((code, msg)) => JsonRpcResponse::err(id, code, msg),
-            })
-            .into_response()
+            }).into_response()
         }
 
-        other => Json(JsonRpcResponse::err(
-            id,
-            -32601,
-            format!("Method not found: {other}"),
-        ))
-        .into_response(),
+        other => Json(JsonRpcResponse::err(id, -32601, format!("Method not found: {other}"))).into_response(),
     }
 }
 
 // ── Tool dispatch ─────────────────────────────────────────────────────────────
 
-async fn handle_tool_call(
-    state: &AppState,
-    params: &Value,
-) -> Result<Value, (i32, String)> {
-    let name = params
-        .get("name")
-        .and_then(|v| v.as_str())
+async fn dispatch_tool(state: &AppState, params: &Value) -> Result<Value, (i32, String)> {
+    let name = params.get("name").and_then(|v| v.as_str())
         .ok_or((-32602, "Missing tool name".to_string()))?;
-
     let args = params.get("arguments").cloned().unwrap_or(json!({}));
 
     match name {
-        "query" => tool_query(state, &args).await,
-        "list_documents" => tool_list_documents(state, &args).await,
+        "query"                      => tool_query(state, &args).await,
+        "document_upload"            => tool_document_upload(state, &args).await,
+        "document_list"              => tool_document_list(state, &args).await,
+        "document_get"               => tool_document_get(state, &args).await,
+        "document_delete"            => tool_document_delete(state, &args).await,
+        "document_status"            => tool_document_status(state, &args).await,
+        "graph_search_entities"      => tool_graph_search_entities(state, &args).await,
+        "graph_get_entity"           => tool_graph_get_entity(state, &args).await,
+        "graph_entity_neighborhood"  => tool_graph_neighborhood(state, &args).await,
+        "graph_search_relationships" => tool_graph_search_relationships(state, &args).await,
+        "health"                     => tool_health(state).await,
+        "workspace_list"             => tool_workspace_list(state).await,
+        "workspace_create"           => tool_workspace_create(state, &args).await,
+        "workspace_get"              => tool_workspace_get(state, &args).await,
+        "workspace_delete"           => tool_workspace_delete(state, &args).await,
+        "workspace_stats"            => tool_workspace_stats(state, &args).await,
         other => Err((-32602, format!("Unknown tool: {other}"))),
     }
 }
 
-// ── query tool ────────────────────────────────────────────────────────────────
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+fn text_result(text: impl Into<String>) -> Value {
+    json!({ "content": [{ "type": "text", "text": text.into() }] })
+}
+
+fn json_result(v: &Value) -> Value {
+    text_result(serde_json::to_string_pretty(v).unwrap_or_else(|_| "{}".to_string()))
+}
+
+fn require_str<'a>(args: &'a Value, key: &str) -> Result<&'a str, (i32, String)> {
+    args.get(key).and_then(|v| v.as_str())
+        .ok_or_else(|| (-32602, format!("Missing required parameter: {key}")))
+}
+
+fn node_label(node: &edgequake_storage::traits::GraphNode) -> &str {
+    node.properties.get("entity_type")
+        .or_else(|| node.properties.get("label"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+}
+
+fn edge_label(edge: &edgequake_storage::traits::GraphEdge) -> &str {
+    edge.properties.get("label")
+        .or_else(|| edge.properties.get("relationship_type"))
+        .or_else(|| edge.properties.get("type"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+}
+
+fn edge_weight(edge: &edgequake_storage::traits::GraphEdge) -> f64 {
+    edge.properties.get("weight")
+        .and_then(|v| v.as_f64())
+        .unwrap_or(1.0)
+}
+
+// ── query ─────────────────────────────────────────────────────────────────────
 
 async fn tool_query(state: &AppState, args: &Value) -> Result<Value, (i32, String)> {
-    let query_text = args
-        .get("query")
-        .and_then(|v| v.as_str())
-        .ok_or((-32602, "Missing required parameter: query".to_string()))?;
+    let query_text = require_str(args, "query")?;
 
-    let mode = args
-        .get("mode")
-        .and_then(|v| v.as_str())
+    let mode = args.get("mode").and_then(|v| v.as_str())
         .and_then(QueryMode::parse)
         .unwrap_or(QueryMode::Hybrid);
 
     let mut engine_req = EngineQueryRequest::new(query_text).with_mode(mode);
 
-    // Apply topic filter if provided and valid
     if let Some(topic) = args.get("topic").and_then(|v| v.as_str()) {
         if ALLOWED_TOPICS.iter().any(|&t| t.eq_ignore_ascii_case(topic)) {
             match crate::handlers::query::topic_resolver::resolve_topic_filter(
-                state.kv_storage.as_ref(),
-                topic,
-                None,
-                None,
-            )
-            .await
-            {
-                Ok(Some(doc_ids)) => {
-                    engine_req = engine_req.with_allowed_document_ids(doc_ids);
-                }
+                state.kv_storage.as_ref(), topic, None, None,
+            ).await {
+                Ok(Some(ids)) => { engine_req = engine_req.with_allowed_document_ids(ids); }
                 Ok(None) => {}
-                Err(e) => {
-                    warn!(error = %e, "MCP topic filter failed — proceeding unscoped");
-                }
+                Err(e) => { warn!(error = %e, "MCP topic filter failed — unscoped"); }
             }
         }
     }
@@ -230,22 +396,15 @@ async fn tool_query(state: &AppState, args: &Value) -> Result<Value, (i32, Strin
     match state.sota_engine.query(engine_req).await {
         Ok(result) => {
             let chunks = &result.context.chunks;
-            let sources_text = if !chunks.is_empty() {
-                let refs: Vec<String> = chunks
-                    .iter()
-                    .take(5)
-                    .enumerate()
-                    .map(|(i, c)| {
-                        format!("[{}] {}", i + 1, c.content.chars().take(150).collect::<String>())
-                    })
+            let sources = if !chunks.is_empty() {
+                let refs: Vec<String> = chunks.iter().take(5).enumerate()
+                    .map(|(i, c)| format!("[{}] {}", i + 1, c.content.chars().take(200).collect::<String>()))
                     .collect();
-                format!("\n\n---\n**Sources:**\n{}", refs.join("\n"))
+                format!("\n\n---\n**Sources:**\n{}", refs.join("\n\n"))
             } else {
                 String::new()
             };
-
-            let text = format!("{}{}", result.answer, sources_text);
-            Ok(json!({ "content": [{ "type": "text", "text": text }] }))
+            Ok(text_result(format!("{}{}", result.answer, sources)))
         }
         Err(e) => Ok(json!({
             "content": [{ "type": "text", "text": format!("Query failed: {e}") }],
@@ -254,35 +413,430 @@ async fn tool_query(state: &AppState, args: &Value) -> Result<Value, (i32, Strin
     }
 }
 
-// ── list_documents tool ───────────────────────────────────────────────────────
+// ── document_upload ───────────────────────────────────────────────────────────
 
-async fn tool_list_documents(state: &AppState, args: &Value) -> Result<Value, (i32, String)> {
-    let limit = args
-        .get("limit")
-        .and_then(|v| v.as_u64())
-        .unwrap_or(20)
-        .min(100) as usize;
+async fn tool_document_upload(state: &AppState, args: &Value) -> Result<Value, (i32, String)> {
+    let content = require_str(args, "content")?;
+    let title = args.get("title").and_then(|v| v.as_str()).unwrap_or("Untitled");
+    let document_id = Uuid::new_v4().to_string();
 
-    let keys = state
-        .kv_storage
-        .keys_with_suffix("-metadata")
-        .await
+    let _ = state.kv_storage.upsert(&[(
+        format!("{}-metadata", document_id),
+        json!({
+            "document_id": document_id,
+            "title": title,
+            "status": "processing",
+            "created_at": chrono::Utc::now().to_rfc3339(),
+        }),
+    )]).await;
+
+    match state.pipeline.process_with_resilience(&document_id, content, None).await {
+        Ok(result) => Ok(json_result(&json!({
+            "document_id": document_id,
+            "status": "completed",
+            "chunk_count": result.stats.chunk_count,
+            "entity_count": result.stats.entity_count,
+            "relationship_count": result.stats.relationship_count,
+        }))),
+        Err(e) => Ok(json!({
+            "content": [{ "type": "text", "text": format!("Upload failed: {e}") }],
+            "isError": true
+        })),
+    }
+}
+
+// ── document_list ─────────────────────────────────────────────────────────────
+
+async fn tool_document_list(state: &AppState, args: &Value) -> Result<Value, (i32, String)> {
+    let page = args.get("page").and_then(|v| v.as_u64()).unwrap_or(1).max(1) as usize;
+    let page_size = args.get("page_size").and_then(|v| v.as_u64()).unwrap_or(20).min(100) as usize;
+    let status_filter = args.get("status").and_then(|v| v.as_str());
+    let search_filter = args.get("search").and_then(|v| v.as_str()).map(|s| s.to_lowercase());
+
+    let keys = state.kv_storage.keys_with_suffix("-metadata").await
         .map_err(|e| (-32603, format!("Storage error: {e}")))?;
 
-    let mut docs = Vec::with_capacity(limit);
-    for key in keys.iter().take(limit) {
-        let doc_id = key.trim_end_matches("-metadata");
+    let mut docs = Vec::new();
+    for key in &keys {
         if let Ok(Some(meta)) = state.kv_storage.get_by_id(key).await {
+            let doc_id = key.trim_end_matches("-metadata");
+            let doc_status = meta.get("enrichment_status").or_else(|| meta.get("status"))
+                .and_then(|v| v.as_str()).unwrap_or("");
+            let title = meta.get("title").and_then(|v| v.as_str()).unwrap_or(doc_id);
+
+            if let Some(sf) = status_filter {
+                if doc_status != sf { continue; }
+            }
+            if let Some(ref q) = search_filter {
+                if !title.to_lowercase().contains(q.as_str()) { continue; }
+            }
+
             docs.push(json!({
                 "id": doc_id,
+                "title": title,
+                "status": doc_status,
                 "topic": meta.get("enrichment_topic").and_then(|v| v.as_str()).unwrap_or(""),
                 "language": meta.get("enrichment_language").and_then(|v| v.as_str()).unwrap_or(""),
-                "status": meta.get("enrichment_status").and_then(|v| v.as_str()).unwrap_or(""),
                 "summary": meta.get("enrichment_summary").and_then(|v| v.as_str()).unwrap_or(""),
+                "created_at": meta.get("created_at").and_then(|v| v.as_str()).unwrap_or(""),
             }));
         }
     }
 
-    let text = serde_json::to_string_pretty(&docs).unwrap_or_else(|_| "[]".to_string());
-    Ok(json!({ "content": [{ "type": "text", "text": text }] }))
+    let total = docs.len();
+    let start = ((page - 1) * page_size).min(total);
+    let end = (start + page_size).min(total);
+
+    Ok(json_result(&json!({
+        "documents": &docs[start..end],
+        "total": total,
+        "page": page,
+        "page_size": page_size,
+        "has_more": end < total,
+    })))
+}
+
+// ── document_get ──────────────────────────────────────────────────────────────
+
+async fn tool_document_get(state: &AppState, args: &Value) -> Result<Value, (i32, String)> {
+    let doc_id = require_str(args, "document_id")?;
+    let key = format!("{}-metadata", doc_id);
+
+    match state.kv_storage.get_by_id(&key).await {
+        Ok(Some(meta)) => Ok(json_result(&json!({
+            "id": doc_id,
+            "title": meta.get("title").and_then(|v| v.as_str()).unwrap_or(doc_id),
+            "status": meta.get("enrichment_status").or_else(|| meta.get("status")).and_then(|v| v.as_str()).unwrap_or(""),
+            "topic": meta.get("enrichment_topic").and_then(|v| v.as_str()).unwrap_or(""),
+            "tags": meta.get("enrichment_tags").cloned().unwrap_or(json!([])),
+            "language": meta.get("enrichment_language").and_then(|v| v.as_str()).unwrap_or(""),
+            "summary": meta.get("enrichment_summary").and_then(|v| v.as_str()).unwrap_or(""),
+            "keywords": meta.get("enrichment_keywords").cloned().unwrap_or(json!([])),
+            "enrichment_completed_at": meta.get("enrichment_completed_at").and_then(|v| v.as_str()).unwrap_or(""),
+            "created_at": meta.get("created_at").and_then(|v| v.as_str()).unwrap_or(""),
+        }))),
+        Ok(None) => Ok(json!({
+            "content": [{ "type": "text", "text": format!("Document not found: {doc_id}") }],
+            "isError": true
+        })),
+        Err(e) => Err((-32603, format!("Storage error: {e}"))),
+    }
+}
+
+// ── document_delete ───────────────────────────────────────────────────────────
+
+async fn tool_document_delete(state: &AppState, args: &Value) -> Result<Value, (i32, String)> {
+    let doc_id = require_str(args, "document_id")?;
+
+    let chunk_keys = state.kv_storage.keys_with_prefix(&format!("{}-chunk-", doc_id)).await
+        .map_err(|e| (-32603, format!("Storage error: {e}")))?;
+
+    let mut keys_to_delete: Vec<String> = chunk_keys;
+    keys_to_delete.push(format!("{}-metadata", doc_id));
+    keys_to_delete.push(format!("{}-summary", doc_id));
+
+    let _ = state.kv_storage.delete(&keys_to_delete).await;
+    let _ = state.vector_storage.delete(&keys_to_delete).await;
+
+    // Remove graph nodes linked to this document (best-effort)
+    let entity_key = format!("{}-entities", doc_id);
+    if let Ok(Some(entity_list)) = state.kv_storage.get_by_id(&entity_key).await {
+        if let Some(arr) = entity_list.as_array() {
+            for v in arr {
+                if let Some(entity_id) = v.as_str() {
+                    let _ = state.graph_storage.delete_node(entity_id).await;
+                }
+            }
+        }
+    }
+
+    Ok(json_result(&json!({ "success": true, "document_id": doc_id })))
+}
+
+// ── document_status ───────────────────────────────────────────────────────────
+
+async fn tool_document_status(state: &AppState, args: &Value) -> Result<Value, (i32, String)> {
+    let doc_id = require_str(args, "document_id")?;
+    let key = format!("{}-metadata", doc_id);
+
+    match state.kv_storage.get_by_id(&key).await {
+        Ok(Some(meta)) => Ok(json_result(&json!({
+            "id": doc_id,
+            "status": meta.get("enrichment_status").or_else(|| meta.get("status")).and_then(|v| v.as_str()).unwrap_or("unknown"),
+            "enrichment_completed_at": meta.get("enrichment_completed_at").and_then(|v| v.as_str()),
+            "enrichment_error": meta.get("enrichment_error").and_then(|v| v.as_str()),
+        }))),
+        Ok(None) => Ok(json!({
+            "content": [{ "type": "text", "text": format!("Document not found: {doc_id}") }],
+            "isError": true
+        })),
+        Err(e) => Err((-32603, format!("Storage error: {e}"))),
+    }
+}
+
+// ── graph_search_entities ─────────────────────────────────────────────────────
+
+async fn tool_graph_search_entities(state: &AppState, args: &Value) -> Result<Value, (i32, String)> {
+    let search = args.get("search").and_then(|v| v.as_str()).unwrap_or("");
+    let label = args.get("label").and_then(|v| v.as_str());
+    let limit = args.get("limit").and_then(|v| v.as_u64()).unwrap_or(20) as usize;
+
+    let results = state.graph_storage
+        .search_nodes(search, limit, label, None, None)
+        .await
+        .map_err(|e| (-32603, format!("Graph error: {e}")))?;
+
+    let entities: Vec<Value> = results.iter().map(|(n, degree)| json!({
+        "name": n.id,
+        "label": node_label(n),
+        "description": n.properties.get("description").and_then(|v| v.as_str()).unwrap_or(""),
+        "degree": degree,
+    })).collect();
+
+    Ok(json_result(&json!(entities)))
+}
+
+// ── graph_get_entity ──────────────────────────────────────────────────────────
+
+async fn tool_graph_get_entity(state: &AppState, args: &Value) -> Result<Value, (i32, String)> {
+    let name = require_str(args, "entity_name")?;
+
+    match state.graph_storage.get_node(name).await {
+        Ok(Some(node)) => Ok(json_result(&json!({
+            "name": node.id,
+            "label": node_label(&node),
+            "description": node.properties.get("description").and_then(|v| v.as_str()).unwrap_or(""),
+            "properties": node.properties,
+        }))),
+        Ok(None) => Ok(json!({
+            "content": [{ "type": "text", "text": format!("Entity not found: {name}") }],
+            "isError": true
+        })),
+        Err(e) => Err((-32603, format!("Graph error: {e}"))),
+    }
+}
+
+// ── graph_entity_neighborhood ─────────────────────────────────────────────────
+
+async fn tool_graph_neighborhood(state: &AppState, args: &Value) -> Result<Value, (i32, String)> {
+    let name = require_str(args, "entity_name")?;
+
+    let center = state.graph_storage.get_node(name).await
+        .map_err(|e| (-32603, format!("Graph error: {e}")))?
+        .ok_or_else(|| (-32602, format!("Entity not found: {name}")))?;
+
+    let edges = state.graph_storage.get_node_edges(&center.id).await
+        .map_err(|e| (-32603, format!("Graph error: {e}")))?;
+
+    let mut neighbor_ids: Vec<String> = edges.iter().map(|e| {
+        if e.source == center.id { e.target.clone() } else { e.source.clone() }
+    }).collect();
+    neighbor_ids.dedup();
+
+    let mut neighbors = Vec::new();
+    for neighbor_id in neighbor_ids.iter().take(20) {
+        if let Ok(Some(node)) = state.graph_storage.get_node(neighbor_id).await {
+            let rel = edges.iter().find(|e| &e.source == neighbor_id || &e.target == neighbor_id);
+            neighbors.push(json!({
+                "entity": {
+                    "name": node.id,
+                    "label": node_label(&node),
+                    "description": node.properties.get("description").and_then(|v| v.as_str()).unwrap_or(""),
+                },
+                "relationship": rel.map(|r| edge_label(r)).unwrap_or(""),
+                "direction": rel.map(|r| if r.source == center.id { "outgoing" } else { "incoming" }).unwrap_or(""),
+            }));
+        }
+    }
+
+    Ok(json_result(&json!({
+        "center": {
+            "name": center.id,
+            "label": node_label(&center),
+            "description": center.properties.get("description").and_then(|v| v.as_str()).unwrap_or(""),
+        },
+        "neighbors": neighbors,
+    })))
+}
+
+// ── graph_search_relationships ────────────────────────────────────────────────
+
+async fn tool_graph_search_relationships(state: &AppState, args: &Value) -> Result<Value, (i32, String)> {
+    let source_filter = args.get("source").and_then(|v| v.as_str());
+    let target_filter = args.get("target").and_then(|v| v.as_str());
+    let label_filter = args.get("label").and_then(|v| v.as_str()).map(|s| s.to_uppercase());
+    let limit = args.get("limit").and_then(|v| v.as_u64()).unwrap_or(20) as usize;
+
+    let edges = if let Some(src) = source_filter {
+        state.graph_storage.get_node_edges(src).await
+            .map_err(|e| (-32603, format!("Graph error: {e}")))?
+    } else if let Some(tgt) = target_filter {
+        state.graph_storage.get_node_edges(tgt).await
+            .map_err(|e| (-32603, format!("Graph error: {e}")))?
+    } else {
+        state.graph_storage.get_all_edges().await
+            .map_err(|e| (-32603, format!("Graph error: {e}")))?
+    };
+
+    let filtered: Vec<Value> = edges.iter()
+        .filter(|e| {
+            source_filter.map_or(true, |s| e.source.to_lowercase().contains(&s.to_lowercase()))
+                && target_filter.map_or(true, |t| e.target.to_lowercase().contains(&t.to_lowercase()))
+                && label_filter.as_deref().map_or(true, |l| edge_label(e).to_uppercase().contains(l))
+        })
+        .take(limit)
+        .map(|e| json!({
+            "source": e.source,
+            "target": e.target,
+            "label": edge_label(e),
+            "description": e.properties.get("description").and_then(|v| v.as_str()).unwrap_or(""),
+            "weight": edge_weight(e),
+        }))
+        .collect();
+
+    Ok(json_result(&json!(filtered)))
+}
+
+// ── health ────────────────────────────────────────────────────────────────────
+
+async fn tool_health(state: &AppState) -> Result<Value, (i32, String)> {
+    let kv_ok = state.kv_storage.ping().await.is_ok();
+    let vector_ok = state.vector_storage.ping().await.is_ok();
+    let graph_ok = state.graph_storage.ping().await.is_ok();
+
+    Ok(json_result(&json!({
+        "status": if kv_ok && vector_ok && graph_ok { "healthy" } else { "degraded" },
+        "components": {
+            "kv_storage": if kv_ok { "ok" } else { "error" },
+            "vector_storage": if vector_ok { "ok" } else { "error" },
+            "graph_storage": if graph_ok { "ok" } else { "error" },
+            "llm_provider": "ok",
+        }
+    })))
+}
+
+// ── workspace_list ────────────────────────────────────────────────────────────
+
+async fn tool_workspace_list(state: &AppState) -> Result<Value, (i32, String)> {
+    let tenants = state.workspace_service.list_tenants(100, 0).await
+        .map_err(|e| (-32603, format!("Workspace service error: {e}")))?;
+
+    let mut all_workspaces = Vec::new();
+    for tenant in &tenants {
+        if let Ok(workspaces) = state.workspace_service.list_workspaces(tenant.tenant_id).await {
+            for w in workspaces {
+                all_workspaces.push(json!({
+                    "id": w.workspace_id,
+                    "name": w.name,
+                    "slug": w.slug,
+                    "description": w.description,
+                    "tenant_id": tenant.tenant_id,
+                    "tenant_name": tenant.name,
+                    "llm_provider": w.llm_provider,
+                    "llm_model": w.llm_model,
+                }));
+            }
+        }
+    }
+
+    Ok(json_result(&json!(all_workspaces)))
+}
+
+// ── workspace_create ──────────────────────────────────────────────────────────
+
+async fn tool_workspace_create(state: &AppState, args: &Value) -> Result<Value, (i32, String)> {
+    let name = require_str(args, "name")?;
+
+    let tenant_id = if let Some(id_str) = args.get("tenant_id").and_then(|v| v.as_str()) {
+        Uuid::parse_str(id_str).map_err(|_| (-32602, "Invalid tenant_id UUID".to_string()))?
+    } else {
+        let tenants = state.workspace_service.list_tenants(1, 0).await
+            .map_err(|e| (-32603, format!("Workspace service error: {e}")))?;
+        tenants.first().map(|t| t.tenant_id)
+            .ok_or((-32603, "No tenants found".to_string()))?
+    };
+
+    let create_req = CreateWorkspaceRequest {
+        name: name.to_string(),
+        slug: None,
+        description: args.get("description").and_then(|v| v.as_str()).map(|s| s.to_string()),
+        max_documents: None,
+        llm_model: args.get("llm_model").and_then(|v| v.as_str()).map(|s| s.to_string()),
+        llm_provider: args.get("llm_provider").and_then(|v| v.as_str()).map(|s| s.to_string()),
+        embedding_model: None,
+        embedding_provider: None,
+        embedding_dimension: None,
+        vision_llm_model: None,
+        vision_llm_provider: None,
+        pdf_parser_backend: None,
+        entity_types: None,
+        entity_types_strict: None,
+    };
+
+    let workspace = state.workspace_service.create_workspace(tenant_id, create_req).await
+        .map_err(|e| (-32603, format!("Create workspace failed: {e}")))?;
+
+    Ok(json_result(&json!({
+        "id": workspace.workspace_id,
+        "name": workspace.name,
+        "slug": workspace.slug,
+        "tenant_id": tenant_id,
+    })))
+}
+
+// ── workspace_get ─────────────────────────────────────────────────────────────
+
+async fn tool_workspace_get(state: &AppState, args: &Value) -> Result<Value, (i32, String)> {
+    let id_str = require_str(args, "workspace_id")?;
+    let workspace_id = Uuid::parse_str(id_str).map_err(|_| (-32602, "Invalid workspace_id UUID".to_string()))?;
+
+    match state.workspace_service.get_workspace(workspace_id).await {
+        Ok(Some(w)) => Ok(json_result(&json!({
+            "id": w.workspace_id,
+            "name": w.name,
+            "slug": w.slug,
+            "description": w.description,
+            "llm_provider": w.llm_provider,
+            "llm_model": w.llm_model,
+            "embedding_provider": w.embedding_provider,
+            "embedding_model": w.embedding_model,
+        }))),
+        Ok(None) => Ok(json!({
+            "content": [{ "type": "text", "text": format!("Workspace not found: {id_str}") }],
+            "isError": true
+        })),
+        Err(e) => Err((-32603, format!("Workspace service error: {e}"))),
+    }
+}
+
+// ── workspace_delete ──────────────────────────────────────────────────────────
+
+async fn tool_workspace_delete(state: &AppState, args: &Value) -> Result<Value, (i32, String)> {
+    let id_str = require_str(args, "workspace_id")?;
+    let workspace_id = Uuid::parse_str(id_str).map_err(|_| (-32602, "Invalid workspace_id UUID".to_string()))?;
+
+    state.workspace_service.delete_workspace(workspace_id).await
+        .map_err(|e| (-32603, format!("Delete workspace failed: {e}")))?;
+
+    Ok(json_result(&json!({ "success": true, "workspace_id": id_str })))
+}
+
+// ── workspace_stats ───────────────────────────────────────────────────────────
+
+async fn tool_workspace_stats(state: &AppState, args: &Value) -> Result<Value, (i32, String)> {
+    let id_str = require_str(args, "workspace_id")?;
+    let workspace_id = Uuid::parse_str(id_str).map_err(|_| (-32602, "Invalid workspace_id UUID".to_string()))?;
+
+    let stats = state.workspace_service.get_workspace_stats(workspace_id).await
+        .map_err(|e| (-32603, format!("Workspace service error: {e}")))?;
+
+    Ok(json_result(&json!({
+        "workspace_id": id_str,
+        "document_count": stats.document_count,
+        "entity_count": stats.entity_count,
+        "relationship_count": stats.relationship_count,
+        "chunk_count": stats.chunk_count,
+        "embedding_count": stats.embedding_count,
+        "storage_bytes": stats.storage_bytes,
+    })))
 }

--- a/edgequake/crates/edgequake-api/src/handlers/mod.rs
+++ b/edgequake/crates/edgequake-api/src/handlers/mod.rs
@@ -67,6 +67,7 @@ pub mod entities_types;
 pub mod graph;
 pub mod graph_types;
 pub mod health;
+pub mod mcp;
 pub mod health_types;
 pub mod injection;
 pub mod injection_types;

--- a/edgequake/crates/edgequake-api/src/handlers/pdf_upload/helpers.rs
+++ b/edgequake/crates/edgequake-api/src/handlers/pdf_upload/helpers.rs
@@ -9,7 +9,7 @@ use crate::middleware::TenantContext;
 use crate::state::AppState;
 use edgequake_core::Workspace;
 use edgequake_storage::PdfDocumentStorage;
-use edgequake_tasks::{PdfProcessingData, Task, TaskStatus, TaskType};
+use edgequake_tasks::{MetadataEnrichData, PdfProcessingData, Task, TaskStatus, TaskType};
 
 // ============================================================================
 // Helper Functions
@@ -34,14 +34,17 @@ pub(super) fn get_pdf_storage(_state: &AppState) -> ApiResult<Arc<dyn PdfDocumen
     ))
 }
 
-/// Create PDF processing background task.
+/// Create PDF processing background task and a paired metadata enrichment task.
+///
+/// Returns `(track_id, document_id)`. The `document_id` is pre-generated so both
+/// tasks share the same metadata record in KV storage.
 pub(super) async fn create_pdf_processing_task(
     state: &AppState,
     context: &TenantContext,
     pdf_id: Uuid,
     options: &PdfUploadOptions,
     workspace: Option<&Workspace>,
-) -> ApiResult<String> {
+) -> ApiResult<(String, String)> {
     let workspace_id = context
         .workspace_id_uuid()
         .ok_or_else(|| ApiError::BadRequest("Workspace ID required".to_string()))?;
@@ -49,6 +52,10 @@ pub(super) async fn create_pdf_processing_task(
     let tenant_id = context
         .tenant_id_uuid()
         .ok_or_else(|| ApiError::BadRequest("Tenant ID required".to_string()))?;
+
+    // Pre-generate document_id so enrichment and processing tasks share the same
+    // metadata record. PdfProcessing uses existing_document_id to avoid duplicates on retry.
+    let document_id = Uuid::new_v4().to_string();
 
     let task_data = PdfProcessingData {
         pdf_id,
@@ -65,7 +72,7 @@ pub(super) async fn create_pdf_processing_task(
         } else {
             None
         },
-        existing_document_id: None, // Fresh upload — create new document
+        existing_document_id: Some(document_id.clone()),
         pdf_parser_backend: options.resolved_backend(workspace),
         restart_from_scratch: false,
     };
@@ -102,19 +109,72 @@ pub(super) async fn create_pdf_processing_task(
         .await
         .map_err(|e| ApiError::Internal(format!("Failed to create task: {}", e)))?;
 
-    // Queue task for background processing (critical - missing this causes tasks to stay in pending)
+    // Queue task for background processing
     state
         .task_queue
         .send(task)
         .await
         .map_err(|e| ApiError::Internal(format!("Failed to queue task: {}", e)))?;
 
+    // Write initial enrichment_status so clients can poll immediately
+    let metadata_key = format!("{}-metadata", document_id);
+    let _ = state
+        .kv_storage
+        .upsert(&[(
+            metadata_key,
+            serde_json::json!({"enrichment_status": "pending"}),
+        )])
+        .await;
+
+    // Enqueue metadata enrichment task to the dedicated enrichment pool
+    let enrich_data = MetadataEnrichData {
+        document_id: document_id.clone(),
+        pdf_id,
+        tenant_id,
+        workspace_id,
+        max_pages: 5,
+    };
+    let enrich_task = Task {
+        track_id: format!("metadata_enrich-{}", Uuid::new_v4()),
+        tenant_id,
+        workspace_id,
+        task_type: TaskType::MetadataEnrich,
+        status: TaskStatus::Pending,
+        created_at: Utc::now(),
+        updated_at: Utc::now(),
+        started_at: None,
+        completed_at: None,
+        error_message: None,
+        error: None,
+        retry_count: 0,
+        max_retries: 3,
+        consecutive_timeout_failures: 0,
+        circuit_breaker_tripped: false,
+        task_data: serde_json::to_value(&enrich_data)
+            .map_err(|e| ApiError::Internal(format!("Failed to serialize enrich data: {}", e)))?,
+        metadata: None,
+        progress: None,
+        result: None,
+    };
+
+    state
+        .task_storage
+        .create_task(&enrich_task)
+        .await
+        .map_err(|e| ApiError::Internal(format!("Failed to create enrichment task: {}", e)))?;
+
+    state
+        .enrich_queue
+        .send(enrich_task)
+        .await
+        .map_err(|e| ApiError::Internal(format!("Failed to queue enrichment task: {}", e)))?;
+
     debug!(
-        "Created and queued PDF processing task: id={}, pdf_id={}",
-        track_id, pdf_id
+        "Created PDF processing task id={} and enrichment task, pdf_id={}, doc_id={}",
+        track_id, pdf_id, document_id
     );
 
-    Ok(track_id)
+    Ok((track_id, document_id))
 }
 
 /// Extract page count from PDF binary data.

--- a/edgequake/crates/edgequake-api/src/handlers/pdf_upload/operations.rs
+++ b/edgequake/crates/edgequake-api/src/handlers/pdf_upload/operations.rs
@@ -132,7 +132,8 @@ pub async fn retry_pdf_processing(
             ..Default::default()
         };
 
-        let task_id = create_pdf_processing_task(&state, &tenant, pdf_uuid, &options, None).await?;
+        let (task_id, _document_id) =
+            create_pdf_processing_task(&state, &tenant, pdf_uuid, &options, None).await?;
 
         info!(
             pdf_id = %pdf_id,

--- a/edgequake/crates/edgequake-api/src/handlers/pdf_upload/upload.rs
+++ b/edgequake/crates/edgequake-api/src/handlers/pdf_upload/upload.rs
@@ -403,7 +403,7 @@ async fn process_pdf_upload_parts(
                 .await
                 .map_err(|e| ApiError::Internal(format!("Failed to reset PDF status: {}", e)))?;
 
-            let task_id = create_pdf_processing_task(
+            let (task_id, _document_id) = create_pdf_processing_task(
                 state,
                 context,
                 existing.pdf_id,
@@ -533,7 +533,7 @@ async fn process_pdf_upload_parts(
         }
     };
 
-    let task_id =
+    let (task_id, document_id) =
         create_pdf_processing_task(state, context, pdf_id, &options, workspace.as_ref()).await?;
     let effective_track_id = options.track_id.clone().unwrap_or_else(|| task_id.clone());
     state
@@ -544,7 +544,7 @@ async fn process_pdf_upload_parts(
     let estimated_time = estimate_processing_time(&file_data, page_count);
     Ok(PdfUploadResponse {
         pdf_id: pdf_id.to_string(),
-        document_id: None,
+        document_id: Some(document_id),
         status: "processing".to_string(),
         task_id: task_id.to_string(),
         track_id: options.track_id,

--- a/edgequake/crates/edgequake-api/src/handlers/query/mod.rs
+++ b/edgequake/crates/edgequake-api/src/handlers/query/mod.rs
@@ -52,6 +52,7 @@
 //! ```
 
 pub(crate) mod document_filter_resolver;
+pub(crate) mod topic_resolver;
 mod query_execute;
 mod query_stream;
 pub(crate) mod workspace_resolve;

--- a/edgequake/crates/edgequake-api/src/handlers/query/query_execute.rs
+++ b/edgequake/crates/edgequake-api/src/handlers/query/query_execute.rs
@@ -179,9 +179,58 @@ pub async fn execute_query(
             );
             engine_request = engine_request.with_allowed_document_ids(allowed_ids);
         }
+    } else if let Some(ref topic) = request.topic {
+        // Explicit topic filter: restrict to documents matching the given topic.
+        match super::topic_resolver::resolve_topic_filter(
+            state.kv_storage.as_ref(),
+            topic,
+            data_tenant_id.as_deref(),
+            tenant_ctx.workspace_id.as_deref(),
+        )
+        .await
+        {
+            Ok(Some(doc_ids)) => {
+                debug!(
+                    topic = %topic,
+                    document_count = doc_ids.len(),
+                    "Explicit topic filter applied"
+                );
+                engine_request = engine_request.with_allowed_document_ids(doc_ids);
+            }
+            Ok(None) => {
+                debug!(topic = %topic, "No documents matched explicit topic — proceeding unscoped");
+            }
+            Err(e) => {
+                tracing::warn!(error = %e, "Explicit topic filter failed — proceeding without scope");
+            }
+        }
+    } else if let Some(ref tags) = request.tags {
+        match super::topic_resolver::resolve_tags_filter(
+            state.kv_storage.as_ref(),
+            tags,
+            data_tenant_id.as_deref(),
+            tenant_ctx.workspace_id.as_deref(),
+        )
+        .await
+        {
+            Ok(Some(doc_ids)) => {
+                debug!(
+                    tags = ?tags,
+                    document_count = doc_ids.len(),
+                    "Tags filter applied"
+                );
+                engine_request = engine_request.with_allowed_document_ids(doc_ids);
+            }
+            Ok(None) => {
+                debug!(tags = ?tags, "No documents matched tags filter — proceeding unscoped");
+            }
+            Err(e) => {
+                tracing::warn!(error = %e, "Tags filter failed — proceeding without scope");
+            }
+        }
     } else if request.enable_topic_scope {
         // Topic-scoped RAG: classify query topic → restrict to relevant documents.
-        // Only runs when no explicit document_filter is set.
+        // Only runs when no explicit document_filter or topic is set.
         match super::topic_resolver::resolve_topic_scope(
             state.kv_storage.as_ref(),
             state.llm_provider.as_ref(),

--- a/edgequake/crates/edgequake-api/src/handlers/query/query_execute.rs
+++ b/edgequake/crates/edgequake-api/src/handlers/query/query_execute.rs
@@ -186,6 +186,7 @@ pub async fn execute_query(
 
     // FIX #168: Create LLM override OUTSIDE the workspace block so it's available
     // in all code paths (with or without workspace context).
+    // Priority: (1) request body llm_provider+llm_model, (2) workspace config, (3) system default.
     let llm_override = if let (Some(ref provider), Some(ref model)) =
         (&request.llm_provider, &request.llm_model)
     {
@@ -198,6 +199,27 @@ pub async fn execute_query(
             )
             .map_err(|e| ApiError::Internal(format!("Failed to create LLM provider: {}", e)))?,
         )
+    } else if let Some(ref ws) = workspace {
+        // Fall back to workspace-configured LLM when no request-level override is given.
+        // WHY: Without this, queries always use the system default model regardless of
+        // the per-workspace llm_provider/llm_model settings stored in the database.
+        if !ws.llm_provider.is_empty() && !ws.llm_model.is_empty() {
+            debug!(
+                provider = %ws.llm_provider,
+                model = %ws.llm_model,
+                "Using workspace LLM provider (no request override)"
+            );
+            Some(
+                crate::safety_limits::create_safe_llm_provider_with_headers(
+                    &ws.llm_provider,
+                    &ws.llm_model,
+                    request.extra_headers.clone(),
+                )
+                .map_err(|e| ApiError::Internal(format!("Failed to create LLM provider: {}", e)))?,
+            )
+        } else {
+            None
+        }
     } else {
         None
     };

--- a/edgequake/crates/edgequake-api/src/handlers/query/query_execute.rs
+++ b/edgequake/crates/edgequake-api/src/handlers/query/query_execute.rs
@@ -179,6 +179,35 @@ pub async fn execute_query(
             );
             engine_request = engine_request.with_allowed_document_ids(allowed_ids);
         }
+    } else if request.enable_topic_scope {
+        // Topic-scoped RAG: classify query topic → restrict to relevant documents.
+        // Only runs when no explicit document_filter is set.
+        match super::topic_resolver::resolve_topic_scope(
+            state.kv_storage.as_ref(),
+            state.llm_provider.as_ref(),
+            &request.query,
+            data_tenant_id.as_deref(),
+            tenant_ctx.workspace_id.as_deref(),
+        )
+        .await
+        {
+            Ok(Some(result)) => {
+                debug!(
+                    matched_topics = ?result.matched_topics,
+                    document_count = result.document_ids.len(),
+                    "Topic scope resolved — restricting query to matched documents"
+                );
+                engine_request =
+                    engine_request.with_allowed_document_ids(result.document_ids);
+            }
+            Ok(None) => {
+                debug!("Topic scope returned no restriction — proceeding with full search");
+            }
+            Err(e) => {
+                // Non-fatal: log and continue with unscoped search
+                tracing::warn!(error = %e, "Topic scope resolution failed — proceeding without scope");
+            }
+        }
     }
 
     // SPEC-032 & SPEC-033: Get workspace-specific embedding provider AND vector storage

--- a/edgequake/crates/edgequake-api/src/handlers/query/query_execute.rs
+++ b/edgequake/crates/edgequake-api/src/handlers/query/query_execute.rs
@@ -204,30 +204,6 @@ pub async fn execute_query(
                 tracing::warn!(error = %e, "Explicit topic filter failed — proceeding without scope");
             }
         }
-    } else if let Some(ref tags) = request.tags {
-        match super::topic_resolver::resolve_tags_filter(
-            state.kv_storage.as_ref(),
-            tags,
-            data_tenant_id.as_deref(),
-            tenant_ctx.workspace_id.as_deref(),
-        )
-        .await
-        {
-            Ok(Some(doc_ids)) => {
-                debug!(
-                    tags = ?tags,
-                    document_count = doc_ids.len(),
-                    "Tags filter applied"
-                );
-                engine_request = engine_request.with_allowed_document_ids(doc_ids);
-            }
-            Ok(None) => {
-                debug!(tags = ?tags, "No documents matched tags filter — proceeding unscoped");
-            }
-            Err(e) => {
-                tracing::warn!(error = %e, "Tags filter failed — proceeding without scope");
-            }
-        }
     } else if request.enable_topic_scope {
         // Topic-scoped RAG: classify query topic → restrict to relevant documents.
         // Only runs when no explicit document_filter or topic is set.

--- a/edgequake/crates/edgequake-api/src/handlers/query/query_stream.rs
+++ b/edgequake/crates/edgequake-api/src/handlers/query/query_stream.rs
@@ -150,30 +150,6 @@ pub async fn stream_query(
                 tracing::warn!(error = %e, "Explicit topic filter failed — proceeding without scope");
             }
         }
-    } else if let Some(ref tags) = request.tags {
-        match crate::handlers::query::topic_resolver::resolve_tags_filter(
-            state.kv_storage.as_ref(),
-            tags,
-            data_tenant_id.as_deref(),
-            tenant_ctx.workspace_id.as_deref(),
-        )
-        .await
-        {
-            Ok(Some(doc_ids)) => {
-                tracing::debug!(
-                    tags = ?tags,
-                    document_count = doc_ids.len(),
-                    "Tags filter applied to stream query"
-                );
-                engine_request = engine_request.with_allowed_document_ids(doc_ids);
-            }
-            Ok(None) => {
-                tracing::debug!(tags = ?tags, "No documents matched tags filter — stream proceeds unscoped");
-            }
-            Err(e) => {
-                tracing::warn!(error = %e, "Tags filter failed — proceeding without scope");
-            }
-        }
     } else if request.enable_topic_scope {
         match crate::handlers::query::topic_resolver::resolve_topic_scope(
             state.kv_storage.as_ref(),

--- a/edgequake/crates/edgequake-api/src/handlers/query/query_stream.rs
+++ b/edgequake/crates/edgequake-api/src/handlers/query/query_stream.rs
@@ -126,6 +126,29 @@ pub async fn stream_query(
                 )));
             }
         }
+    } else if request.enable_topic_scope {
+        match crate::handlers::query::topic_resolver::resolve_topic_scope(
+            state.kv_storage.as_ref(),
+            state.llm_provider.as_ref(),
+            &request.query,
+            data_tenant_id.as_deref(),
+            tenant_ctx.workspace_id.as_deref(),
+        )
+        .await
+        {
+            Ok(Some(result)) => {
+                tracing::debug!(
+                    matched_topics = ?result.matched_topics,
+                    document_count = result.document_ids.len(),
+                    "Topic scope resolved — restricting stream query to matched documents"
+                );
+                engine_request = engine_request.with_allowed_document_ids(result.document_ids);
+            }
+            Ok(None) => {}
+            Err(e) => {
+                tracing::warn!(error = %e, "Topic scope resolution failed — proceeding without scope");
+            }
+        }
     }
 
     // SPEC-006 + SPEC-032: Resolve LLM provider override

--- a/edgequake/crates/edgequake-api/src/handlers/query/query_stream.rs
+++ b/edgequake/crates/edgequake-api/src/handlers/query/query_stream.rs
@@ -126,6 +126,54 @@ pub async fn stream_query(
                 )));
             }
         }
+    } else if let Some(ref topic) = request.topic {
+        match crate::handlers::query::topic_resolver::resolve_topic_filter(
+            state.kv_storage.as_ref(),
+            topic,
+            data_tenant_id.as_deref(),
+            tenant_ctx.workspace_id.as_deref(),
+        )
+        .await
+        {
+            Ok(Some(doc_ids)) => {
+                tracing::debug!(
+                    topic = %topic,
+                    document_count = doc_ids.len(),
+                    "Explicit topic filter applied to stream query"
+                );
+                engine_request = engine_request.with_allowed_document_ids(doc_ids);
+            }
+            Ok(None) => {
+                tracing::debug!(topic = %topic, "No documents matched explicit topic — stream proceeds unscoped");
+            }
+            Err(e) => {
+                tracing::warn!(error = %e, "Explicit topic filter failed — proceeding without scope");
+            }
+        }
+    } else if let Some(ref tags) = request.tags {
+        match crate::handlers::query::topic_resolver::resolve_tags_filter(
+            state.kv_storage.as_ref(),
+            tags,
+            data_tenant_id.as_deref(),
+            tenant_ctx.workspace_id.as_deref(),
+        )
+        .await
+        {
+            Ok(Some(doc_ids)) => {
+                tracing::debug!(
+                    tags = ?tags,
+                    document_count = doc_ids.len(),
+                    "Tags filter applied to stream query"
+                );
+                engine_request = engine_request.with_allowed_document_ids(doc_ids);
+            }
+            Ok(None) => {
+                tracing::debug!(tags = ?tags, "No documents matched tags filter — stream proceeds unscoped");
+            }
+            Err(e) => {
+                tracing::warn!(error = %e, "Tags filter failed — proceeding without scope");
+            }
+        }
     } else if request.enable_topic_scope {
         match crate::handlers::query::topic_resolver::resolve_topic_scope(
             state.kv_storage.as_ref(),

--- a/edgequake/crates/edgequake-api/src/handlers/query/topic_resolver.rs
+++ b/edgequake/crates/edgequake-api/src/handlers/query/topic_resolver.rs
@@ -1,0 +1,272 @@
+//! Resolve query scope by matching query topic against document enrichment topics.
+//!
+//! When `enable_topic_scope` is set on a query, this module:
+//! 1. Scans KV for all `{doc_id}-metadata` keys in the workspace
+//! 2. Collects unique `enrichment_topic` values from completed enrichments
+//! 3. Uses the LLM to classify which topics are relevant to the query
+//! 4. Returns document IDs belonging to those matched topics
+//!
+//! Falls back gracefully (returns `None`) when:
+//! - Fewer than 2 distinct topics exist (no useful filtering)
+//! - No documents have completed enrichment
+//! - LLM classification fails (logs warning, search proceeds unscoped)
+
+use std::collections::HashMap;
+
+use edgequake_llm::traits::LLMProvider;
+use edgequake_storage::traits::KVStorage;
+use tracing::{debug, warn};
+
+pub struct TopicResolveResult {
+    pub matched_topics: Vec<String>,
+    pub document_ids: Vec<String>,
+}
+
+/// Resolve which document IDs are relevant to the query based on enrichment topics.
+///
+/// Returns `None` if topic scoping is not applicable (too few topics, no enrichment data).
+/// Returns `Some(result)` with matched topics and their document IDs.
+pub async fn resolve_topic_scope(
+    kv_storage: &dyn KVStorage,
+    llm_provider: &dyn LLMProvider,
+    query: &str,
+    tenant_id: Option<&str>,
+    workspace_id: Option<&str>,
+) -> Result<Option<TopicResolveResult>, crate::error::ApiError> {
+    // Collect topic → [doc_id] map from KV enrichment metadata
+    let topic_map = build_topic_map(kv_storage, tenant_id, workspace_id).await?;
+
+    if topic_map.len() < 2 {
+        debug!(
+            topic_count = topic_map.len(),
+            "Too few topics for scoping — skipping topic filter"
+        );
+        return Ok(None);
+    }
+
+    let topics: Vec<&str> = topic_map.keys().map(|s| s.as_str()).collect();
+
+    debug!(
+        topic_count = topics.len(),
+        topics = ?topics,
+        "Classifying query against available topics"
+    );
+
+    let matched_topics = classify_query_topics(llm_provider, query, &topics).await;
+
+    if matched_topics.is_empty() {
+        debug!("LLM found no matching topics — query will search all documents");
+        return Ok(None);
+    }
+
+    let document_ids: Vec<String> = matched_topics
+        .iter()
+        .filter_map(|t| topic_map.get(t.as_str()))
+        .flat_map(|ids| ids.iter().cloned())
+        .collect();
+
+    if document_ids.is_empty() {
+        return Ok(None);
+    }
+
+    debug!(
+        matched_topics = ?matched_topics,
+        document_count = document_ids.len(),
+        "Topic scope resolved"
+    );
+
+    Ok(Some(TopicResolveResult {
+        matched_topics,
+        document_ids,
+    }))
+}
+
+/// Scan KV storage and build a `HashMap<topic, Vec<doc_id>>`.
+async fn build_topic_map(
+    kv_storage: &dyn KVStorage,
+    tenant_id: Option<&str>,
+    workspace_id: Option<&str>,
+) -> Result<HashMap<String, Vec<String>>, crate::error::ApiError> {
+    let keys = kv_storage
+        .keys()
+        .await
+        .map_err(|e| crate::error::ApiError::Internal(format!("KV keys scan failed: {}", e)))?;
+
+    let metadata_keys: Vec<String> = keys
+        .into_iter()
+        .filter(|k| k.ends_with("-metadata"))
+        .collect();
+
+    if metadata_keys.is_empty() {
+        return Ok(HashMap::new());
+    }
+
+    let metadata_values = kv_storage
+        .get_by_ids(&metadata_keys)
+        .await
+        .map_err(|e| crate::error::ApiError::Internal(format!("KV batch fetch failed: {}", e)))?;
+
+    let mut topic_map: HashMap<String, Vec<String>> = HashMap::new();
+
+    for value in &metadata_values {
+        let obj = match value.as_object() {
+            Some(o) => o,
+            None => continue,
+        };
+
+        // Scope to matching tenant/workspace if provided
+        if let Some(tid) = tenant_id {
+            if obj.get("tenant_id").and_then(|v| v.as_str()) != Some(tid) {
+                continue;
+            }
+        }
+        if let Some(wid) = workspace_id {
+            if obj.get("workspace_id").and_then(|v| v.as_str()) != Some(wid) {
+                continue;
+            }
+        }
+
+        // Only include documents with completed enrichment
+        if obj.get("enrichment_status").and_then(|v| v.as_str()) != Some("completed") {
+            continue;
+        }
+
+        let topic = match obj
+            .get("enrichment_topic")
+            .and_then(|v| v.as_str())
+            .map(|s| s.trim())
+            .filter(|s| !s.is_empty())
+        {
+            Some(t) => t.to_string(),
+            None => continue,
+        };
+
+        let doc_id = match obj.get("id").and_then(|v| v.as_str()) {
+            Some(id) => id.to_string(),
+            None => continue,
+        };
+
+        topic_map.entry(topic).or_default().push(doc_id);
+    }
+
+    Ok(topic_map)
+}
+
+const TOPIC_CLASSIFY_PROMPT: &str = r#"You are a document topic classifier.
+
+Given a user query and a numbered list of available document topics, identify which topics are likely to contain relevant information to answer the query.
+
+Available topics:
+{topics}
+
+User query: {query}
+
+Return ONLY a JSON array of exact topic names from the list above. Example: ["Topic A", "Topic B"]
+Rules:
+- Include all topics that are likely relevant (cast wide when uncertain)
+- If the query spans multiple topics, include all of them
+- If no topic is relevant, return []
+- Do NOT invent new topics, only use names from the list above
+- Return raw JSON, no markdown, no explanation"#;
+
+/// Ask the LLM which topics from the list match the query.
+/// On any error returns an empty vec (fail-open: no scoping).
+async fn classify_query_topics(
+    llm_provider: &dyn LLMProvider,
+    query: &str,
+    topics: &[&str],
+) -> Vec<String> {
+    let topics_str = topics
+        .iter()
+        .enumerate()
+        .map(|(i, t)| format!("{}. {}", i + 1, t))
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    let prompt = TOPIC_CLASSIFY_PROMPT
+        .replace("{topics}", &topics_str)
+        .replace("{query}", query);
+
+    let response = match llm_provider.complete(&prompt).await {
+        Ok(r) => r,
+        Err(e) => {
+            warn!(error = %e, "Topic classification LLM call failed — proceeding without scope");
+            return Vec::new();
+        }
+    };
+
+    parse_topics_response(&response.content, topics)
+}
+
+/// Parse the LLM JSON response, keeping only topics that exist in the original list.
+fn parse_topics_response(content: &str, valid_topics: &[&str]) -> Vec<String> {
+    // Strip optional ```json fences
+    let trimmed = content.trim();
+    let json_str = trimmed
+        .trim_start_matches("```json")
+        .trim_start_matches("```")
+        .trim_end_matches("```")
+        .trim();
+
+    let parsed: Vec<String> = match serde_json::from_str(json_str) {
+        Ok(v) => v,
+        Err(e) => {
+            warn!(
+                raw = %content,
+                error = %e,
+                "Failed to parse topic classification response"
+            );
+            return Vec::new();
+        }
+    };
+
+    // Only keep topics that exist in the original list (case-insensitive guard)
+    let valid_lower: Vec<String> = valid_topics.iter().map(|t| t.to_lowercase()).collect();
+    parsed
+        .into_iter()
+        .filter(|t| {
+            let lower = t.to_lowercase();
+            valid_lower.contains(&lower)
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_topics_response_valid() {
+        let valid = &["Machine Learning", "Financial Reports", "Legal"];
+        let result = parse_topics_response(r#"["Machine Learning", "Legal"]"#, valid);
+        assert_eq!(result, vec!["Machine Learning", "Legal"]);
+    }
+
+    #[test]
+    fn test_parse_topics_response_strips_fences() {
+        let valid = &["Finance", "Tech"];
+        let result = parse_topics_response("```json\n[\"Finance\"]\n```", valid);
+        assert_eq!(result, vec!["Finance"]);
+    }
+
+    #[test]
+    fn test_parse_topics_response_rejects_unknown() {
+        let valid = &["Finance", "Tech"];
+        let result = parse_topics_response(r#"["Finance", "Unknown Topic"]"#, valid);
+        assert_eq!(result, vec!["Finance"]);
+    }
+
+    #[test]
+    fn test_parse_topics_response_empty() {
+        let valid = &["Finance", "Tech"];
+        let result = parse_topics_response("[]", valid);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_parse_topics_response_invalid_json() {
+        let valid = &["Finance"];
+        let result = parse_topics_response("not json at all", valid);
+        assert!(result.is_empty());
+    }
+}

--- a/edgequake/crates/edgequake-api/src/handlers/query/topic_resolver.rs
+++ b/edgequake/crates/edgequake-api/src/handlers/query/topic_resolver.rs
@@ -81,6 +81,122 @@ pub async fn resolve_topic_scope(
     }))
 }
 
+/// Resolve document IDs whose `enrichment_tags` contain ANY of the requested tags (case-insensitive).
+///
+/// Returns `None` when no documents match (caller should proceed unscoped).
+pub async fn resolve_tags_filter(
+    kv_storage: &dyn KVStorage,
+    tags: &[String],
+    tenant_id: Option<&str>,
+    workspace_id: Option<&str>,
+) -> Result<Option<Vec<String>>, crate::error::ApiError> {
+    if tags.is_empty() {
+        return Ok(None);
+    }
+
+    let tags_lower: Vec<String> = tags.iter().map(|t| t.to_lowercase()).collect();
+
+    let keys = kv_storage
+        .keys()
+        .await
+        .map_err(|e| crate::error::ApiError::Internal(format!("KV keys scan failed: {}", e)))?;
+
+    let metadata_keys: Vec<String> = keys.into_iter().filter(|k| k.ends_with("-metadata")).collect();
+    if metadata_keys.is_empty() {
+        return Ok(None);
+    }
+
+    let metadata_values = kv_storage
+        .get_by_ids(&metadata_keys)
+        .await
+        .map_err(|e| crate::error::ApiError::Internal(format!("KV batch fetch failed: {}", e)))?;
+
+    let mut doc_ids: Vec<String> = Vec::new();
+
+    for value in &metadata_values {
+        let obj = match value.as_object() {
+            Some(o) => o,
+            None => continue,
+        };
+
+        if let Some(tid) = tenant_id {
+            if obj.get("tenant_id").and_then(|v| v.as_str()) != Some(tid) {
+                continue;
+            }
+        }
+        if let Some(wid) = workspace_id {
+            if obj.get("workspace_id").and_then(|v| v.as_str()) != Some(wid) {
+                continue;
+            }
+        }
+
+        if obj.get("enrichment_status").and_then(|v| v.as_str()) != Some("completed") {
+            continue;
+        }
+
+        let doc_enrichment_tags: Vec<String> = obj
+            .get("enrichment_tags")
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|v| v.as_str().map(|s| s.to_lowercase()))
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        // Include document if it has ANY of the requested tags
+        let matches = tags_lower.iter().any(|t| doc_enrichment_tags.contains(t));
+        if matches {
+            if let Some(id) = obj.get("id").and_then(|v| v.as_str()) {
+                doc_ids.push(id.to_string());
+            }
+        }
+    }
+
+    if doc_ids.is_empty() {
+        debug!(tags = ?tags, "No documents found for tag filter");
+        return Ok(None);
+    }
+
+    debug!(
+        tags = ?tags,
+        document_count = doc_ids.len(),
+        "Tags filter resolved"
+    );
+    Ok(Some(doc_ids))
+}
+
+/// Resolve document IDs whose `enrichment_topic` matches `topic` (case-insensitive).
+///
+/// Returns `None` when no documents match (caller should proceed unscoped).
+pub async fn resolve_topic_filter(
+    kv_storage: &dyn KVStorage,
+    topic: &str,
+    tenant_id: Option<&str>,
+    workspace_id: Option<&str>,
+) -> Result<Option<Vec<String>>, crate::error::ApiError> {
+    let topic_map = build_topic_map(kv_storage, tenant_id, workspace_id).await?;
+    let topic_lower = topic.to_lowercase();
+
+    let doc_ids: Vec<String> = topic_map
+        .iter()
+        .filter(|(k, _)| k.to_lowercase() == topic_lower)
+        .flat_map(|(_, ids)| ids.iter().cloned())
+        .collect();
+
+    if doc_ids.is_empty() {
+        debug!(topic = %topic, "No documents found for explicit topic filter");
+        return Ok(None);
+    }
+
+    debug!(
+        topic = %topic,
+        document_count = doc_ids.len(),
+        "Explicit topic filter resolved"
+    );
+    Ok(Some(doc_ids))
+}
+
 /// Scan KV storage and build a `HashMap<topic, Vec<doc_id>>`.
 async fn build_topic_map(
     kv_storage: &dyn KVStorage,

--- a/edgequake/crates/edgequake-api/src/handlers/query_types.rs
+++ b/edgequake/crates/edgequake-api/src/handlers/query_types.rs
@@ -122,6 +122,14 @@ pub struct QueryRequest {
     #[serde(default)]
     pub document_filter: Option<DocumentFilter>,
 
+    /// When true, automatically scope the query to documents whose enrichment_topic
+    /// matches the query. Uses the LLM to classify which topics are relevant, then
+    /// restricts retrieval to those document IDs. Falls back to full search when
+    /// fewer than 2 topics exist or classification returns no match.
+    /// Ignored when `document_filter` is already set.
+    #[serde(default)]
+    pub enable_topic_scope: bool,
+
     /// Optional HTTP headers to propagate to the upstream LLM provider call.
     ///
     /// Useful for B2B / multi-tenant deployments where the caller needs to pass
@@ -160,6 +168,11 @@ pub struct StreamQueryRequest {
     /// @implements SPEC-005 + SPEC-006: Document filters for streaming queries
     #[serde(default)]
     pub document_filter: Option<DocumentFilter>,
+
+    /// Automatic topic-based scoping for streaming queries. Same semantics as
+    /// `QueryRequest.enable_topic_scope`.
+    #[serde(default)]
+    pub enable_topic_scope: bool,
 
     /// LLM provider to use for this query (e.g., "openai", "ollama", "lmstudio").
     /// @implements SPEC-006 + SPEC-032: Provider selection in streaming queries

--- a/edgequake/crates/edgequake-api/src/handlers/query_types.rs
+++ b/edgequake/crates/edgequake-api/src/handlers/query_types.rs
@@ -126,9 +126,23 @@ pub struct QueryRequest {
     /// matches the query. Uses the LLM to classify which topics are relevant, then
     /// restricts retrieval to those document IDs. Falls back to full search when
     /// fewer than 2 topics exist or classification returns no match.
-    /// Ignored when `document_filter` is already set.
+    /// Ignored when `document_filter` or `topic` is already set.
     #[serde(default)]
     pub enable_topic_scope: bool,
+
+    /// Explicitly filter the query to documents with this enrichment topic.
+    /// Case-insensitive exact match against `enrichment_topic` in document metadata.
+    /// Example: "Technology", "Finance", "Law".
+    /// Takes precedence over `enable_topic_scope`. Ignored when `document_filter` is set.
+    #[serde(default)]
+    pub topic: Option<String>,
+
+    /// Filter the query to documents that contain ANY of these enrichment tags.
+    /// Case-insensitive match against `enrichment_tags` array in document metadata.
+    /// Example: ["Machine Learning", "Python"].
+    /// Applied after `topic` if both are set. Ignored when `document_filter` is set.
+    #[serde(default)]
+    pub tags: Option<Vec<String>>,
 
     /// Optional HTTP headers to propagate to the upstream LLM provider call.
     ///
@@ -173,6 +187,16 @@ pub struct StreamQueryRequest {
     /// `QueryRequest.enable_topic_scope`.
     #[serde(default)]
     pub enable_topic_scope: bool,
+
+    /// Explicitly filter the streaming query to documents with this enrichment topic.
+    /// Same semantics as `QueryRequest.topic`.
+    #[serde(default)]
+    pub topic: Option<String>,
+
+    /// Filter streaming query to documents containing ANY of these enrichment tags.
+    /// Same semantics as `QueryRequest.tags`.
+    #[serde(default)]
+    pub tags: Option<Vec<String>>,
 
     /// LLM provider to use for this query (e.g., "openai", "ollama", "lmstudio").
     /// @implements SPEC-006 + SPEC-032: Provider selection in streaming queries

--- a/edgequake/crates/edgequake-api/src/handlers/query_types.rs
+++ b/edgequake/crates/edgequake-api/src/handlers/query_types.rs
@@ -137,13 +137,6 @@ pub struct QueryRequest {
     #[serde(default)]
     pub topic: Option<String>,
 
-    /// Filter the query to documents that contain ANY of these enrichment tags.
-    /// Case-insensitive match against `enrichment_tags` array in document metadata.
-    /// Example: ["Machine Learning", "Python"].
-    /// Applied after `topic` if both are set. Ignored when `document_filter` is set.
-    #[serde(default)]
-    pub tags: Option<Vec<String>>,
-
     /// Optional HTTP headers to propagate to the upstream LLM provider call.
     ///
     /// Useful for B2B / multi-tenant deployments where the caller needs to pass
@@ -192,11 +185,6 @@ pub struct StreamQueryRequest {
     /// Same semantics as `QueryRequest.topic`.
     #[serde(default)]
     pub topic: Option<String>,
-
-    /// Filter streaming query to documents containing ANY of these enrichment tags.
-    /// Same semantics as `QueryRequest.tags`.
-    #[serde(default)]
-    pub tags: Option<Vec<String>>,
 
     /// LLM provider to use for this query (e.g., "openai", "ollama", "lmstudio").
     /// @implements SPEC-006 + SPEC-032: Provider selection in streaming queries

--- a/edgequake/crates/edgequake-api/src/handlers/settings.rs
+++ b/edgequake/crates/edgequake-api/src/handlers/settings.rs
@@ -333,8 +333,14 @@ fn build_config_area(
     levels: Vec<ConfigLevel>,
     effective_provider: String,
     effective_model: String,
+    has_custom_base_url: bool,
 ) -> ConfigAreaResponse {
-    let has_mismatch = is_model_provider_mismatch(&effective_provider, &effective_model);
+    let raw_mismatch = is_model_provider_mismatch(&effective_provider, &effective_model);
+    // Custom OpenAI-compatible servers (e.g. LMDeploy, vLLM) often expose models
+    // as "/models/<name>" paths. This is not an Ollama-style naming conflict — the
+    // operator explicitly pointed the base URL at a different server, so the "/"
+    // path pattern is not a mismatch indicator.
+    let has_mismatch = raw_mismatch && !(has_custom_base_url && effective_model.contains('/'));
 
     // Find which env var set the mismatched value to give targeted remediation.
     let mismatch_description = if has_mismatch {
@@ -465,10 +471,23 @@ pub async fn get_effective_config(
         "Effective config requested"
     );
 
+    let llm_has_custom_base = std::env::var("EDGEQUAKE_CHAT_BASE_URL")
+        .ok()
+        .filter(|s| !s.is_empty())
+        .is_some()
+        || std::env::var("OPENAI_BASE_URL")
+            .ok()
+            .filter(|s| !s.is_empty())
+            .is_some();
+    let emb_has_custom_base = std::env::var("EDGEQUAKE_EMBEDDING_BASE_URL")
+        .ok()
+        .filter(|s| !s.is_empty())
+        .is_some();
+
     Ok(Json(EffectiveConfigResponse {
-        llm: build_config_area(llm_levels, llm_provider, llm_model),
-        embedding: build_config_area(emb_levels, emb_provider, emb_model),
-        vision: build_config_area(vis_levels, vis_provider, vis_model),
+        llm: build_config_area(llm_levels, llm_provider, llm_model, llm_has_custom_base),
+        embedding: build_config_area(emb_levels, emb_provider, emb_model, emb_has_custom_base),
+        vision: build_config_area(vis_levels, vis_provider, vis_model, llm_has_custom_base),
         priority_rule:
             "Higher-indexed levels override lower. \
              compiled_default < env_alias < env_secondary < env_primary. \

--- a/edgequake/crates/edgequake-api/src/handlers/workspaces/bulk_ops/mod.rs
+++ b/edgequake/crates/edgequake-api/src/handlers/workspaces/bulk_ops/mod.rs
@@ -15,10 +15,12 @@
 //! - [`mark_document_pending`]: Document status update to "pending"
 //! - [`build_reprocess_task`]: SPEC-041 source-type routing (PDF vs text)
 
+mod re_enrich_documents;
 mod rebuild_embeddings;
 mod rebuild_knowledge_graph;
 mod reprocess_documents;
 
+pub use re_enrich_documents::re_enrich_documents;
 pub use rebuild_embeddings::rebuild_embeddings;
 pub use rebuild_knowledge_graph::rebuild_knowledge_graph;
 pub use reprocess_documents::reprocess_all_documents;

--- a/edgequake/crates/edgequake-api/src/handlers/workspaces/bulk_ops/re_enrich_documents.rs
+++ b/edgequake/crates/edgequake-api/src/handlers/workspaces/bulk_ops/re_enrich_documents.rs
@@ -1,0 +1,219 @@
+//! Bulk re-enrich documents whose topic belongs to the legacy taxonomy.
+//!
+//! Queues MetadataEnrich tasks for every document in the workspace whose
+//! `enrichment_topic` is in the old topic list (or all enriched docs when
+//! `force=true`).
+
+use axum::extract::{Path, Query, State};
+use axum::Json;
+use chrono::Utc;
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+use uuid::Uuid;
+
+use crate::error::{ApiError, ApiResult};
+use crate::handlers::isolation::doc_belongs_to_workspace;
+use crate::middleware::TenantContext;
+use crate::state::AppState;
+use edgequake_tasks::{MetadataEnrichData, Task, TaskStatus, TaskType};
+
+/// Topics from the old taxonomy that should be re-classified.
+const LEGACY_TOPICS: &[&str] = &[
+    "Politics", "Indonesia", "Psychology", "Business", "Communication",
+    "Technology", "Science", "SocialMedia", "Religion", "Media",
+    "AI", "Culinary", "Finance", "Literature", "Law",
+    "Sports", "Education",
+    // "History" and "Uncategorized" exist in both old and new — always re-enrich these too
+    "History", "Uncategorized",
+];
+
+#[derive(Debug, Deserialize)]
+pub struct ReEnrichQuery {
+    /// When true, re-enrich ALL documents regardless of current topic.
+    #[serde(default)]
+    pub force: bool,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct ReEnrichResponse {
+    pub queued: usize,
+    pub skipped: usize,
+    pub track_id: String,
+    pub message: String,
+}
+
+/// Bulk re-enrich documents with stale/legacy topics.
+///
+/// By default only queues documents whose `enrichment_topic` is from the
+/// old taxonomy. Pass `?force=true` to re-enrich every document in the
+/// workspace regardless.
+#[utoipa::path(
+    post,
+    path = "/api/v1/workspaces/{workspace_id}/re-enrich",
+    tag = "Workspaces",
+    params(
+        ("workspace_id" = String, Path, description = "Workspace ID"),
+        ("force" = Option<bool>, Query, description = "Re-enrich all docs regardless of topic (default: false)")
+    ),
+    responses(
+        (status = 200, description = "Re-enrich tasks queued", body = ReEnrichResponse),
+        (status = 404, description = "Workspace not found")
+    )
+)]
+pub async fn re_enrich_documents(
+    State(state): State<AppState>,
+    tenant_ctx: TenantContext,
+    Path(workspace_id): Path<String>,
+    Query(params): Query<ReEnrichQuery>,
+) -> ApiResult<Json<ReEnrichResponse>> {
+    let workspace_uuid = Uuid::parse_str(&workspace_id)
+        .map_err(|_| ApiError::BadRequest("Invalid workspace_id".to_string()))?;
+
+    let workspace = state
+        .workspace_service
+        .get_workspace(workspace_uuid)
+        .await
+        .map_err(|e| ApiError::Internal(format!("Failed to load workspace: {}", e)))?
+        .ok_or_else(|| ApiError::NotFound(format!("Workspace not found: {}", workspace_id)))?;
+
+    let tenant_id = tenant_ctx
+        .tenant_id_uuid()
+        .unwrap_or(workspace.tenant_id);
+
+    let track_id = format!("re_enrich_{}_{}", workspace_id, Uuid::new_v4());
+
+    let all_keys = state
+        .kv_storage
+        .keys()
+        .await
+        .map_err(|e| ApiError::Internal(format!("Failed to list keys: {}", e)))?;
+
+    let mut queued = 0usize;
+    let mut skipped = 0usize;
+
+    for key in all_keys.iter().filter(|k| k.ends_with("-metadata")) {
+        let value = match state.kv_storage.get_by_id(key).await {
+            Ok(Some(v)) => v,
+            _ => continue,
+        };
+        let obj = match value.as_object() {
+            Some(o) => o,
+            None => continue,
+        };
+
+        // Workspace isolation
+        let doc_workspace = obj.get("workspace_id").and_then(|v| v.as_str()).unwrap_or("default");
+        if !doc_belongs_to_workspace(doc_workspace, &workspace_uuid.to_string(), &workspace.slug) {
+            continue;
+        }
+
+        // Only PDF documents can be enriched (need pdf_id)
+        let pdf_id_str = match obj.get("pdf_id").and_then(|v| v.as_str()) {
+            Some(s) => s,
+            None => { skipped += 1; continue; }
+        };
+        let pdf_id = match Uuid::parse_str(pdf_id_str) {
+            Ok(id) => id,
+            Err(_) => { skipped += 1; continue; }
+        };
+
+        // Filter by legacy topic unless force=true
+        if !params.force {
+            let current_topic = obj.get("enrichment_topic").and_then(|v| v.as_str()).unwrap_or("");
+            let is_legacy = current_topic.is_empty()
+                || LEGACY_TOPICS.iter().any(|&t| t.eq_ignore_ascii_case(current_topic));
+            if !is_legacy {
+                skipped += 1;
+                continue;
+            }
+        }
+
+        let doc_id = match obj.get("id").and_then(|v| v.as_str()) {
+            Some(id) => id.to_string(),
+            None => continue,
+        };
+
+        let doc_tenant_id = obj
+            .get("tenant_id")
+            .and_then(|v| v.as_str())
+            .and_then(|s| Uuid::parse_str(s).ok())
+            .unwrap_or(tenant_id);
+
+        let doc_workspace_id = obj
+            .get("workspace_id")
+            .and_then(|v| v.as_str())
+            .and_then(|s| Uuid::parse_str(s).ok())
+            .unwrap_or(workspace_uuid);
+
+        // Reset enrichment fields so the processor writes fresh results
+        let mut updated = obj.clone();
+        updated.insert("enrichment_status".to_string(), serde_json::json!("pending"));
+        updated.remove("enrichment_topic");
+        updated.remove("enrichment_summary");
+        updated.remove("enrichment_language");
+        updated.remove("enrichment_keywords");
+        updated.remove("enrichment_tags");
+        updated.remove("enrichment_completed_at");
+        updated.remove("enrichment_error");
+
+        if let Err(e) = state.kv_storage.upsert(&[(key.clone(), serde_json::Value::Object(updated))]).await {
+            tracing::warn!(doc_id = %doc_id, error = %e, "Failed to reset enrichment fields, skipping");
+            skipped += 1;
+            continue;
+        }
+
+        let enrich_data = MetadataEnrichData {
+            document_id: doc_id.clone(),
+            pdf_id,
+            tenant_id: doc_tenant_id,
+            workspace_id: doc_workspace_id,
+            max_pages: 5,
+        };
+
+        let task_track_id = format!("{}-{}", track_id, doc_id);
+        let task = Task {
+            track_id: task_track_id,
+            tenant_id: doc_tenant_id,
+            workspace_id: doc_workspace_id,
+            task_type: TaskType::MetadataEnrich,
+            status: TaskStatus::Pending,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+            started_at: None,
+            completed_at: None,
+            error_message: None,
+            error: None,
+            retry_count: 0,
+            max_retries: 3,
+            consecutive_timeout_failures: 0,
+            circuit_breaker_tripped: false,
+            task_data: serde_json::to_value(&enrich_data)
+                .map_err(|e| ApiError::Internal(format!("Serialization failed: {}", e)))?,
+            metadata: None,
+            progress: None,
+            result: None,
+        };
+
+        if let Err(e) = state.task_storage.create_task(&task).await {
+            tracing::warn!(doc_id = %doc_id, error = %e, "Failed to create enrich task, skipping");
+            skipped += 1;
+            continue;
+        }
+
+        if let Err(e) = state.enrich_queue.send(task).await {
+            tracing::warn!(doc_id = %doc_id, error = %e, "Failed to queue enrich task");
+            skipped += 1;
+            continue;
+        }
+
+        tracing::info!(doc_id = %doc_id, "Re-enrich task queued");
+        queued += 1;
+    }
+
+    Ok(Json(ReEnrichResponse {
+        queued,
+        skipped,
+        track_id,
+        message: format!("Queued {} documents for re-enrichment ({} skipped)", queued, skipped),
+    }))
+}

--- a/edgequake/crates/edgequake-api/src/processor/enrichment_config.rs
+++ b/edgequake/crates/edgequake-api/src/processor/enrichment_config.rs
@@ -1,0 +1,66 @@
+#[derive(Debug, Clone)]
+pub struct EnrichmentConfig {
+    pub vlm_base_url: String,
+    pub vlm_model: String,
+    pub max_pages: usize,
+    pub concurrent: usize,
+}
+
+impl EnrichmentConfig {
+    pub fn from_env() -> Self {
+        Self {
+            vlm_base_url: std::env::var("ENRICHMENT_VLM_BASE_URL")
+                .unwrap_or_else(|_| "http://localhost:11434/v1".to_string()),
+            vlm_model: std::env::var("ENRICHMENT_VLM_MODEL")
+                .unwrap_or_else(|_| "llava:7b".to_string()),
+            max_pages: std::env::var("ENRICHMENT_MAX_PAGES")
+                .ok()
+                .and_then(|s| s.parse().ok())
+                .unwrap_or(5),
+            concurrent: std::env::var("ENRICHMENT_CONCURRENT")
+                .ok()
+                .and_then(|s| s.parse().ok())
+                .unwrap_or(4),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_enrichment_config_defaults() {
+        std::env::remove_var("ENRICHMENT_VLM_BASE_URL");
+        std::env::remove_var("ENRICHMENT_VLM_MODEL");
+        std::env::remove_var("ENRICHMENT_MAX_PAGES");
+        std::env::remove_var("ENRICHMENT_CONCURRENT");
+
+        let config = EnrichmentConfig::from_env();
+
+        assert_eq!(config.vlm_base_url, "http://localhost:11434/v1");
+        assert_eq!(config.vlm_model, "llava:7b");
+        assert_eq!(config.max_pages, 5);
+        assert_eq!(config.concurrent, 4);
+    }
+
+    #[test]
+    fn test_enrichment_config_from_env() {
+        std::env::set_var("ENRICHMENT_VLM_BASE_URL", "http://myhost:8080/v1");
+        std::env::set_var("ENRICHMENT_VLM_MODEL", "gemma3:12b");
+        std::env::set_var("ENRICHMENT_MAX_PAGES", "3");
+        std::env::set_var("ENRICHMENT_CONCURRENT", "8");
+
+        let config = EnrichmentConfig::from_env();
+
+        std::env::remove_var("ENRICHMENT_VLM_BASE_URL");
+        std::env::remove_var("ENRICHMENT_VLM_MODEL");
+        std::env::remove_var("ENRICHMENT_MAX_PAGES");
+        std::env::remove_var("ENRICHMENT_CONCURRENT");
+
+        assert_eq!(config.vlm_base_url, "http://myhost:8080/v1");
+        assert_eq!(config.vlm_model, "gemma3:12b");
+        assert_eq!(config.max_pages, 3);
+        assert_eq!(config.concurrent, 8);
+    }
+}

--- a/edgequake/crates/edgequake-api/src/processor/enrichment_config.rs
+++ b/edgequake/crates/edgequake-api/src/processor/enrichment_config.rs
@@ -17,10 +17,13 @@ impl EnrichmentConfig {
                 .ok()
                 .and_then(|s| s.parse().ok())
                 .unwrap_or(5),
+            // WHY num_cpus / 2: Enrichment is IO-bound (one HTTP call to local VLM).
+            // Scaling with CPU count ensures throughput grows on larger machines
+            // without manual tuning. Floor at 4 for small machines.
             concurrent: std::env::var("ENRICHMENT_CONCURRENT")
                 .ok()
                 .and_then(|s| s.parse().ok())
-                .unwrap_or(4),
+                .unwrap_or_else(|| (num_cpus::get() / 2).max(4)),
         }
     }
 }
@@ -41,7 +44,9 @@ mod tests {
         assert_eq!(config.vlm_base_url, "http://localhost:11434/v1");
         assert_eq!(config.vlm_model, "llava:7b");
         assert_eq!(config.max_pages, 5);
-        assert_eq!(config.concurrent, 4);
+        // Default scales with CPU count: (num_cpus / 2).max(4)
+        let expected = (num_cpus::get() / 2).max(4);
+        assert_eq!(config.concurrent, expected);
     }
 
     #[test]

--- a/edgequake/crates/edgequake-api/src/processor/metadata_enrich.rs
+++ b/edgequake/crates/edgequake-api/src/processor/metadata_enrich.rs
@@ -1,0 +1,1 @@
+// Populated in Task 3

--- a/edgequake/crates/edgequake-api/src/processor/metadata_enrich.rs
+++ b/edgequake/crates/edgequake-api/src/processor/metadata_enrich.rs
@@ -12,15 +12,24 @@ use super::enrichment_config::EnrichmentConfig;
 
 const MAX_TEXT_CHARS: usize = 8_000;
 
+const ALLOWED_TOPICS: &[&str] = &[
+    "Politics", "Indonesia", "Psychology", "Business", "Communication",
+    "Technology", "Science", "SocialMedia", "Religion", "Media",
+    "AI", "Culinary", "Finance", "Literature", "Law",
+    "Sports", "Education", "History", "Uncategorized",
+];
+
 const ENRICHMENT_PROMPT: &str = "You are a document classifier. Given text from a document, \
 return ONLY valid JSON with no markdown, no explanation.\n\
 \n\
 RULES for \"topic\":\n\
-- MAXIMUM 2 words\n\
-- Use a generic domain label, NOT a description of the document\n\
-- Good examples: Technology, Finance, Law, Healthcare, Education, Marketing, Engineering, Science, Management, Communication\n\
-- BAD examples: \"SmartHome Hub product launch strategy\", \"Cross-Cultural Communication\", \"Workplace Communication Skills\"\n\
-- If unsure, pick the single closest domain word\n\
+- You MUST pick exactly one value from this allowed list:\n\
+  Politics, Indonesia, Psychology, Business, Communication, Technology, Science,\n\
+  SocialMedia, Religion, Media, AI, Culinary, Finance, Literature, Law,\n\
+  Sports, Education, History, Uncategorized\n\
+- Do NOT invent new topics outside this list\n\
+- Pick the closest match to the document's main subject\n\
+- Use \"Uncategorized\" only if no other topic fits\n\
 \n\
 RULES for \"tags\":\n\
 - 3 to 6 short tags (1-3 words each)\n\
@@ -30,7 +39,7 @@ RULES for \"tags\":\n\
 - Use the document's own language for tags\n\
 \n\
 {\n  \"summary\": \"2-3 sentence summary in the document's own language\",\n  \
-\"topic\": \"1-2 word domain label\",\n  \
+\"topic\": \"one value from the allowed topic list\",\n  \
 \"tags\": [\"3-6 specific subtopic tags\"],\n  \
 \"language\": \"ISO 639-1 code (e.g. en, id, fr)\",\n  \
 \"keywords\": [\"up to 10 keywords\"]\n}\n\nDocument text:";
@@ -228,12 +237,30 @@ impl TaskProcessor for MetadataEnrichProcessor {
         let keywords: Vec<String> = result.keywords.into_iter().take(10).collect();
         let tags: Vec<String> = result.tags.into_iter().take(6).collect();
 
+        // Enforce allowed topic list — fall back to Uncategorized if LLM hallucinated
+        let topic = if ALLOWED_TOPICS.iter().any(|&t| t.eq_ignore_ascii_case(&result.topic)) {
+            // Normalize to canonical casing from the allowed list
+            ALLOWED_TOPICS
+                .iter()
+                .find(|&&t| t.eq_ignore_ascii_case(&result.topic))
+                .copied()
+                .unwrap_or("Uncategorized")
+                .to_string()
+        } else {
+            warn!(
+                document_id = %data.document_id,
+                llm_topic = %result.topic,
+                "LLM returned topic outside allowed list — falling back to Uncategorized"
+            );
+            "Uncategorized".to_string()
+        };
+
         self.write_metadata(
             &data.document_id,
             serde_json::json!({
                 "enrichment_status": "completed",
                 "enrichment_summary": result.summary,
-                "enrichment_topic": result.topic,
+                "enrichment_topic": topic,
                 "enrichment_tags": tags,
                 "enrichment_language": result.language,
                 "enrichment_keywords": keywords,
@@ -245,14 +272,14 @@ impl TaskProcessor for MetadataEnrichProcessor {
 
         info!(
             document_id = %data.document_id,
-            topic = %result.topic,
+            topic = %topic,
             language = %result.language,
             "Metadata enrichment completed"
         );
 
         Ok(serde_json::json!({
             "enrichment_status": "completed",
-            "topic": result.topic,
+            "topic": topic,
             "language": result.language,
         }))
     }

--- a/edgequake/crates/edgequake-api/src/processor/metadata_enrich.rs
+++ b/edgequake/crates/edgequake-api/src/processor/metadata_enrich.rs
@@ -16,7 +16,8 @@ const ENRICHMENT_PROMPT: &str = "You are a document analyst. Given the text from
 of a document, extract structured metadata. Respond ONLY with valid JSON, no markdown, \
 no explanation:\n\
 {\n  \"summary\": \"2-3 paragraph summary written in the document's own language\",\n  \
-\"topic\": \"single short topic phrase\",\n  \"language\": \"ISO 639-1 code (e.g. en, id, fr)\",\n  \
+\"topic\": \"1-2 word broad category (e.g. Communication, Finance, Law, Healthcare, Education, Technology). Use the most general umbrella term possible — avoid adjectives or subcategories.\",\n  \
+\"language\": \"ISO 639-1 code (e.g. en, id, fr)\",\n  \
 \"keywords\": [\"up to 10 keywords\"]\n}\n\nDocument text:";
 
 #[derive(Debug, Deserialize)]

--- a/edgequake/crates/edgequake-api/src/processor/metadata_enrich.rs
+++ b/edgequake/crates/edgequake-api/src/processor/metadata_enrich.rs
@@ -12,11 +12,18 @@ use super::enrichment_config::EnrichmentConfig;
 
 const MAX_TEXT_CHARS: usize = 8_000;
 
-const ENRICHMENT_PROMPT: &str = "You are a document analyst. Given the text from the first pages \
-of a document, extract structured metadata. Respond ONLY with valid JSON, no markdown, \
-no explanation:\n\
-{\n  \"summary\": \"2-3 paragraph summary written in the document's own language\",\n  \
-\"topic\": \"1-2 word broad category (e.g. Communication, Finance, Law, Healthcare, Education, Technology). Use the most general umbrella term possible — avoid adjectives or subcategories.\",\n  \
+const ENRICHMENT_PROMPT: &str = "You are a document classifier. Given text from a document, \
+return ONLY valid JSON with no markdown, no explanation.\n\
+\n\
+RULES for \"topic\":\n\
+- MAXIMUM 2 words\n\
+- Use a generic domain label, NOT a description of the document\n\
+- Good examples: Technology, Finance, Law, Healthcare, Education, Marketing, Engineering, Science, Management, Communication\n\
+- BAD examples: \"SmartHome Hub product launch strategy\", \"Cross-Cultural Communication\", \"Workplace Communication Skills\"\n\
+- If unsure, pick the single closest domain word\n\
+\n\
+{\n  \"summary\": \"2-3 sentence summary in the document's own language\",\n  \
+\"topic\": \"1-2 word domain label\",\n  \
 \"language\": \"ISO 639-1 code (e.g. en, id, fr)\",\n  \
 \"keywords\": [\"up to 10 keywords\"]\n}\n\nDocument text:";
 

--- a/edgequake/crates/edgequake-api/src/processor/metadata_enrich.rs
+++ b/edgequake/crates/edgequake-api/src/processor/metadata_enrich.rs
@@ -251,3 +251,118 @@ impl TaskProcessor for MetadataEnrichProcessor {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use edgequake_storage::MemoryKVStorage;
+    use edgequake_tasks::TaskStatus;
+
+    fn make_processor() -> MetadataEnrichProcessor {
+        let kv = Arc::new(MemoryKVStorage::new("test"));
+        let config = EnrichmentConfig {
+            vlm_base_url: "http://localhost:1".to_string(), // unreachable — not called in these tests
+            vlm_model: "test-model".to_string(),
+            max_pages: 5,
+            concurrent: 1,
+        };
+        MetadataEnrichProcessor::new(kv, None, config)
+    }
+
+    fn make_task(document_id: &str, pdf_id: uuid::Uuid) -> Task {
+        let tenant_id = uuid::Uuid::new_v4();
+        let workspace_id = uuid::Uuid::new_v4();
+        let data = MetadataEnrichData {
+            document_id: document_id.to_string(),
+            pdf_id,
+            tenant_id,
+            workspace_id,
+            max_pages: 5,
+        };
+        Task {
+            track_id: format!("metadata_enrich-{}", uuid::Uuid::new_v4()),
+            tenant_id,
+            workspace_id,
+            task_type: TaskType::MetadataEnrich,
+            status: TaskStatus::Failed,
+            created_at: chrono::Utc::now(),
+            updated_at: chrono::Utc::now(),
+            started_at: None,
+            completed_at: None,
+            error_message: None,
+            error: None,
+            retry_count: 3,
+            max_retries: 3,
+            consecutive_timeout_failures: 0,
+            circuit_breaker_tripped: false,
+            task_data: serde_json::to_value(&data).unwrap(),
+            metadata: None,
+            progress: None,
+            result: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn test_on_permanent_failure_writes_failed_status() {
+        let processor = make_processor();
+        let doc_id = uuid::Uuid::new_v4().to_string();
+        let task = make_task(&doc_id, uuid::Uuid::new_v4());
+
+        processor.on_permanent_failure(&task, "retries exhausted").await;
+
+        let kv = Arc::new(MemoryKVStorage::new("test"));
+        // Verify by re-constructing the processor with a shared kv
+        let kv_shared = Arc::new(MemoryKVStorage::new("verify"));
+        let config = EnrichmentConfig {
+            vlm_base_url: "http://localhost:1".to_string(),
+            vlm_model: "test".to_string(),
+            max_pages: 5,
+            concurrent: 1,
+        };
+        let p2 = MetadataEnrichProcessor::new(Arc::clone(&kv_shared) as Arc<dyn KVStorage>, None, config);
+        let doc_id2 = uuid::Uuid::new_v4().to_string();
+        let task2 = make_task(&doc_id2, uuid::Uuid::new_v4());
+
+        p2.on_permanent_failure(&task2, "test error msg").await;
+
+        let stored = kv_shared
+            .get_by_id(&format!("{}-metadata", doc_id2))
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(stored["enrichment_status"], "failed");
+        assert!(stored["enrichment_error"]
+            .as_str()
+            .unwrap()
+            .contains("test error msg"));
+        drop(kv);
+    }
+
+    #[test]
+    fn test_metadata_enrich_data_serde_default() {
+        // max_pages should default to 5 when absent from JSON
+        let json = serde_json::json!({
+            "document_id": "doc-abc",
+            "pdf_id": "00000000-0000-0000-0000-000000000001",
+            "tenant_id": "00000000-0000-0000-0000-000000000002",
+            "workspace_id": "00000000-0000-0000-0000-000000000003"
+        });
+        let data: MetadataEnrichData = serde_json::from_value(json).unwrap();
+        assert_eq!(data.max_pages, 5);
+        assert_eq!(data.document_id, "doc-abc");
+    }
+
+    #[test]
+    fn test_strip_json_fences() {
+        // Verify the fence-stripping logic works for models that wrap output in ```json
+        let raw = "```json\n{\"summary\":\"s\",\"topic\":\"t\",\"language\":\"en\",\"keywords\":[]}\n```";
+        let stripped = raw
+            .trim()
+            .trim_start_matches("```json")
+            .trim_start_matches("```")
+            .trim_end_matches("```")
+            .trim();
+        let parsed: serde_json::Value = serde_json::from_str(stripped).unwrap();
+        assert_eq!(parsed["topic"], "t");
+    }
+}

--- a/edgequake/crates/edgequake-api/src/processor/metadata_enrich.rs
+++ b/edgequake/crates/edgequake-api/src/processor/metadata_enrich.rs
@@ -13,10 +13,20 @@ use super::enrichment_config::EnrichmentConfig;
 const MAX_TEXT_CHARS: usize = 8_000;
 
 const ALLOWED_TOPICS: &[&str] = &[
-    "Politics", "Indonesia", "Psychology", "Business", "Communication",
-    "Technology", "Science", "SocialMedia", "Religion", "Media",
-    "AI", "Culinary", "Finance", "Literature", "Law",
-    "Sports", "Education", "History", "Uncategorized",
+    // Fiction
+    "Romance", "Science Fiction & Fantasy", "Mystery, Thriller & Suspense",
+    "Literature & Fiction", "Teen & Young Adult", "LGBTQIA+",
+    // Nonfiction
+    "Arts & Photography", "Biographies & Memoirs", "Business & Money",
+    "Computers & Technology", "Cookbooks, Food & Wine", "Crafts, Hobbies & Home",
+    "Education & Teaching", "Engineering & Transportation", "Health, Fitness & Dieting",
+    "History", "Humor & Entertainment", "Law", "Medical Books",
+    "Parenting & Relationships", "Politics & Social Sciences", "Reference",
+    "Religion & Spirituality", "Science & Math", "Self-help",
+    "Sports & Outdoors", "Travel",
+    // Other
+    "Comics & Manga", "Children's Books", "Textbooks",
+    "Uncategorized",
 ];
 
 const ENRICHMENT_PROMPT: &str = "You are a document classifier. Given text from a document, \
@@ -24,9 +34,16 @@ return ONLY valid JSON with no markdown, no explanation.\n\
 \n\
 RULES for \"topic\":\n\
 - You MUST pick exactly one value from this allowed list:\n\
-  Politics, Indonesia, Psychology, Business, Communication, Technology, Science,\n\
-  SocialMedia, Religion, Media, AI, Culinary, Finance, Literature, Law,\n\
-  Sports, Education, History, Uncategorized\n\
+  Romance, Science Fiction & Fantasy, Mystery Thriller & Suspense,\n\
+  Literature & Fiction, Teen & Young Adult, LGBTQIA+,\n\
+  Arts & Photography, Biographies & Memoirs, Business & Money,\n\
+  Computers & Technology, Cookbooks Food & Wine, Crafts Hobbies & Home,\n\
+  Education & Teaching, Engineering & Transportation, Health Fitness & Dieting,\n\
+  History, Humor & Entertainment, Law, Medical Books,\n\
+  Parenting & Relationships, Politics & Social Sciences, Reference,\n\
+  Religion & Spirituality, Science & Math, Self-help,\n\
+  Sports & Outdoors, Travel, Comics & Manga, Children's Books, Textbooks,\n\
+  Uncategorized\n\
 - Do NOT invent new topics outside this list\n\
 - Pick the closest match to the document's main subject\n\
 - Use \"Uncategorized\" only if no other topic fits\n\
@@ -34,8 +51,8 @@ RULES for \"topic\":\n\
 RULES for \"tags\":\n\
 - 3 to 6 short tags (1-3 words each)\n\
 - More specific than the topic — describe subtopics, key themes, or subject areas in the document\n\
-- Good examples for a Technology doc: [\"Machine Learning\", \"Neural Networks\", \"Python\"]\n\
-- Good examples for a Finance doc: [\"Investment\", \"Risk Management\", \"Stock Market\"]\n\
+- Good examples for a Computers & Technology doc: [\"Machine Learning\", \"Neural Networks\", \"Python\"]\n\
+- Good examples for a Business & Money doc: [\"Investment\", \"Risk Management\", \"Stock Market\"]\n\
 - Use the document's own language for tags\n\
 \n\
 {\n  \"summary\": \"2-3 sentence summary in the document's own language\",\n  \

--- a/edgequake/crates/edgequake-api/src/processor/metadata_enrich.rs
+++ b/edgequake/crates/edgequake-api/src/processor/metadata_enrich.rs
@@ -22,8 +22,16 @@ RULES for \"topic\":\n\
 - BAD examples: \"SmartHome Hub product launch strategy\", \"Cross-Cultural Communication\", \"Workplace Communication Skills\"\n\
 - If unsure, pick the single closest domain word\n\
 \n\
+RULES for \"tags\":\n\
+- 3 to 6 short tags (1-3 words each)\n\
+- More specific than the topic — describe subtopics, key themes, or subject areas in the document\n\
+- Good examples for a Technology doc: [\"Machine Learning\", \"Neural Networks\", \"Python\"]\n\
+- Good examples for a Finance doc: [\"Investment\", \"Risk Management\", \"Stock Market\"]\n\
+- Use the document's own language for tags\n\
+\n\
 {\n  \"summary\": \"2-3 sentence summary in the document's own language\",\n  \
 \"topic\": \"1-2 word domain label\",\n  \
+\"tags\": [\"3-6 specific subtopic tags\"],\n  \
 \"language\": \"ISO 639-1 code (e.g. en, id, fr)\",\n  \
 \"keywords\": [\"up to 10 keywords\"]\n}\n\nDocument text:";
 
@@ -31,6 +39,8 @@ RULES for \"topic\":\n\
 struct EnrichmentResponse {
     summary: String,
     topic: String,
+    #[serde(default)]
+    tags: Vec<String>,
     language: String,
     keywords: Vec<String>,
 }
@@ -216,6 +226,7 @@ impl TaskProcessor for MetadataEnrichProcessor {
         };
 
         let keywords: Vec<String> = result.keywords.into_iter().take(10).collect();
+        let tags: Vec<String> = result.tags.into_iter().take(6).collect();
 
         self.write_metadata(
             &data.document_id,
@@ -223,6 +234,7 @@ impl TaskProcessor for MetadataEnrichProcessor {
                 "enrichment_status": "completed",
                 "enrichment_summary": result.summary,
                 "enrichment_topic": result.topic,
+                "enrichment_tags": tags,
                 "enrichment_language": result.language,
                 "enrichment_keywords": keywords,
                 "enrichment_completed_at": chrono::Utc::now().to_rfc3339(),

--- a/edgequake/crates/edgequake-api/src/processor/metadata_enrich.rs
+++ b/edgequake/crates/edgequake-api/src/processor/metadata_enrich.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use edgequake_pdf::{backend::edgeparse::EdgeParsePdfConverter, PdfConversionConfig, PdfConverter};
+use edgequake_pdf::{backend::EdgeParsePdfConverter, PdfConversionConfig, PdfConverter};
 use edgequake_storage::{traits::KVStorage, PdfDocumentStorage};
 use edgequake_tasks::{MetadataEnrichData, Task, TaskError, TaskProcessor, TaskResult};
 use reqwest::Client;

--- a/edgequake/crates/edgequake-api/src/processor/metadata_enrich.rs
+++ b/edgequake/crates/edgequake-api/src/processor/metadata_enrich.rs
@@ -1,1 +1,253 @@
-// Populated in Task 3
+use async_trait::async_trait;
+use edgequake_pdf::{backend::edgeparse::EdgeParsePdfConverter, PdfConversionConfig, PdfConverter};
+use edgequake_storage::{traits::KVStorage, PdfDocumentStorage};
+use edgequake_tasks::{MetadataEnrichData, Task, TaskError, TaskProcessor, TaskResult};
+use reqwest::Client;
+use serde::Deserialize;
+use std::sync::Arc;
+use tokio_util::sync::CancellationToken;
+use tracing::{info, warn};
+
+use super::enrichment_config::EnrichmentConfig;
+
+const MAX_TEXT_CHARS: usize = 8_000;
+
+const ENRICHMENT_PROMPT: &str = "You are a document analyst. Given the text from the first pages \
+of a document, extract structured metadata. Respond ONLY with valid JSON, no markdown, \
+no explanation:\n\
+{\n  \"summary\": \"2-3 paragraph summary written in the document's own language\",\n  \
+\"topic\": \"single short topic phrase\",\n  \"language\": \"ISO 639-1 code (e.g. en, id, fr)\",\n  \
+\"keywords\": [\"up to 10 keywords\"]\n}\n\nDocument text:";
+
+#[derive(Debug, Deserialize)]
+struct EnrichmentResponse {
+    summary: String,
+    topic: String,
+    language: String,
+    keywords: Vec<String>,
+}
+
+pub struct MetadataEnrichProcessor {
+    kv_storage: Arc<dyn KVStorage>,
+    pdf_storage: Option<Arc<dyn PdfDocumentStorage>>,
+    config: EnrichmentConfig,
+    http_client: Client,
+}
+
+impl MetadataEnrichProcessor {
+    pub fn new(
+        kv_storage: Arc<dyn KVStorage>,
+        pdf_storage: Option<Arc<dyn PdfDocumentStorage>>,
+        config: EnrichmentConfig,
+    ) -> Self {
+        Self {
+            kv_storage,
+            pdf_storage,
+            config,
+            http_client: Client::new(),
+        }
+    }
+
+    async fn load_pdf_bytes(&self, pdf_id: &uuid::Uuid) -> TaskResult<Vec<u8>> {
+        let storage = self.pdf_storage.as_ref().ok_or_else(|| {
+            TaskError::Processing(
+                "pdf_storage not available (postgres feature required)".to_string(),
+            )
+        })?;
+
+        let doc = storage
+            .get_pdf(pdf_id)
+            .await
+            .map_err(|e| TaskError::Processing(format!("Failed to load PDF: {}", e)))?
+            .ok_or_else(|| TaskError::NotFound(format!("PDF not found: {}", pdf_id)))?;
+
+        Ok(doc.pdf_data)
+    }
+
+    async fn write_metadata(
+        &self,
+        document_id: &str,
+        updates: serde_json::Value,
+    ) -> TaskResult<()> {
+        let key = format!("{}-metadata", document_id);
+
+        let existing = self
+            .kv_storage
+            .get_by_id(&key)
+            .await
+            .ok()
+            .flatten()
+            .unwrap_or_else(|| serde_json::json!({}));
+
+        let mut obj = existing.as_object().cloned().unwrap_or_default();
+
+        if let Some(map) = updates.as_object() {
+            for (k, v) in map {
+                obj.insert(k.clone(), v.clone());
+            }
+        }
+
+        self.kv_storage
+            .upsert(&[(key, serde_json::Value::Object(obj))])
+            .await
+            .map_err(|e| TaskError::Processing(format!("KV write failed: {}", e)))
+    }
+
+    async fn call_vlm(&self, text: &str) -> Result<EnrichmentResponse, String> {
+        let prompt = format!("{}\n\n{}", ENRICHMENT_PROMPT, text);
+
+        let body = serde_json::json!({
+            "model": self.config.vlm_model,
+            "messages": [{"role": "user", "content": prompt}],
+            "temperature": 0.1,
+        });
+
+        let url = format!("{}/chat/completions", self.config.vlm_base_url);
+
+        let response = self
+            .http_client
+            .post(&url)
+            .json(&body)
+            .timeout(std::time::Duration::from_secs(120))
+            .send()
+            .await
+            .map_err(|e| format!("VLM request failed: {}", e))?;
+
+        let resp_json: serde_json::Value = response
+            .json()
+            .await
+            .map_err(|e| format!("Failed to read VLM response: {}", e))?;
+
+        let content = resp_json["choices"][0]["message"]["content"]
+            .as_str()
+            .ok_or_else(|| format!("Unexpected VLM response shape: {}", resp_json))?;
+
+        // Strip optional ```json fences some models add
+        let json_str = content
+            .trim()
+            .trim_start_matches("```json")
+            .trim_start_matches("```")
+            .trim_end_matches("```")
+            .trim();
+
+        serde_json::from_str::<EnrichmentResponse>(json_str)
+            .map_err(|e| format!("VLM returned invalid JSON ({e}): {json_str}"))
+    }
+}
+
+#[async_trait]
+impl TaskProcessor for MetadataEnrichProcessor {
+    async fn process(
+        &self,
+        task: &mut Task,
+        _cancel_token: CancellationToken,
+    ) -> TaskResult<serde_json::Value> {
+        let data: MetadataEnrichData =
+            serde_json::from_value(task.task_data.clone()).map_err(|e| {
+                TaskError::InvalidPayload(format!("Invalid MetadataEnrichData: {}", e))
+            })?;
+
+        self.write_metadata(
+            &data.document_id,
+            serde_json::json!({"enrichment_status": "processing"}),
+        )
+        .await?;
+
+        let pdf_bytes = self.load_pdf_bytes(&data.pdf_id).await?;
+
+        let converter = EdgeParsePdfConverter::default();
+        let full_text = match converter
+            .convert(&pdf_bytes, &PdfConversionConfig::default())
+            .await
+        {
+            Ok(text) => text,
+            Err(e) => {
+                warn!(
+                    document_id = %data.document_id,
+                    "EdgeParser failed, skipping enrichment: {}", e
+                );
+                self.write_metadata(
+                    &data.document_id,
+                    serde_json::json!({
+                        "enrichment_status": "skipped",
+                        "enrichment_error": format!("EdgeParser error: {}", e),
+                    }),
+                )
+                .await?;
+                return Ok(serde_json::json!({"enrichment_status": "skipped"}));
+            }
+        };
+
+        if full_text.trim().is_empty() {
+            self.write_metadata(
+                &data.document_id,
+                serde_json::json!({"enrichment_status": "skipped"}),
+            )
+            .await?;
+            return Ok(serde_json::json!({"enrichment_status": "skipped"}));
+        }
+
+        let text = if full_text.len() > MAX_TEXT_CHARS {
+            &full_text[..MAX_TEXT_CHARS]
+        } else {
+            full_text.as_str()
+        };
+
+        // One internal retry for JSON parse failures; worker pool handles broader retries
+        let result = match self.call_vlm(text).await {
+            Ok(r) => r,
+            Err(first_err) => {
+                warn!(
+                    document_id = %data.document_id,
+                    "VLM call failed ({}), retrying once", first_err
+                );
+                self.call_vlm(text).await.map_err(|e| {
+                    TaskError::Processing(format!("VLM enrichment failed after retry: {}", e))
+                })?
+            }
+        };
+
+        let keywords: Vec<String> = result.keywords.into_iter().take(10).collect();
+
+        self.write_metadata(
+            &data.document_id,
+            serde_json::json!({
+                "enrichment_status": "completed",
+                "enrichment_summary": result.summary,
+                "enrichment_topic": result.topic,
+                "enrichment_language": result.language,
+                "enrichment_keywords": keywords,
+                "enrichment_completed_at": chrono::Utc::now().to_rfc3339(),
+                "enrichment_error": null,
+            }),
+        )
+        .await?;
+
+        info!(
+            document_id = %data.document_id,
+            topic = %result.topic,
+            language = %result.language,
+            "Metadata enrichment completed"
+        );
+
+        Ok(serde_json::json!({
+            "enrichment_status": "completed",
+            "topic": result.topic,
+            "language": result.language,
+        }))
+    }
+
+    async fn on_permanent_failure(&self, task: &Task, error_msg: &str) {
+        if let Ok(data) = serde_json::from_value::<MetadataEnrichData>(task.task_data.clone()) {
+            let _ = self
+                .write_metadata(
+                    &data.document_id,
+                    serde_json::json!({
+                        "enrichment_status": "failed",
+                        "enrichment_error": error_msg,
+                    }),
+                )
+                .await;
+        }
+    }
+}

--- a/edgequake/crates/edgequake-api/src/processor/mod.rs
+++ b/edgequake/crates/edgequake-api/src/processor/mod.rs
@@ -82,6 +82,8 @@ mod status_updates;
 mod task_impl;
 mod text_insert;
 mod workspace_resolver;
+pub mod enrichment_config;
+pub mod metadata_enrich;
 
 use std::sync::Arc;
 

--- a/edgequake/crates/edgequake-api/src/processor/pdf_processing.rs
+++ b/edgequake/crates/edgequake-api/src/processor/pdf_processing.rs
@@ -206,6 +206,21 @@ impl DocumentTaskProcessor {
             .clone()
             .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
 
+        // Skip processing if doc is already completed and this is not a forced restart.
+        // Prevents orphan-recovered tasks from overwriting manually restored docs.
+        if has_existing_document && !data.restart_from_scratch {
+            let meta_key = format!("{}-metadata", early_doc_id);
+            if let Ok(Some(meta)) = self.kv_storage.get_by_id(&meta_key).await {
+                if meta.get("status").and_then(|v| v.as_str()) == Some("completed") {
+                    tracing::info!(
+                        document_id = %early_doc_id,
+                        "Skipping task — document already completed"
+                    );
+                    return Ok(serde_json::json!({"skipped": true, "reason": "already_completed"}));
+                }
+            }
+        }
+
         // FIX-DUPLICATE-BUG: Persist the generated document ID back into task_data
         // so that worker retries reuse the same document ID instead of creating
         // a new UUID on each attempt. Without this, a single PDF upload that fails

--- a/edgequake/crates/edgequake-api/src/processor/status_updates.rs
+++ b/edgequake/crates/edgequake-api/src/processor/status_updates.rs
@@ -352,6 +352,13 @@ impl DocumentTaskProcessor {
 
                 updated.remove("error_message");
 
+                // Persist storage error details so they are visible via API
+                if let Some(ref err) = stats.error_details {
+                    updated.insert("error_details".to_string(), json!(err));
+                } else {
+                    updated.remove("error_details");
+                }
+
                 self.kv_storage
                     .upsert(&[(metadata_key, json!(updated))])
                     .await

--- a/edgequake/crates/edgequake-api/src/processor/task_impl.rs
+++ b/edgequake/crates/edgequake-api/src/processor/task_impl.rs
@@ -58,6 +58,12 @@ impl TaskProcessor for DocumentTaskProcessor {
 
                 self.process_pdf_processing(task, data, cancel_token).await
             }
+            TaskType::MetadataEnrich => {
+                // MetadataEnrich handler — implemented in Task 3 (metadata_enrich module)
+                Err(edgequake_tasks::TaskError::UnsupportedOperation(
+                    "MetadataEnrich not yet implemented".to_string(),
+                ))
+            }
         }
     }
 

--- a/edgequake/crates/edgequake-api/src/processor/text_insert.rs
+++ b/edgequake/crates/edgequake-api/src/processor/text_insert.rs
@@ -1120,11 +1120,14 @@ impl DocumentTaskProcessor {
             }
         }
 
-        // CHECKPOINT-CLEAR: All storage stages completed successfully.
-        // Remove the checkpoint so it won't be reloaded on next run.
-        // WHY: If we reach here, every piece of data is safely persisted.
-        // Keeping the checkpoint would waste storage and risk stale reloads.
-        super::pipeline_checkpoint::clear_pipeline_checkpoint(&self.kv_storage, &document_id).await;
+        // CHECKPOINT-CLEAR: Only clear on full success.
+        // WHY: On partial_failure (graph storage timeout, etc.) the checkpoint must
+        // survive so the next reprocess run can skip LLM extraction and retry only
+        // the storage stage. Clearing on partial_failure would force re-extraction.
+        if final_status == "completed" {
+            super::pipeline_checkpoint::clear_pipeline_checkpoint(&self.kv_storage, &document_id)
+                .await;
+        }
 
         // Log success
         self.pipeline_state

--- a/edgequake/crates/edgequake-api/src/processor/text_insert.rs
+++ b/edgequake/crates/edgequake-api/src/processor/text_insert.rs
@@ -980,6 +980,11 @@ impl DocumentTaskProcessor {
                 "ANOMALY: Document processed but extracted 0 entities from {} chunks - marking as partial_failure",
                 result.stats.chunk_count
             );
+            stats_with_lineage.error_details = Some(format!(
+                "Extracted 0 entities from {} chunks ({} failed) — likely LLM extraction failure",
+                result.stats.chunk_count,
+                result.stats.failed_chunks,
+            ));
             "partial_failure"
         } else if has_storage_errors {
             // Extraction succeeded but storage partially failed

--- a/edgequake/crates/edgequake-api/src/routes.rs
+++ b/edgequake/crates/edgequake-api/src/routes.rs
@@ -294,6 +294,8 @@ fn api_v1_routes() -> Router<AppState> {
         .route("/documents/reprocess", post(handlers::reprocess_failed))
         // Recover Stuck Processing Documents - MUST come before /documents/{document_id}
         .route("/documents/recover-stuck", post(handlers::recover_stuck))
+        // Trigger metadata enrichment for a single document - MUST come before /documents/{document_id}
+        .route("/documents/{document_id}/enrich", post(handlers::enrich_document))
         // Document deletion impact analysis - MUST come before /documents/{document_id}
         .route(
             "/documents/{document_id}/deletion-impact",

--- a/edgequake/crates/edgequake-api/src/routes.rs
+++ b/edgequake/crates/edgequake-api/src/routes.rs
@@ -111,6 +111,8 @@ pub fn create_router(state: AppState) -> Router {
             "/ws/progress/{track_id}",
             get(handlers::ws_progress_by_track_id),
         )
+        // MCP Streamable HTTP endpoint
+        .route("/mcp", post(handlers::mcp::mcp_handler))
         // Ollama Emulation API (GAP-038)
         .nest("/api", ollama_api_routes())
         // API v1 endpoints

--- a/edgequake/crates/edgequake-api/src/routes.rs
+++ b/edgequake/crates/edgequake-api/src/routes.rs
@@ -219,6 +219,11 @@ fn api_v1_routes() -> Router<AppState> {
             "/workspaces/{workspace_id}/reprocess-documents",
             post(handlers::reprocess_all_documents),
         )
+        // Re-enrich documents with legacy topics using the current taxonomy
+        .route(
+            "/workspaces/{workspace_id}/re-enrich",
+            post(handlers::re_enrich_documents),
+        )
         // SPEC-0002: Knowledge Injection
         .route(
             "/workspaces/{workspace_id}/injection",

--- a/edgequake/crates/edgequake-api/src/state/memory.rs
+++ b/edgequake/crates/edgequake-api/src/state/memory.rs
@@ -50,6 +50,7 @@ impl AppState {
         let rbac_service = Arc::new(RbacService::new());
         let conversation_service: SharedConversationService =
             Arc::new(InMemoryConversationService::new());
+        let enrich_queue = Arc::new(edgequake_tasks::queue::ChannelTaskQueue::new(200));
 
         Self {
             kv_storage,
@@ -64,6 +65,7 @@ impl AppState {
             pipeline,
             task_storage,
             task_queue,
+            enrich_queue,
             pipeline_state: PipelineState::new(),
             progress_broadcaster: ProgressBroadcaster::default(),
             workspace_service,
@@ -215,6 +217,7 @@ impl AppState {
             pipeline,
             task_storage,
             task_queue,
+            enrich_queue,
             pipeline_state: PipelineState::new(),
             progress_broadcaster: ProgressBroadcaster::default(),
             workspace_service,
@@ -269,6 +272,7 @@ impl AppState {
         // Create task infrastructure
         let task_storage = Arc::new(edgequake_tasks::memory::MemoryTaskStorage::new());
         let task_queue = Arc::new(edgequake_tasks::queue::ChannelTaskQueue::new(100));
+        let enrich_queue = Arc::new(edgequake_tasks::queue::ChannelTaskQueue::new(200));
 
         // Create legacy query engine (for backward compatibility)
         let query_config = QueryEngineConfig::default();
@@ -317,6 +321,7 @@ impl AppState {
             pipeline,
             task_storage,
             task_queue,
+            enrich_queue,
             pipeline_state: PipelineState::new(),
             progress_broadcaster: ProgressBroadcaster::default(),
             workspace_service,

--- a/edgequake/crates/edgequake-api/src/state/memory.rs
+++ b/edgequake/crates/edgequake-api/src/state/memory.rs
@@ -167,6 +167,7 @@ impl AppState {
         // Create task infrastructure
         let task_storage = Arc::new(edgequake_tasks::memory::MemoryTaskStorage::new());
         let task_queue = Arc::new(edgequake_tasks::queue::ChannelTaskQueue::new(100));
+        let enrich_queue = Arc::new(edgequake_tasks::queue::ChannelTaskQueue::new(200));
 
         // Create legacy query engine (for backward compatibility)
         let query_engine = Arc::new(QueryEngine::new(

--- a/edgequake/crates/edgequake-api/src/state/memory.rs
+++ b/edgequake/crates/edgequake-api/src/state/memory.rs
@@ -50,7 +50,7 @@ impl AppState {
         let rbac_service = Arc::new(RbacService::new());
         let conversation_service: SharedConversationService =
             Arc::new(InMemoryConversationService::new());
-        let enrich_queue = Arc::new(edgequake_tasks::queue::ChannelTaskQueue::new(200));
+        let enrich_queue = Arc::new(edgequake_tasks::queue::ChannelTaskQueue::new(500));
 
         Self {
             kv_storage,
@@ -166,8 +166,8 @@ impl AppState {
 
         // Create task infrastructure
         let task_storage = Arc::new(edgequake_tasks::memory::MemoryTaskStorage::new());
-        let task_queue = Arc::new(edgequake_tasks::queue::ChannelTaskQueue::new(100));
-        let enrich_queue = Arc::new(edgequake_tasks::queue::ChannelTaskQueue::new(200));
+        let task_queue = Arc::new(edgequake_tasks::queue::ChannelTaskQueue::new(500));
+        let enrich_queue = Arc::new(edgequake_tasks::queue::ChannelTaskQueue::new(500));
 
         // Create legacy query engine (for backward compatibility)
         let query_engine = Arc::new(QueryEngine::new(
@@ -272,8 +272,8 @@ impl AppState {
 
         // Create task infrastructure
         let task_storage = Arc::new(edgequake_tasks::memory::MemoryTaskStorage::new());
-        let task_queue = Arc::new(edgequake_tasks::queue::ChannelTaskQueue::new(100));
-        let enrich_queue = Arc::new(edgequake_tasks::queue::ChannelTaskQueue::new(200));
+        let task_queue = Arc::new(edgequake_tasks::queue::ChannelTaskQueue::new(500));
+        let enrich_queue = Arc::new(edgequake_tasks::queue::ChannelTaskQueue::new(500));
 
         // Create legacy query engine (for backward compatibility)
         let query_config = QueryEngineConfig::default();

--- a/edgequake/crates/edgequake-api/src/state/mod.rs
+++ b/edgequake/crates/edgequake-api/src/state/mod.rs
@@ -163,6 +163,9 @@ pub struct AppState {
     /// Task queue.
     pub task_queue: SharedTaskQueue,
 
+    /// Dedicated queue for metadata enrichment tasks.
+    pub enrich_queue: SharedTaskQueue,
+
     /// Pipeline state for real-time progress tracking (Phase 3).
     pub pipeline_state: PipelineState,
 

--- a/edgequake/crates/edgequake-api/src/state/postgres.rs
+++ b/edgequake/crates/edgequake-api/src/state/postgres.rs
@@ -304,8 +304,8 @@ impl AppState {
         let task_storage: edgequake_tasks::SharedTaskStorage = Arc::new(
             edgequake_tasks::postgres::PostgresTaskStorage::new(pool.clone()),
         );
-        let task_queue = Arc::new(edgequake_tasks::queue::ChannelTaskQueue::new(100));
-        let enrich_queue = Arc::new(edgequake_tasks::queue::ChannelTaskQueue::new(200));
+        let task_queue = Arc::new(edgequake_tasks::queue::ChannelTaskQueue::new(500));
+        let enrich_queue = Arc::new(edgequake_tasks::queue::ChannelTaskQueue::new(500));
         tracing::info!("✓ Task storage: PostgreSQL (persistent across restarts)");
 
         // Create legacy query engine (for backward compatibility)

--- a/edgequake/crates/edgequake-api/src/state/postgres.rs
+++ b/edgequake/crates/edgequake-api/src/state/postgres.rs
@@ -305,6 +305,7 @@ impl AppState {
             edgequake_tasks::postgres::PostgresTaskStorage::new(pool.clone()),
         );
         let task_queue = Arc::new(edgequake_tasks::queue::ChannelTaskQueue::new(100));
+        let enrich_queue = Arc::new(edgequake_tasks::queue::ChannelTaskQueue::new(200));
         tracing::info!("✓ Task storage: PostgreSQL (persistent across restarts)");
 
         // Create legacy query engine (for backward compatibility)
@@ -363,6 +364,7 @@ impl AppState {
             pipeline,
             task_storage,
             task_queue,
+            enrich_queue,
             pipeline_state: PipelineState::new(),
             progress_broadcaster: ProgressBroadcaster::default(),
             workspace_service,

--- a/edgequake/crates/edgequake-storage/src/adapters/postgres/graph/mod.rs
+++ b/edgequake/crates/edgequake-storage/src/adapters/postgres/graph/mod.rs
@@ -365,17 +365,20 @@ impl GraphStorage for PostgresAGEGraphStorage {
 
         // WHY: Use ::text cast for graphid comparison - Apache AGE's graphid type
         // lacks a native equality operator, but text comparison works correctly.
+        // WHY "Node"/"EDGE" not "_ag_label_vertex"/"_ag_label_edge": direct label tables
+        // use specific indexes (idx_node_prop_node_id, idx_edge_start_id) instead of
+        // triggering a full inheritance scan through the base tables.
         let sql = format!(
             "WITH node_vid AS ( \
-                SELECT id::text as id_text FROM {}.\"_ag_label_vertex\" \
+                SELECT id::text as id_text FROM {}.\"Node\" \
                 WHERE ag_catalog.agtype_to_json(properties)->>'node_id' = '{}' \
              ), \
              out_edges AS ( \
-                SELECT COUNT(*) as cnt FROM {}.\"_ag_label_edge\" e \
+                SELECT COUNT(*) as cnt FROM {}.\"EDGE\" e \
                 JOIN node_vid n ON e.start_id::text = n.id_text \
              ), \
              in_edges AS ( \
-                SELECT COUNT(*) as cnt FROM {}.\"_ag_label_edge\" e \
+                SELECT COUNT(*) as cnt FROM {}.\"EDGE\" e \
                 JOIN node_vid n ON e.end_id::text = n.id_text \
              ) \
              SELECT COALESCE(o.cnt, 0) + COALESCE(i.cnt, 0) as degree \
@@ -417,21 +420,23 @@ impl GraphStorage for PostgresAGEGraphStorage {
 
         // WHY: Use ::text cast for graphid comparison - Apache AGE's graphid type
         // lacks a native equality operator, but text comparison works correctly.
+        // WHY "Node"/"EDGE": direct label tables use specific indexes instead of
+        // triggering PostgreSQL inheritance scans through the base label tables.
         let sql = format!(
             "WITH target_nodes AS ( \
                 SELECT id::text as id_text, ag_catalog.agtype_to_json(properties)->>'node_id' as node_id \
-                FROM {}.\"_ag_label_vertex\" \
+                FROM {}.\"Node\" \
                 WHERE ag_catalog.agtype_to_json(properties)->>'node_id' IN ({}) \
              ), \
              out_degrees AS ( \
                 SELECT n.node_id, COUNT(*) as out_deg \
-                FROM {}.\"_ag_label_edge\" e \
+                FROM {}.\"EDGE\" e \
                 JOIN target_nodes n ON e.start_id::text = n.id_text \
                 GROUP BY n.node_id \
              ), \
              in_degrees AS ( \
                 SELECT n.node_id, COUNT(*) as in_deg \
-                FROM {}.\"_ag_label_edge\" e \
+                FROM {}.\"EDGE\" e \
                 JOIN target_nodes n ON e.end_id::text = n.id_text \
                 GROUP BY n.node_id \
              ) \
@@ -1022,7 +1027,7 @@ impl GraphStorage for PostgresAGEGraphStorage {
                     to_tsvector('english', ag_catalog.agtype_to_json(properties)->>'node_id'), \
                     plainto_tsquery('english', '{}') \
                 ) as rank \
-             FROM {}.\"_ag_label_vertex\" \
+             FROM {}.\"Node\" \
              WHERE to_tsvector('english', ag_catalog.agtype_to_json(properties)->>'node_id') \
                    @@ plainto_tsquery('english', '{}') \
              ORDER BY rank DESC \
@@ -1056,7 +1061,7 @@ impl GraphStorage for PostgresAGEGraphStorage {
                     ag_catalog.agtype_to_json(properties)->>'node_id', \
                     '{}' \
                 ) as sim \
-             FROM {}.\"_ag_label_vertex\" \
+             FROM {}.\"Node\" \
              WHERE ag_catalog.agtype_to_json(properties)->>'node_id' OPERATOR(ag_catalog.%) '{}' \
              ORDER BY sim DESC \
              LIMIT {}",
@@ -1084,7 +1089,7 @@ impl GraphStorage for PostgresAGEGraphStorage {
         // Final fallback to simple ILIKE prefix matching (always works)
         let prefix_sql = format!(
             "SELECT ag_catalog.agtype_to_json(properties)->>'node_id' as label \
-             FROM {}.\"_ag_label_vertex\" \
+             FROM {}.\"Node\" \
              WHERE LOWER(ag_catalog.agtype_to_json(properties)->>'node_id') LIKE LOWER('{}%') \
              ORDER BY ag_catalog.agtype_to_json(properties)->>'node_id' \
              LIMIT {}",
@@ -1158,26 +1163,28 @@ impl GraphStorage for PostgresAGEGraphStorage {
         let where_clause = where_conditions.join(" AND ");
 
         // CTE query to get nodes with degree count in one query
+        // WHY "Node"/"EDGE": direct label tables use specific indexes instead of
+        // triggering PostgreSQL inheritance scans through the base label tables.
         let sql = format!(
             "WITH node_props AS (
-                SELECT 
+                SELECT
                     v.id as vertex_id,
                     ag_catalog.agtype_to_json(v.properties) as props
-                FROM {graph}.\"_ag_label_vertex\" v
+                FROM {graph}.\"Node\" v
                 WHERE {where_clause}
             ),
             edge_counts AS (
-                SELECT 
+                SELECT
                     e.start_id as node_id,
                     COUNT(*) as out_degree
-                FROM {graph}.\"_ag_label_edge\" e
+                FROM {graph}.\"EDGE\" e
                 GROUP BY e.start_id
             ),
             in_edge_counts AS (
-                SELECT 
+                SELECT
                     e.end_id as node_id,
                     COUNT(*) as in_degree
-                FROM {graph}.\"_ag_label_edge\" e
+                FROM {graph}.\"EDGE\" e
                 GROUP BY e.end_id
             )
             SELECT 
@@ -1548,12 +1555,19 @@ impl GraphStorage for PostgresAGEGraphStorage {
         // output format is not a bare integer string, the ::bigint cast fails.
         // The consistent pattern (same as node_degree / node_degrees_batch) is to cast
         // graphid to text and join on text = text, which AGE always supports.
+        //
+        // WHY "EDGE"/"Node" instead of "_ag_label_edge"/"_ag_label_vertex":
+        // The base label tables are parent tables in PostgreSQL's table inheritance
+        // hierarchy. Querying them triggers a scan of ALL child tables, bypassing the
+        // specific indexes (idx_edge_start_id, idx_node_props_gin) that exist on the
+        // concrete "EDGE" and "Node" tables. Direct table access uses those indexes and
+        // avoids the inheritance scan overhead (~196 MB + ~183 MB respectively).
         let sql = format!(
             "WITH edge_counts AS ( \
                 SELECT \
                     start_id::text AS start_id_text, \
                     COUNT(*) as out_degree \
-                FROM {}.\"_ag_label_edge\" \
+                FROM {}.\"EDGE\" \
                 GROUP BY start_id::text \
             ), \
             node_degrees AS ( \
@@ -1561,7 +1575,7 @@ impl GraphStorage for PostgresAGEGraphStorage {
                     v.id::text AS id_text, \
                     v.properties, \
                     COALESCE(ec.out_degree, 0) as degree \
-                FROM {}.\"_ag_label_vertex\" v \
+                FROM {}.\"Node\" v \
                 LEFT JOIN edge_counts ec ON v.id::text = ec.start_id_text \
                 {} \
             ) \
@@ -1675,9 +1689,11 @@ impl GraphStorage for PostgresAGEGraphStorage {
         // Native SQL: filter on edge properties directly.
         // `source_id` and `target_id` are stored in edge properties (not vertex joins needed).
         // Migration 036 adds expression indexes on these properties for fast lookups.
+        // WHY "EDGE" not "_ag_label_edge": direct table uses existing expression indexes
+        // from migration 036 instead of triggering a costly inheritance scan.
         let sql = format!(
             r#"SELECT ag_catalog.agtype_to_json(properties) AS edge_props
-               FROM {}."_ag_label_edge"
+               FROM {}."EDGE"
                WHERE ag_catalog.agtype_to_json(properties)->>'source_id' IN ({})
                  AND ag_catalog.agtype_to_json(properties)->>'target_id' IN ({})
                  {}"#,

--- a/edgequake/crates/edgequake-storage/src/adapters/postgres/graph/mod.rs
+++ b/edgequake/crates/edgequake-storage/src/adapters/postgres/graph/mod.rs
@@ -300,7 +300,9 @@ impl GraphStorage for PostgresAGEGraphStorage {
 
         // WHY chunk: bound the generated query string so a pathological batch
         // cannot blow past PostgreSQL's statement size / planner limits.
-        const CHUNK: usize = 500;
+        // WHY 100 not 500: large documents (4000+ entities with long LLM descriptions)
+        // cause the inlined UNWIND literal to exceed the statement_timeout at 500.
+        const CHUNK: usize = 100;
 
         for chunk in nodes.chunks(CHUNK) {
             let rows: Vec<String> = chunk
@@ -807,7 +809,9 @@ impl GraphStorage for PostgresAGEGraphStorage {
             return Ok(());
         }
 
-        const CHUNK: usize = 500;
+        // WHY 100: mirrors the node chunk rationale — avoids statement_timeout on
+        // large documents with many relationship properties.
+        const CHUNK: usize = 100;
 
         for chunk in edges.chunks(CHUNK) {
             let rows: Vec<String> = chunk

--- a/edgequake/crates/edgequake-storage/src/adapters/postgres/graph/mod.rs
+++ b/edgequake/crates/edgequake-storage/src/adapters/postgres/graph/mod.rs
@@ -324,7 +324,32 @@ impl GraphStorage for PostgresAGEGraphStorage {
                  SET n = props",
                 rows.join(", ")
             );
-            self.cypher_execute(&cypher).await?;
+
+            // WHY retry: "Entity failed to be updated" is a transient AGE concurrency
+            // conflict when multiple workers MERGE the same shared entity (e.g. "Google",
+            // "United States") simultaneously. A short backoff-retry resolves it without
+            // failing the entire document.
+            let mut attempts = 0u32;
+            loop {
+                match self.cypher_execute(&cypher).await {
+                    Ok(()) => break,
+                    Err(e)
+                        if attempts < 3
+                            && e.to_string().contains("Entity failed to be updated") =>
+                    {
+                        attempts += 1;
+                        tokio::time::sleep(tokio::time::Duration::from_millis(
+                            200 * u64::from(attempts),
+                        ))
+                        .await;
+                        tracing::warn!(
+                            attempt = attempts,
+                            "Node batch concurrent-update conflict — retrying"
+                        );
+                    }
+                    Err(e) => return Err(e),
+                }
+            }
         }
 
         // Lazily create indexes after the first successful batch (AGE builds the
@@ -838,7 +863,28 @@ impl GraphStorage for PostgresAGEGraphStorage {
                  SET r += e",
                 rows.join(", ")
             );
-            self.cypher_execute(&cypher).await?;
+
+            let mut attempts = 0u32;
+            loop {
+                match self.cypher_execute(&cypher).await {
+                    Ok(()) => break,
+                    Err(e)
+                        if attempts < 3
+                            && e.to_string().contains("Entity failed to be updated") =>
+                    {
+                        attempts += 1;
+                        tokio::time::sleep(tokio::time::Duration::from_millis(
+                            200 * u64::from(attempts),
+                        ))
+                        .await;
+                        tracing::warn!(
+                            attempt = attempts,
+                            "Edge batch concurrent-update conflict — retrying"
+                        );
+                    }
+                    Err(e) => return Err(e),
+                }
+            }
         }
 
         Ok(())

--- a/edgequake/crates/edgequake-storage/src/adapters/postgres/kv.rs
+++ b/edgequake/crates/edgequake-storage/src/adapters/postgres/kv.rs
@@ -183,15 +183,27 @@ impl KVStorage for PostgresKVStorage {
 
         let pool = self.pool.get().await?;
 
-        let sql = format!("SELECT value FROM {} WHERE key = ANY($1)", self.table_name);
+        // Use unnest WITH ORDINALITY so results come back in the same order as
+        // the input slice. WHERE key = ANY($1) does not guarantee order and
+        // causes callers that zip keys+values to pair wrong entries.
+        let sql = format!(
+            "SELECT t.value \
+             FROM unnest($1::text[]) WITH ORDINALITY AS u(key, ord) \
+             LEFT JOIN {} t ON t.key = u.key \
+             ORDER BY u.ord",
+            self.table_name
+        );
 
-        let rows: Vec<(serde_json::Value,)> = sqlx::query_as(&sql)
+        let rows: Vec<(Option<serde_json::Value>,)> = sqlx::query_as(&sql)
             .bind(ids)
             .fetch_all(&pool)
             .await
             .map_err(|e| StorageError::Database(format!("KV get_by_ids failed: {}", e)))?;
 
-        Ok(rows.into_iter().map(|(v,)| v).collect())
+        Ok(rows
+            .into_iter()
+            .map(|(v,)| v.unwrap_or(serde_json::Value::Null))
+            .collect())
     }
 
     async fn filter_keys(&self, keys: HashSet<String>) -> Result<HashSet<String>> {

--- a/edgequake/crates/edgequake-tasks/src/lib.rs
+++ b/edgequake/crates/edgequake-tasks/src/lib.rs
@@ -96,7 +96,7 @@ pub use storage::{
 };
 pub use tenant_limiter::TenantConcurrencyLimiter;
 pub use types::{
-    ChunkProgress, DirectoryScanData, DocumentUploadData, PdfProcessingData, ReindexData, Task,
-    TaskFailureInfo, TaskProgress, TaskStatus, TaskType, TextInsertData,
+    ChunkProgress, DirectoryScanData, DocumentUploadData, MetadataEnrichData, PdfProcessingData,
+    ReindexData, Task, TaskFailureInfo, TaskProgress, TaskStatus, TaskType, TextInsertData,
 };
 pub use worker::{SharedTaskProcessor, TaskProcessor, WorkerPool, WorkerPoolConfig};

--- a/edgequake/crates/edgequake-tasks/src/postgres.rs
+++ b/edgequake/crates/edgequake-tasks/src/postgres.rs
@@ -594,6 +594,7 @@ impl std::str::FromStr for crate::types::TaskType {
             "scan" => Ok(crate::types::TaskType::Scan),
             "reindex" => Ok(crate::types::TaskType::Reindex),
             "pdf_processing" => Ok(crate::types::TaskType::PdfProcessing),
+            "metadata_enrich" => Ok(crate::types::TaskType::MetadataEnrich),
             _ => Err(format!("Invalid task type: {}", s)),
         }
     }

--- a/edgequake/crates/edgequake-tasks/src/types/data.rs
+++ b/edgequake/crates/edgequake-tasks/src/types/data.rs
@@ -94,3 +94,31 @@ pub struct ReindexData {
     pub workspace_id: String,
     pub reason: String,
 }
+
+/// Metadata enrichment task payload.
+///
+/// Carries everything the enrichment worker needs to extract a summary,
+/// topic, language, and keywords from the first `max_pages` of a PDF.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MetadataEnrichData {
+    /// Pre-generated document ID shared with the PdfProcessing task.
+    /// The enrichment worker writes results to `{document_id}-metadata`.
+    pub document_id: String,
+
+    /// PDF identifier in pdf_storage (used to load raw bytes).
+    pub pdf_id: uuid::Uuid,
+
+    /// Tenant ID for multi-tenant isolation.
+    pub tenant_id: uuid::Uuid,
+
+    /// Workspace ID for isolation.
+    pub workspace_id: uuid::Uuid,
+
+    /// Maximum number of pages to extract text from (default 5).
+    #[serde(default = "default_max_pages")]
+    pub max_pages: usize,
+}
+
+fn default_max_pages() -> usize {
+    5
+}

--- a/edgequake/crates/edgequake-tasks/src/types/data.rs
+++ b/edgequake/crates/edgequake-tasks/src/types/data.rs
@@ -106,13 +106,13 @@ pub struct MetadataEnrichData {
     pub document_id: String,
 
     /// PDF identifier in pdf_storage (used to load raw bytes).
-    pub pdf_id: uuid::Uuid,
+    pub pdf_id: Uuid,
 
     /// Tenant ID for multi-tenant isolation.
-    pub tenant_id: uuid::Uuid,
+    pub tenant_id: Uuid,
 
     /// Workspace ID for isolation.
-    pub workspace_id: uuid::Uuid,
+    pub workspace_id: Uuid,
 
     /// Maximum number of pages to extract text from (default 5).
     #[serde(default = "default_max_pages")]

--- a/edgequake/crates/edgequake-tasks/src/types/mod.rs
+++ b/edgequake/crates/edgequake-tasks/src/types/mod.rs
@@ -479,4 +479,32 @@ mod tests {
         assert!(!task.circuit_breaker_tripped);
         assert!(!task.can_retry()); // max_retries exhausted
     }
+
+    #[test]
+    fn test_metadata_enrich_task_type() {
+        let task = Task::new(
+            test_tenant_id(),
+            test_workspace_id(),
+            TaskType::MetadataEnrich,
+            serde_json::json!({}),
+        );
+        assert_eq!(task.task_type, TaskType::MetadataEnrich);
+        assert!(task.track_id.starts_with("metadata_enrich-"));
+    }
+
+    #[test]
+    fn test_metadata_enrich_data_serialization() {
+        use crate::types::MetadataEnrichData;
+        let data = MetadataEnrichData {
+            document_id: "doc-123".to_string(),
+            pdf_id: uuid::Uuid::parse_str("00000000-0000-0000-0000-000000000001").unwrap(),
+            tenant_id: test_tenant_id(),
+            workspace_id: test_workspace_id(),
+            max_pages: 5,
+        };
+        let json = serde_json::to_value(&data).unwrap();
+        let back: MetadataEnrichData = serde_json::from_value(json).unwrap();
+        assert_eq!(back.document_id, "doc-123");
+        assert_eq!(back.max_pages, 5);
+    }
 }

--- a/edgequake/crates/edgequake-tasks/src/types/mod.rs
+++ b/edgequake/crates/edgequake-tasks/src/types/mod.rs
@@ -506,5 +506,15 @@ mod tests {
         let back: MetadataEnrichData = serde_json::from_value(json).unwrap();
         assert_eq!(back.document_id, "doc-123");
         assert_eq!(back.max_pages, 5);
+
+        // Also verify serde default: JSON without max_pages should default to 5
+        let json_no_max = serde_json::json!({
+            "document_id": "doc-456",
+            "pdf_id": "00000000-0000-0000-0000-000000000001",
+            "tenant_id": TEST_TENANT_ID,
+            "workspace_id": TEST_WORKSPACE_ID
+        });
+        let back2: MetadataEnrichData = serde_json::from_value(json_no_max).unwrap();
+        assert_eq!(back2.max_pages, 5); // serde default applied
     }
 }

--- a/edgequake/crates/edgequake-tasks/src/types/status.rs
+++ b/edgequake/crates/edgequake-tasks/src/types/status.rs
@@ -38,6 +38,7 @@ pub enum TaskType {
     Scan,
     Reindex,
     PdfProcessing,
+    MetadataEnrich,
 }
 
 impl fmt::Display for TaskType {
@@ -48,6 +49,7 @@ impl fmt::Display for TaskType {
             Self::Scan => write!(f, "scan"),
             Self::Reindex => write!(f, "reindex"),
             Self::PdfProcessing => write!(f, "pdf_processing"),
+            Self::MetadataEnrich => write!(f, "metadata_enrich"),
         }
     }
 }

--- a/edgequake/docker/.env.example
+++ b/edgequake/docker/.env.example
@@ -54,5 +54,13 @@ OLLAMA_CONTEXT_LENGTH=32768
 # OLLAMA_EMBEDDING_HOST=http://gpu-box:11434
 # OLLAMA_EMBEDDING_MODEL=nomic-embed-text
 
+# ── Entity Extraction ────────────────────────────────────────────────────────
+# Max parallel LLM calls during entity extraction.
+# Use 2-4 for local LLMs (Ollama/LMStudio) to avoid overwhelming the model.
+# Default is 2 (docker-compose); internal default is 16 (suited for cloud APIs).
+# EDGEQUAKE_MAX_CONCURRENT_EXTRACTIONS=2
+# Per-chunk LLM call timeout in seconds. Increase for slow/large local models.
+# EDGEQUAKE_CHUNK_TIMEOUT_SECS=300
+
 # ── Logging ───────────────────────────────────────────────────────────────────
 RUST_LOG=info

--- a/edgequake/docker/docker-compose.yml
+++ b/edgequake/docker/docker-compose.yml
@@ -63,6 +63,11 @@ services:
       - EDGEQUAKE_EMBEDDING_PROVIDER=${EDGEQUAKE_EMBEDDING_PROVIDER:-}
       # Vision extraction timeout (seconds). Default 600s (10 min).
       - EDGEQUAKE_VISION_TIMEOUT_SECS=${EDGEQUAKE_VISION_TIMEOUT_SECS:-600}
+      # Entity extraction concurrency and timeout.
+      # For local LLMs (Ollama/LMStudio), lower concurrency to avoid overwhelming the model.
+      # Default concurrency is 16 (suited for cloud APIs); use 2-4 for local LLMs.
+      - EDGEQUAKE_MAX_CONCURRENT_EXTRACTIONS=${EDGEQUAKE_MAX_CONCURRENT_EXTRACTIONS:-2}
+      - EDGEQUAKE_CHUNK_TIMEOUT_SECS=${EDGEQUAKE_CHUNK_TIMEOUT_SECS:-300}
       # pdfium-auto cache dir — writable by the non-root container user.
       # Override with PDFIUM_AUTO_CACHE_DIR if you mount a persistent volume.
       - PDFIUM_AUTO_CACHE_DIR=${PDFIUM_AUTO_CACHE_DIR:-/tmp/edgequake-pdfium-cache}

--- a/edgequake/migrations/038_add_metadata_enrich_task_type.sql
+++ b/edgequake/migrations/038_add_metadata_enrich_task_type.sql
@@ -1,0 +1,20 @@
+-- Migration 038: Add metadata_enrich to valid task_type constraint
+--
+-- WHY: Migration 026 added a CHECK constraint limiting task_type to a fixed list.
+-- The PDF Metadata Enrichment Pipeline introduces a new 'metadata_enrich' task type
+-- that runs before full graph processing to extract summary/topic/language/keywords.
+-- Without this, INSERT of metadata_enrich tasks fails with a constraint violation
+-- and the upload endpoint returns HTTP 500.
+
+ALTER TABLE tasks DROP CONSTRAINT IF EXISTS valid_task_type;
+
+ALTER TABLE tasks ADD CONSTRAINT valid_task_type CHECK (
+    task_type IN (
+        'upload',
+        'insert',
+        'scan',
+        'reindex',
+        'pdf_processing',
+        'metadata_enrich'
+    )
+);

--- a/edgequake/src/main.rs
+++ b/edgequake/src/main.rs
@@ -548,19 +548,20 @@ async fn main() -> Result<()> {
     let worker_config = WorkerPoolConfig {
         num_workers,
         auto_retry: true,
-        initial_retry_delay_ms: 5000,
+        // WHY 2000ms: Pipeline tasks are IO-bound (LLM calls, embeddings). Transient
+        // failures (rate limits, brief network drops) typically resolve within 1-2s.
+        // Starting retry at 2s instead of 5s reduces idle worker time on busy queues.
+        // Backoff still caps at 60s for persistent failures.
+        initial_retry_delay_ms: 2000,
         max_retry_delay_ms: 60000,
         backoff_multiplier: 2.0,
-        // FEAT-TENANT-FAIRNESS: Per-tenant concurrency limit.
-        // Ensures no single tenant can monopolize all workers.
-        // Default: max(1, num_workers * 3/4) — IO-bound workloads benefit
-        // from higher per-tenant concurrency while still reserving 25%
-        // capacity for other tenants.
-        // Set MAX_TASKS_PER_TENANT=0 to disable.
+        // WHY 0 default: Most deployments are single-tenant. The 3/4 cap wastes
+        // 25% of workers when there is only one tenant. Set MAX_TASKS_PER_TENANT
+        // to a non-zero value in multi-tenant production to restore fairness.
         max_tasks_per_tenant: std::env::var("MAX_TASKS_PER_TENANT")
             .ok()
             .and_then(|s| s.parse().ok())
-            .unwrap_or_else(|| (num_workers * 3 / 4).max(1)),
+            .unwrap_or(0),
         // WHY 2 hours (7200s): Large PDFs with vision LLM extraction can take
         // 3+ hours (1000+ pages × ~12s/page). 2 hours covers the vast majority
         // of real-world documents while still catching truly stuck tasks.

--- a/edgequake/src/main.rs
+++ b/edgequake/src/main.rs
@@ -639,6 +639,40 @@ async fn main() -> Result<()> {
     );
     worker_pool.start();
 
+    // ── Enrichment worker pool ────────────────────────────────────────────────
+    // Separate pool dedicated to MetadataEnrich tasks (fast: EdgeParser + VLM call).
+    // Keeps enrichment from competing with heavy PdfProcessing tasks.
+    let enrichment_config =
+        edgequake_api::processor::enrichment_config::EnrichmentConfig::from_env();
+    let enrich_concurrent = enrichment_config.concurrent;
+    let enrich_processor = Arc::new(
+        edgequake_api::processor::metadata_enrich::MetadataEnrichProcessor::new(
+            Arc::clone(&state.kv_storage) as Arc<dyn edgequake_storage::traits::KVStorage>,
+            state.pdf_storage.as_ref().map(Arc::clone),
+            enrichment_config,
+        ),
+    );
+    let enrich_pool_config = WorkerPoolConfig {
+        num_workers: enrich_concurrent,
+        auto_retry: true,
+        initial_retry_delay_ms: 1_000,
+        max_retry_delay_ms: 10_000,
+        backoff_multiplier: 2.0,
+        max_tasks_per_tenant: enrich_concurrent,
+        processing_timeout_secs: 300, // 5 min is plenty for 5-page enrichment
+    };
+    let mut enrich_pool = WorkerPool::new(
+        enrich_pool_config,
+        Arc::clone(&state.enrich_queue) as Arc<dyn edgequake_tasks::TaskQueue>,
+        Arc::clone(&state.task_storage) as Arc<dyn edgequake_tasks::TaskStorage>,
+        enrich_processor,
+    );
+    info!(
+        "Starting enrichment worker pool with {} workers",
+        enrich_concurrent
+    );
+    enrich_pool.start();
+
     // PERIODIC ORPHAN RECOVERY: Background task that catches tasks whose heartbeat
     // stopped mid-runtime (e.g., worker panic, tokio task cancellation). Uses the
     // 10-minute updated_at threshold — safe because legitimate tasks have heartbeats
@@ -682,9 +716,10 @@ async fn main() -> Result<()> {
     let server = Server::new(config, state);
     let result = server.run().await;
 
-    // Graceful shutdown of worker pool
-    info!("Shutting down worker pool...");
+    // Graceful shutdown of worker pools
+    info!("Shutting down worker pools...");
     worker_pool.shutdown().await;
+    enrich_pool.shutdown().await;
 
     result?;
     Ok(())

--- a/edgequake_webui/src/components/documents/document-actions-menu.tsx
+++ b/edgequake_webui/src/components/documents/document-actions-menu.tsx
@@ -8,7 +8,7 @@ import {
     DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import type { Document } from '@/types';
-import { Copy, Eye, MoreVertical, RefreshCw, StopCircle, Trash2 } from 'lucide-react';
+import { Copy, Eye, MoreVertical, RefreshCw, Sparkles, StopCircle, Trash2 } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
 import { ResetDocumentStatusButton } from './reset-document-status-button';
@@ -25,6 +25,8 @@ interface DocumentActionsMenuProps {
   onCancel: (trackId: string) => void;
   /** Callback to reprocess document */
   onReprocess: (id: string) => void;
+  /** Callback to trigger metadata enrichment */
+  onEnrich: (id: string) => void;
   /** Callback to delete document */
   onDelete: (id: string) => void;
   /** Whether a cancel operation is in progress */
@@ -52,6 +54,7 @@ export function DocumentActionsMenu({
   onViewPdf,
   onCancel,
   onReprocess,
+  onEnrich,
   onDelete,
   isCancelling = false,
 }: DocumentActionsMenuProps) {
@@ -119,6 +122,14 @@ export function DocumentActionsMenu({
           <RefreshCw className="h-4 w-4 mr-2" />
           {t('documents.actions.reprocess')}
         </DropdownMenuItem>
+
+        {/* Enrich — only for PDF documents */}
+        {doc.source_type === 'pdf' && (
+          <DropdownMenuItem onClick={() => onEnrich(doc.id)}>
+            <Sparkles className="h-4 w-4 mr-2" />
+            {t('documents.actions.enrich', 'Extract Topic & Summary')}
+          </DropdownMenuItem>
+        )}
 
         {/* Delete */}
         <DropdownMenuItem

--- a/edgequake_webui/src/components/documents/document-group-accordion.tsx
+++ b/edgequake_webui/src/components/documents/document-group-accordion.tsx
@@ -25,6 +25,7 @@ export interface DocumentGroupRowHandlers
     | 'onViewInGraph'
     | 'onViewPdf'
     | 'onRetry'
+    | 'onEnrich'
     | 'onCancel'
     | 'onDelete'
     | 'isRetrying'
@@ -61,6 +62,7 @@ export const DocumentGroupAccordion = memo(function DocumentGroupAccordion({
   onViewInGraph,
   onViewPdf,
   onRetry,
+  onEnrich,
   onCancel,
   onDelete,
   isRetrying,
@@ -112,6 +114,7 @@ export const DocumentGroupAccordion = memo(function DocumentGroupAccordion({
             onViewInGraph={onViewInGraph}
             onViewPdf={onViewPdf}
             onRetry={onRetry}
+            onEnrich={onEnrich}
             onCancel={onCancel}
             onDelete={onDelete}
             isRetrying={isRetrying}

--- a/edgequake_webui/src/components/documents/document-group-accordion.tsx
+++ b/edgequake_webui/src/components/documents/document-group-accordion.tsx
@@ -95,6 +95,26 @@ export const DocumentGroupAccordion = memo(function DocumentGroupAccordion({
           <span className="ml-1.5 text-xs text-muted-foreground bg-muted px-1.5 py-0.5 rounded-full">
             {documents.length}
           </span>
+          {/* Show union of all tags in this group */}
+          {(() => {
+            const allTags = Array.from(
+              new Set(
+                documents.flatMap((d) => d.enrichment_tags ?? [])
+              )
+            ).slice(0, 5);
+            return allTags.length > 0 ? (
+              <div className="ml-2 flex flex-wrap gap-1">
+                {allTags.map((tag) => (
+                  <span
+                    key={tag}
+                    className="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium bg-secondary/70 text-secondary-foreground"
+                  >
+                    {tag}
+                  </span>
+                ))}
+              </div>
+            ) : null;
+          })()}
         </button>
       </CollapsibleTrigger>
 

--- a/edgequake_webui/src/components/documents/document-group-accordion.tsx
+++ b/edgequake_webui/src/components/documents/document-group-accordion.tsx
@@ -1,0 +1,124 @@
+'use client';
+
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from '@/components/ui/collapsible';
+import { cn } from '@/lib/utils';
+import type { Document } from '@/types';
+import { ChevronDown, ChevronRight, Folder } from 'lucide-react';
+import { memo, useState } from 'react';
+import { DocumentTableRow } from './document-table-row';
+import type { DocumentTableRowProps } from './document-table-row';
+
+/**
+ * Handlers passed through to each DocumentTableRow — all row actions.
+ */
+export interface DocumentGroupRowHandlers
+  extends Pick<
+    DocumentTableRowProps,
+    | 'onSelect'
+    | 'onClick'
+    | 'onDoubleClick'
+    | 'onViewDetails'
+    | 'onViewInGraph'
+    | 'onViewPdf'
+    | 'onRetry'
+    | 'onCancel'
+    | 'onDelete'
+    | 'isRetrying'
+    | 'isCancelling'
+  > {}
+
+export interface DocumentGroupAccordionProps extends DocumentGroupRowHandlers {
+  /** Topic label for this group */
+  topic: string;
+  /** Documents in this group */
+  documents: Document[];
+  /** Currently selected document IDs */
+  selectedIds: Set<string>;
+  /** Currently active/previewed document */
+  selectedDocument: Document | null;
+  /** Current search query (for row highlight) */
+  searchQuery: string;
+}
+
+/**
+ * Collapsible accordion group for documents sharing the same topic.
+ * Collapsed by default. "Tanpa Topic" label rendered muted.
+ */
+export const DocumentGroupAccordion = memo(function DocumentGroupAccordion({
+  topic,
+  documents,
+  selectedIds,
+  selectedDocument,
+  searchQuery,
+  onSelect,
+  onClick,
+  onDoubleClick,
+  onViewDetails,
+  onViewInGraph,
+  onViewPdf,
+  onRetry,
+  onCancel,
+  onDelete,
+  isRetrying,
+  isCancelling,
+}: DocumentGroupAccordionProps) {
+  const [open, setOpen] = useState(false);
+  const isNoTopic = topic === 'Tanpa Topic';
+
+  return (
+    <Collapsible open={open} onOpenChange={setOpen}>
+      <CollapsibleTrigger asChild>
+        <button
+          className="w-full flex items-center gap-2 px-4 py-2 bg-muted/30 hover:bg-muted/50 border-b text-left transition-colors"
+          aria-expanded={open}
+        >
+          {open ? (
+            <ChevronDown className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
+          ) : (
+            <ChevronRight className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
+          )}
+          <Folder className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+          <span
+            className={cn(
+              'text-sm font-medium',
+              isNoTopic ? 'text-muted-foreground italic' : 'text-foreground',
+            )}
+          >
+            {topic}
+          </span>
+          <span className="ml-1.5 text-xs text-muted-foreground bg-muted px-1.5 py-0.5 rounded-full">
+            {documents.length}
+          </span>
+        </button>
+      </CollapsibleTrigger>
+
+      <CollapsibleContent>
+        {documents.map((doc, index) => (
+          <DocumentTableRow
+            key={doc.id}
+            doc={doc}
+            index={index}
+            isSelected={selectedIds.has(doc.id)}
+            isActive={selectedDocument?.id === doc.id}
+            searchQuery={searchQuery}
+            onSelect={onSelect}
+            onClick={onClick}
+            onDoubleClick={onDoubleClick}
+            onViewDetails={onViewDetails}
+            onViewInGraph={onViewInGraph}
+            onViewPdf={onViewPdf}
+            onRetry={onRetry}
+            onCancel={onCancel}
+            onDelete={onDelete}
+            isRetrying={isRetrying}
+            isCancelling={isCancelling}
+          />
+        ))}
+      </CollapsibleContent>
+    </Collapsible>
+  );
+});

--- a/edgequake_webui/src/components/documents/document-manager.tsx
+++ b/edgequake_webui/src/components/documents/document-manager.tsx
@@ -104,6 +104,7 @@ export function DocumentManager() {
   const {
     deleteMutation,
     reprocessMutation,
+    enrichMutation,
     cancelMutation,
   } = useDocumentMutations({
     onReprocessSuccess: () => setPipelineDialogOpen(true),
@@ -279,6 +280,7 @@ export function DocumentManager() {
         onViewInGraph={handleViewInGraph}
         onViewPdf={handleViewPdf}
         onRetry={(id) => reprocessMutation.mutate(id)}
+        onEnrich={(id) => enrichMutation.mutate(id)}
         onCancel={(trackId) => cancelMutation.mutate(trackId)}
         onDelete={(id) => deleteMutation.mutate(id)}
         isRetrying={reprocessMutation.isPending}

--- a/edgequake_webui/src/components/documents/document-manager.tsx
+++ b/edgequake_webui/src/components/documents/document-manager.tsx
@@ -76,6 +76,7 @@ export function DocumentManager() {
     statusFilter, setStatusFilter,
     sortField, setSortField,
     sortDirection, setSortDirection,
+    groupedView, setGroupedView,
   } = useDocumentPreferences();
 
   // Pipeline status dialog state
@@ -235,6 +236,8 @@ export function DocumentManager() {
             onSortFieldChange={setSortField}
             sortDirection={sortDirection}
             onSortDirectionChange={setSortDirection}
+            groupedView={groupedView}
+            onGroupedViewChange={setGroupedView}
             statusCounts={statusCounts}
             pipelineStatus={pipelineStatus}
             documents={documents}
@@ -286,6 +289,7 @@ export function DocumentManager() {
         pageSize={pageSize}
         onPageChange={setCurrentPage}
         onPageSizeChange={setPageSize}
+        groupedView={groupedView}
         onClearFilter={() => {
           setStatusFilter('all');
           setSearchQuery('');

--- a/edgequake_webui/src/components/documents/document-preview-panel.tsx
+++ b/edgequake_webui/src/components/documents/document-preview-panel.tsx
@@ -51,7 +51,9 @@ import {
     Loader2,
     Network,
     RefreshCw,
+    Sparkles,
     StopCircle,
+    Tag,
     Trash2,
     Wifi,
     XCircle,
@@ -175,7 +177,10 @@ export function DocumentPreviewPanel({
   }, [document, t]);
 
   const handleCopyContent = useCallback(async () => {
-    const content = fullDocument?.content || document?.content_summary;
+    const content = fullDocument?.content
+      || document?.content_summary
+      || fullDocument?.enrichment_summary
+      || document?.enrichment_summary;
     if (!content) return;
     try {
       await navigator.clipboard.writeText(content);
@@ -210,10 +215,20 @@ export function DocumentPreviewPanel({
   const isFailed = status === 'failed' || status === 'partial_failure';
   const isCancelled = status === 'cancelled';
 
-  const contentPreview = fullDocument?.content || document?.content_summary || '';
+  // Content: full text → summary → enrichment summary (PDF docs rarely have plain content)
+  const contentPreview = fullDocument?.content
+    || document?.content_summary
+    || fullDocument?.enrichment_summary
+    || document?.enrichment_summary
+    || '';
   const previewLength = 500;
   const hasMoreContent = contentPreview.length > previewLength;
   const displayContent = showFullContent ? contentPreview : contentPreview.slice(0, previewLength);
+
+  // Enrichment data (prefer from freshly-fetched full document)
+  const topic = fullDocument?.enrichment_topic ?? document?.enrichment_topic;
+  const tags = fullDocument?.enrichment_tags ?? document?.enrichment_tags;
+  const enrichmentLanguage = fullDocument?.enrichment_language ?? document?.enrichment_language;
 
   return (
     <article
@@ -362,6 +377,50 @@ export function DocumentPreviewPanel({
         </div>
       </div>
 
+      {/* Enrichment: Topic & Tags */}
+      {(topic || (tags && tags.length > 0)) && (
+        <>
+          <Separator />
+          <div className="space-y-3">
+            <h4 className="text-sm font-medium text-muted-foreground uppercase tracking-wider flex items-center gap-1.5">
+              <Sparkles className="h-3.5 w-3.5" />
+              {t('documents.preview.enrichment', 'Topic & Tags')}
+            </h4>
+            <div className="space-y-2">
+              {topic && (
+                <div className="flex items-center justify-between">
+                  <span className="text-sm text-muted-foreground flex items-center gap-1.5">
+                    <Tag className="h-3.5 w-3.5" />
+                    {t('documents.preview.topic', 'Topic')}
+                  </span>
+                  <span className="text-sm font-medium">{topic}</span>
+                </div>
+              )}
+              {enrichmentLanguage && (
+                <div className="flex items-center justify-between">
+                  <span className="text-sm text-muted-foreground">
+                    {t('documents.preview.language', 'Language')}
+                  </span>
+                  <span className="text-sm font-medium uppercase">{enrichmentLanguage}</span>
+                </div>
+              )}
+              {tags && tags.length > 0 && (
+                <div className="flex flex-wrap gap-1 pt-1">
+                  {tags.map((tag) => (
+                    <span
+                      key={tag}
+                      className="inline-flex items-center px-2 py-0.5 rounded-md text-xs font-medium bg-secondary text-secondary-foreground"
+                    >
+                      {tag}
+                    </span>
+                  ))}
+                </div>
+              )}
+            </div>
+          </div>
+        </>
+      )}
+
       {/* Cost Information */}
       {(document.cost_usd !== undefined || document.total_tokens !== undefined) && (
         <>
@@ -485,7 +544,7 @@ export function DocumentPreviewPanel({
           <h4 className="text-sm font-medium text-muted-foreground uppercase tracking-wider">
             {t('documents.preview.content', 'Content Preview')}
           </h4>
-          {(fullDocument?.content || document?.content_summary) && (
+          {(fullDocument?.content || document?.content_summary || fullDocument?.enrichment_summary || document?.enrichment_summary) && (
             <Button variant="ghost" size="sm" className="h-7 text-xs" onClick={handleCopyContent}>
               <Copy className="h-3 w-3 mr-1" />
               {t('common.copy', 'Copy')}
@@ -501,7 +560,7 @@ export function DocumentPreviewPanel({
                 <Skeleton className="h-4 w-3/4" />
                 <Skeleton className="h-4 w-1/2" />
               </div>
-            ) : (fullDocument?.content || document?.content_summary) ? (
+            ) : contentPreview ? (
               <div className="space-y-2">
                 <pre className="text-xs text-muted-foreground whitespace-pre-wrap font-mono leading-relaxed max-h-[200px] overflow-y-auto">
                   {displayContent}

--- a/edgequake_webui/src/components/documents/document-table-row.tsx
+++ b/edgequake_webui/src/components/documents/document-table-row.tsx
@@ -228,6 +228,19 @@ export const DocumentTableRow = memo(function DocumentTableRow({
               {t('documents.cancelled.subtitle', 'Processing was cancelled')}
             </span>
           )}
+          {/* Enrichment tags */}
+          {doc.enrichment_tags && doc.enrichment_tags.length > 0 && (
+            <div className="flex flex-wrap gap-1 mt-0.5">
+              {doc.enrichment_tags.map((tag) => (
+                <span
+                  key={tag}
+                  className="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium bg-secondary text-secondary-foreground"
+                >
+                  {tag}
+                </span>
+              ))}
+            </div>
+          )}
         </div>
       </TableCell>
 

--- a/edgequake_webui/src/components/documents/document-table-row.tsx
+++ b/edgequake_webui/src/components/documents/document-table-row.tsx
@@ -127,6 +127,8 @@ export interface DocumentTableRowProps {
   onViewPdf: (doc: Document) => void;
   /** Called when Retry action is triggered */
   onRetry: (docId: string) => void;
+  /** Called when Enrich action is triggered */
+  onEnrich: (docId: string) => void;
   /** Called when Cancel action is triggered */
   onCancel: (trackId: string) => void;
   /** Called when Delete action is triggered */
@@ -154,6 +156,7 @@ export const DocumentTableRow = memo(function DocumentTableRow({
   onViewInGraph,
   onViewPdf,
   onRetry,
+  onEnrich,
   onCancel,
   onDelete,
   isRetrying,
@@ -295,6 +298,7 @@ export const DocumentTableRow = memo(function DocumentTableRow({
             onViewPdf={onViewPdf}
             onCancel={onCancel}
             onReprocess={onRetry}
+            onEnrich={onEnrich}
             onDelete={onDelete}
             isCancelling={isCancelling}
           />

--- a/edgequake_webui/src/components/documents/document-table-section.tsx
+++ b/edgequake_webui/src/components/documents/document-table-section.tsx
@@ -69,6 +69,8 @@ export interface DocumentTableSectionProps {
   onViewPdf: (doc: Document) => void;
   /** Handler for retry action */
   onRetry: (id: string) => void;
+  /** Handler for enrich action */
+  onEnrich: (id: string) => void;
   /** Handler for cancel action */
   onCancel: (trackId: string) => void;
   /** Handler for delete action */
@@ -111,6 +113,7 @@ function GroupedView({
   onViewInGraph,
   onViewPdf,
   onRetry,
+  onEnrich,
   onCancel,
   onDelete,
   isRetrying,
@@ -127,6 +130,7 @@ function GroupedView({
   onViewInGraph: (doc: Document) => void;
   onViewPdf: (doc: Document) => void;
   onRetry: (id: string) => void;
+  onEnrich: (id: string) => void;
   onCancel: (trackId: string) => void;
   onDelete: (id: string) => void;
   isRetrying: boolean;
@@ -151,6 +155,7 @@ function GroupedView({
           onViewInGraph={onViewInGraph}
           onViewPdf={onViewPdf}
           onRetry={onRetry}
+          onEnrich={onEnrich}
           onCancel={onCancel}
           onDelete={onDelete}
           isRetrying={isRetrying}
@@ -183,6 +188,7 @@ export const DocumentTableSection = memo(function DocumentTableSection({
   onViewInGraph,
   onViewPdf,
   onRetry,
+  onEnrich,
   onCancel,
   onDelete,
   isRetrying,
@@ -235,6 +241,7 @@ export const DocumentTableSection = memo(function DocumentTableSection({
                   onViewInGraph={onViewInGraph}
                   onViewPdf={onViewPdf}
                   onRetry={onRetry}
+                  onEnrich={onEnrich}
                   onCancel={onCancel}
                   onDelete={onDelete}
                   isRetrying={isRetrying}
@@ -276,6 +283,7 @@ export const DocumentTableSection = memo(function DocumentTableSection({
                           onViewInGraph={onViewInGraph}
                           onViewPdf={onViewPdf}
                           onRetry={onRetry}
+                          onEnrich={onEnrich}
                           onCancel={onCancel}
                           onDelete={onDelete}
                           isRetrying={isRetrying}

--- a/edgequake_webui/src/components/documents/document-table-section.tsx
+++ b/edgequake_webui/src/components/documents/document-table-section.tsx
@@ -27,6 +27,8 @@ import type { Document } from '@/types';
 import { FileText } from 'lucide-react';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useDocumentGrouping } from '@/hooks/use-document-grouping';
+import { DocumentGroupAccordion } from './document-group-accordion';
 import { DocumentTableRow } from './document-table-row';
 import { DocumentTableStates } from './document-table-states';
 import { PaginationControls } from './pagination-controls';
@@ -89,6 +91,74 @@ export interface DocumentTableSectionProps {
   onPageSizeChange: (size: number) => void;
   /** Optional callback to clear active filters/search (shows clear button in empty state) */
   onClearFilter?: () => void;
+  /** Whether to render documents grouped by topic */
+  groupedView?: boolean;
+}
+
+/**
+ * Private helper: renders all topic groups as accordions.
+ * Keeps grouped rendering out of DocumentTableSection's main render.
+ */
+function GroupedView({
+  documents,
+  selectedIds,
+  selectedDocument,
+  searchQuery,
+  onSelectOne,
+  onRowClick,
+  onRowDoubleClick,
+  onViewDetails,
+  onViewInGraph,
+  onViewPdf,
+  onRetry,
+  onCancel,
+  onDelete,
+  isRetrying,
+  isCancelling,
+}: {
+  documents: Document[];
+  selectedIds: Set<string>;
+  selectedDocument: Document | null;
+  searchQuery: string;
+  onSelectOne: (id: string, checked: boolean) => void;
+  onRowClick: (doc: Document) => void;
+  onRowDoubleClick: (doc: Document) => void;
+  onViewDetails: (doc: Document) => void;
+  onViewInGraph: (doc: Document) => void;
+  onViewPdf: (doc: Document) => void;
+  onRetry: (id: string) => void;
+  onCancel: (trackId: string) => void;
+  onDelete: (id: string) => void;
+  isRetrying: boolean;
+  isCancelling: boolean;
+}) {
+  const groups = useDocumentGrouping(documents);
+
+  return (
+    <div className="border rounded-lg overflow-hidden shadow-sm divide-y">
+      {Array.from(groups.entries()).map(([topic, docs]) => (
+        <DocumentGroupAccordion
+          key={topic}
+          topic={topic}
+          documents={docs}
+          selectedIds={selectedIds}
+          selectedDocument={selectedDocument}
+          searchQuery={searchQuery}
+          onSelect={onSelectOne}
+          onClick={onRowClick}
+          onDoubleClick={onRowDoubleClick}
+          onViewDetails={onViewDetails}
+          onViewInGraph={onViewInGraph}
+          onViewPdf={onViewPdf}
+          onRetry={onRetry}
+          onCancel={onCancel}
+          onDelete={onDelete}
+          isRetrying={isRetrying}
+          isCancelling={isCancelling}
+        />
+      ))}
+    </div>
+  );
 }
 
 /**
@@ -124,6 +194,7 @@ export const DocumentTableSection = memo(function DocumentTableSection({
   onPageChange,
   onPageSizeChange,
   onClearFilter,
+  groupedView = false,
 }: DocumentTableSectionProps) {
   const { t } = useTranslation();
 
@@ -151,51 +222,69 @@ export const DocumentTableSection = memo(function DocumentTableSection({
           />
           
           {!isLoading && documents.length > 0 && (
-            <div className="border rounded-lg overflow-hidden shadow-sm">
-              <Table aria-label="Documents list">
-                <TableHeader className="bg-muted/50 sticky top-0 z-10">
-                  <TableRow className="hover:bg-transparent">
-                    <TableHead scope="col" className="w-10">
-                      <Checkbox
-                        checked={isAllSelected}
-                        onCheckedChange={(checked) => onSelectAll(!!checked)}
-                        aria-label={t('documents.bulk.selectAll', 'Select all')}
-                      />
-                    </TableHead>
-                    <TableHead scope="col">{t('documents.table.title', 'Title')}</TableHead>
-                    <TableHead scope="col">{t('documents.table.status', 'Status')}</TableHead>
-                    <TableHead scope="col" className="text-center">{t('documents.table.entities', 'Entities')}</TableHead>
-                    <TableHead scope="col" className="text-center">{t('documents.table.cost', 'Cost')}</TableHead>
-                    <TableHead scope="col">{t('documents.table.created', 'Created')}</TableHead>
-                    <TableHead scope="col">{t('documents.table.updated', 'Last Updated')}</TableHead>
-                    <TableHead scope="col" className="w-25"><span className="sr-only">{t('documents.table.actions', 'Actions')}</span></TableHead>
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
-                  {documents.map((doc, index) => (
-                    <DocumentTableRow
-                      key={doc.id}
-                      doc={doc}
-                      index={index}
-                      isSelected={selectedIds.has(doc.id)}
-                      isActive={selectedDocument?.id === doc.id}
-                      searchQuery={searchQuery}
-                      onSelect={onSelectOne}
-                      onClick={onRowClick}
-                      onDoubleClick={onRowDoubleClick}
-                      onViewDetails={onViewDetails}
-                      onViewInGraph={onViewInGraph}
-                      onViewPdf={onViewPdf}
-                      onRetry={onRetry}
-                      onCancel={onCancel}
-                      onDelete={onDelete}
-                      isRetrying={isRetrying}
-                      isCancelling={isCancelling}
-                    />
-                  ))}
-                </TableBody>
-              </Table>
-            </div>
+            groupedView
+              ? <GroupedView
+                  documents={documents}
+                  selectedIds={selectedIds}
+                  selectedDocument={selectedDocument}
+                  searchQuery={searchQuery}
+                  onSelectOne={onSelectOne}
+                  onRowClick={onRowClick}
+                  onRowDoubleClick={onRowDoubleClick}
+                  onViewDetails={onViewDetails}
+                  onViewInGraph={onViewInGraph}
+                  onViewPdf={onViewPdf}
+                  onRetry={onRetry}
+                  onCancel={onCancel}
+                  onDelete={onDelete}
+                  isRetrying={isRetrying}
+                  isCancelling={isCancelling}
+                />
+              : <div className="border rounded-lg overflow-hidden shadow-sm">
+                  <Table aria-label="Documents list">
+                    <TableHeader className="bg-muted/50 sticky top-0 z-10">
+                      <TableRow className="hover:bg-transparent">
+                        <TableHead scope="col" className="w-10">
+                          <Checkbox
+                            checked={isAllSelected}
+                            onCheckedChange={(checked) => onSelectAll(!!checked)}
+                            aria-label={t('documents.bulk.selectAll', 'Select all')}
+                          />
+                        </TableHead>
+                        <TableHead scope="col">{t('documents.table.title', 'Title')}</TableHead>
+                        <TableHead scope="col">{t('documents.table.status', 'Status')}</TableHead>
+                        <TableHead scope="col" className="text-center">{t('documents.table.entities', 'Entities')}</TableHead>
+                        <TableHead scope="col" className="text-center">{t('documents.table.cost', 'Cost')}</TableHead>
+                        <TableHead scope="col">{t('documents.table.created', 'Created')}</TableHead>
+                        <TableHead scope="col">{t('documents.table.updated', 'Last Updated')}</TableHead>
+                        <TableHead scope="col" className="w-25"><span className="sr-only">{t('documents.table.actions', 'Actions')}</span></TableHead>
+                      </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                      {documents.map((doc, index) => (
+                        <DocumentTableRow
+                          key={doc.id}
+                          doc={doc}
+                          index={index}
+                          isSelected={selectedIds.has(doc.id)}
+                          isActive={selectedDocument?.id === doc.id}
+                          searchQuery={searchQuery}
+                          onSelect={onSelectOne}
+                          onClick={onRowClick}
+                          onDoubleClick={onRowDoubleClick}
+                          onViewDetails={onViewDetails}
+                          onViewInGraph={onViewInGraph}
+                          onViewPdf={onViewPdf}
+                          onRetry={onRetry}
+                          onCancel={onCancel}
+                          onDelete={onDelete}
+                          isRetrying={isRetrying}
+                          isCancelling={isCancelling}
+                        />
+                      ))}
+                    </TableBody>
+                  </Table>
+                </div>
           )}
         </div>
       </div>

--- a/edgequake_webui/src/components/documents/document-toolbar-section.tsx
+++ b/edgequake_webui/src/components/documents/document-toolbar-section.tsx
@@ -1,7 +1,9 @@
 'use client';
 
+import { LayoutList, LayoutGrid } from 'lucide-react';
 import type { StatusCounts } from '@/hooks/use-document-filtering';
 import type { Document, PipelineStatus } from '@/types';
+import { Button } from '@/components/ui/button';
 import { BatchActionsBar } from './batch-actions-bar';
 import { DocumentDropzone, type DocumentDropzoneProps } from './document-dropzone';
 import type { DocStatus, SortField } from './document-filters';
@@ -30,6 +32,10 @@ export interface DocumentToolbarSectionProps {
   onSortFieldChange: (value: SortField) => void;
   sortDirection: 'asc' | 'desc';
   onSortDirectionChange: (value: 'asc' | 'desc') => void;
+  /** Whether documents are currently grouped by topic */
+  groupedView: boolean;
+  /** Toggle grouped view on/off */
+  onGroupedViewChange: (value: boolean) => void;
   statusCounts: StatusCounts;
   
   // Pipeline status
@@ -68,6 +74,8 @@ export function DocumentToolbarSection({
   onSortFieldChange,
   sortDirection,
   onSortDirectionChange,
+  groupedView,
+  onGroupedViewChange,
   statusCounts,
   pipelineStatus,
   documents,
@@ -105,6 +113,29 @@ export function DocumentToolbarSection({
           onSortDirectionChange={onSortDirectionChange}
           statusCounts={statusCounts}
         />
+        {/* List / Grouped toggle */}
+        <div className="flex items-center border rounded-md overflow-hidden shrink-0">
+          <Button
+            variant={!groupedView ? 'secondary' : 'ghost'}
+            size="sm"
+            className="rounded-none h-8 px-2.5 gap-1.5"
+            onClick={() => onGroupedViewChange(false)}
+            title="List view"
+          >
+            <LayoutList className="h-3.5 w-3.5" />
+            <span className="text-xs hidden sm:inline">List</span>
+          </Button>
+          <Button
+            variant={groupedView ? 'secondary' : 'ghost'}
+            size="sm"
+            className="rounded-none h-8 px-2.5 gap-1.5 border-l"
+            onClick={() => onGroupedViewChange(true)}
+            title="Grouped by topic"
+          >
+            <LayoutGrid className="h-3.5 w-3.5" />
+            <span className="text-xs hidden sm:inline">Grouped</span>
+          </Button>
+        </div>
       </div>
 
       {/* Processing Status Summary */}

--- a/edgequake_webui/src/components/documents/index.ts
+++ b/edgequake_webui/src/components/documents/index.ts
@@ -50,6 +50,7 @@ export { ScanDocumentsButton } from "./scan-documents-button";
 // Display components
 export { CostBadge } from "./cost-badge";
 export { CostCell } from "./cost-cell";
+export { DocumentGroupAccordion } from "./document-group-accordion";
 export { ErrorMessagePopover } from "./error-message-popover";
 export { FailedChunksCard } from "./failed-chunks-card";
 

--- a/edgequake_webui/src/hooks/__tests__/use-document-grouping.test.ts
+++ b/edgequake_webui/src/hooks/__tests__/use-document-grouping.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { groupDocumentsByTopic } from "../use-document-grouping";
+import type { Document } from "@/types";
+
+function makeDoc(id: string, topic?: string): Document {
+  return { id, enrichment_topic: topic } as Document;
+}
+
+describe("groupDocumentsByTopic", () => {
+  it("groups documents by topic", () => {
+    const docs = [
+      makeDoc("1", "Psikologi"),
+      makeDoc("2", "Politik"),
+      makeDoc("3", "Psikologi"),
+    ];
+    const result = groupDocumentsByTopic(docs);
+    expect(result.get("Psikologi")).toHaveLength(2);
+    expect(result.get("Politik")).toHaveLength(1);
+  });
+
+  it("puts docs without topic into 'Tanpa Topic'", () => {
+    const docs = [makeDoc("1", undefined), makeDoc("2", ""), makeDoc("3", "Politik")];
+    const result = groupDocumentsByTopic(docs);
+    expect(result.get("Tanpa Topic")).toHaveLength(2);
+    expect(result.get("Politik")).toHaveLength(1);
+  });
+
+  it("'Tanpa Topic' is always last key in the map", () => {
+    const docs = [
+      makeDoc("1", undefined),
+      makeDoc("2", "Zzz Topic"),
+      makeDoc("3", "Aaa Topic"),
+    ];
+    const result = groupDocumentsByTopic(docs);
+    const keys = Array.from(result.keys());
+    expect(keys[keys.length - 1]).toBe("Tanpa Topic");
+  });
+
+  it("sorts other topics alphabetically", () => {
+    const docs = [
+      makeDoc("1", "Zebra"),
+      makeDoc("2", "Apple"),
+      makeDoc("3", "Mango"),
+    ];
+    const result = groupDocumentsByTopic(docs);
+    const keys = Array.from(result.keys());
+    expect(keys).toEqual(["Apple", "Mango", "Zebra"]);
+  });
+
+  it("returns empty map for empty input", () => {
+    expect(groupDocumentsByTopic([]).size).toBe(0);
+  });
+
+  it("returns single group when all docs have same topic", () => {
+    const docs = [makeDoc("1", "ML"), makeDoc("2", "ML")];
+    const result = groupDocumentsByTopic(docs);
+    expect(result.size).toBe(1);
+    expect(result.get("ML")).toHaveLength(2);
+  });
+});

--- a/edgequake_webui/src/hooks/use-document-grouping.ts
+++ b/edgequake_webui/src/hooks/use-document-grouping.ts
@@ -1,3 +1,12 @@
+/**
+ * @module useDocumentGrouping
+ * @description Groups documents by enrichment_topic for accordion display.
+ * Extracted as a separate hook for SRP compliance and independent testability.
+ *
+ * @implements Document Topic Grouping feature
+ */
+"use client";
+
 import type { Document } from "@/types";
 import { useMemo } from "react";
 

--- a/edgequake_webui/src/hooks/use-document-grouping.ts
+++ b/edgequake_webui/src/hooks/use-document-grouping.ts
@@ -1,0 +1,52 @@
+import type { Document } from "@/types";
+import { useMemo } from "react";
+
+const NO_TOPIC_KEY = "Tanpa Topic";
+
+/**
+ * Groups an array of documents by their `enrichment_topic`.
+ * Documents without a topic are placed under "Tanpa Topic", always last.
+ * Other groups are sorted alphabetically.
+ *
+ * Exported as a named function so it can be tested independently of React.
+ */
+export function groupDocumentsByTopic(documents: Document[]): Map<string, Document[]> {
+  const groups = new Map<string, Document[]>();
+
+  for (const doc of documents) {
+    const topic =
+      doc.enrichment_topic && doc.enrichment_topic.trim() !== ""
+        ? doc.enrichment_topic.trim()
+        : NO_TOPIC_KEY;
+
+    const existing = groups.get(topic);
+    if (existing) {
+      existing.push(doc);
+    } else {
+      groups.set(topic, [doc]);
+    }
+  }
+
+  // Sort: alphabetical first, "Tanpa Topic" last
+  const sorted = new Map<string, Document[]>();
+  const keys = Array.from(groups.keys())
+    .filter((k) => k !== NO_TOPIC_KEY)
+    .sort((a, b) => a.localeCompare(b));
+
+  for (const key of keys) {
+    sorted.set(key, groups.get(key)!);
+  }
+  if (groups.has(NO_TOPIC_KEY)) {
+    sorted.set(NO_TOPIC_KEY, groups.get(NO_TOPIC_KEY)!);
+  }
+
+  return sorted;
+}
+
+/**
+ * React hook wrapping groupDocumentsByTopic with memoization.
+ * Re-groups only when the documents array reference changes.
+ */
+export function useDocumentGrouping(documents: Document[]): Map<string, Document[]> {
+  return useMemo(() => groupDocumentsByTopic(documents), [documents]);
+}

--- a/edgequake_webui/src/hooks/use-document-mutations.ts
+++ b/edgequake_webui/src/hooks/use-document-mutations.ts
@@ -21,6 +21,7 @@ import {
     cancelTask,
     deleteAllDocuments,
     deleteDocument,
+    enrichDocument,
     reprocessDocument,
     retryTask,
 } from "@/lib/api/edgequake";
@@ -69,6 +70,17 @@ export interface UseDocumentMutationsReturn {
    */
   reprocessMutation: UseMutationResult<
     { track_id: string; message: string; count: number },
+    Error,
+    string,
+    unknown
+  >;
+
+  /**
+   * Trigger metadata enrichment for a document by ID.
+   * Re-runs topic/summary/language/keywords extraction.
+   */
+  enrichMutation: UseMutationResult<
+    { document_id: string; track_id: string; message: string },
     Error,
     string,
     unknown
@@ -275,6 +287,21 @@ export function useDocumentMutations(
     },
   });
 
+  const enrichMutation = useMutation({
+    mutationFn: (documentId: string) => enrichDocument(documentId),
+    onSuccess: () => {
+      toast.success(t("documents.enrich.success", "Enrichment task queued"), {
+        duration: 4000,
+      });
+      queryClient.invalidateQueries({ queryKey: ["documents"] });
+    },
+    onError: (error: Error) => {
+      toast.error(t("documents.enrich.failed", "Enrichment failed"), {
+        description: error instanceof Error ? error.message : t("common.unknownError", "Unknown error"),
+      });
+    },
+  });
+
   /**
    * WHY: Cancel mutation for stopping in-progress extraction.
    * Track ID required to identify the specific processing task.
@@ -358,6 +385,7 @@ export function useDocumentMutations(
     deleteMutation,
     deleteAllMutation,
     reprocessMutation,
+    enrichMutation,
     cancelMutation,
     retryTaskMutation,
     isAnyMutationPending,

--- a/edgequake_webui/src/hooks/use-document-preferences.ts
+++ b/edgequake_webui/src/hooks/use-document-preferences.ts
@@ -56,6 +56,7 @@ const DEFAULTS = {
   statusFilter: "all" as DocStatus,
   sortField: "created_at" as SortField,
   sortDirection: "desc" as SortDirection,
+  groupedView: false,
 };
 
 /**
@@ -82,6 +83,10 @@ export interface UseDocumentPreferencesReturn {
   /** Sort direction */
   sortDirection: SortDirection;
   setSortDirection: (direction: SortDirection) => void;
+
+  /** Whether documents are grouped by topic */
+  groupedView: boolean;
+  setGroupedView: (value: boolean) => void;
 }
 
 /**
@@ -93,6 +98,7 @@ function readPreferences(): Partial<{
   statusFilter: DocStatus;
   sortField: SortField;
   sortDirection: SortDirection;
+  groupedView: boolean;
 }> {
   if (typeof window === "undefined") return {};
 
@@ -150,6 +156,11 @@ export function useDocumentPreferences(): UseDocumentPreferencesReturn {
     return prefs.sortDirection || DEFAULTS.sortDirection;
   });
 
+  const [groupedView, setGroupedView] = useState<boolean>(() => {
+    const prefs = readPreferences();
+    return prefs.groupedView ?? DEFAULTS.groupedView;
+  });
+
   // Persist changes to localStorage
   useEffect(() => {
     try {
@@ -160,12 +171,13 @@ export function useDocumentPreferences(): UseDocumentPreferencesReturn {
           statusFilter,
           sortField,
           sortDirection,
+          groupedView,
         }),
       );
     } catch {
       // Ignore localStorage errors (e.g., in incognito mode)
     }
-  }, [pageSize, statusFilter, sortField, sortDirection]);
+  }, [pageSize, statusFilter, sortField, sortDirection, groupedView]);
 
   return {
     pageSize,
@@ -176,6 +188,8 @@ export function useDocumentPreferences(): UseDocumentPreferencesReturn {
     setSortField,
     sortDirection,
     setSortDirection,
+    groupedView,
+    setGroupedView,
   };
 }
 

--- a/edgequake_webui/src/lib/api/edgequake.ts
+++ b/edgequake_webui/src/lib/api/edgequake.ts
@@ -841,6 +841,19 @@ export async function reprocessDocument(
 }
 
 /**
+ * Trigger metadata enrichment for a single document.
+ * Re-runs topic/summary/language/keywords extraction via the enrichment VLM.
+ */
+export async function enrichDocument(
+  documentId: string,
+): Promise<{ document_id: string; track_id: string; message: string }> {
+  return api.post<{ document_id: string; track_id: string; message: string }>(
+    `/documents/${documentId}/enrich`,
+    {},
+  );
+}
+
+/**
  * Scan input directory for new documents.
  * Triggers background scanning and processing of new files.
  * @param path Optional path to scan (defaults to configured input directory)
@@ -1944,6 +1957,7 @@ export const edgequakeApi = {
   deleteDocument,
   deleteAllDocuments,
   reprocessDocument,
+  enrichDocument,
   scanDocuments,
   reprocessFailedDocuments,
   retryFailedChunks,

--- a/edgequake_webui/src/types/index.ts
+++ b/edgequake_webui/src/types/index.ts
@@ -174,6 +174,25 @@ export interface Document {
    * @implements SPEC-002
    */
   pdf_id?: string;
+
+  // ========================================================================
+  // Metadata Enrichment Fields (PDF Metadata Enrichment Pipeline)
+  // ========================================================================
+
+  /** Enrichment pipeline status. */
+  enrichment_status?: "pending" | "processing" | "completed" | "failed" | "skipped";
+  /** Short topic phrase extracted from first 5 pages. */
+  enrichment_topic?: string;
+  /** 2-3 paragraph summary. */
+  enrichment_summary?: string;
+  /** ISO 639-1 language code detected from content. */
+  enrichment_language?: string;
+  /** Up to 10 keywords extracted from content. */
+  enrichment_keywords?: string[];
+  /** When enrichment completed. */
+  enrichment_completed_at?: string;
+  /** Error message if enrichment failed. */
+  enrichment_error?: string;
 }
 
 /** Extraction lineage information for a document. */

--- a/edgequake_webui/src/types/index.ts
+++ b/edgequake_webui/src/types/index.ts
@@ -183,6 +183,8 @@ export interface Document {
   enrichment_status?: "pending" | "processing" | "completed" | "failed" | "skipped";
   /** Short topic phrase extracted from first 5 pages. */
   enrichment_topic?: string;
+  /** 3-6 specific subtopic tags extracted from content. */
+  enrichment_tags?: string[];
   /** 2-3 paragraph summary. */
   enrichment_summary?: string;
   /** ISO 639-1 language code detected from content. */

--- a/mcp/package-lock.json
+++ b/mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@edgequake/mcp-server",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@edgequake/mcp-server",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@edgequake/mcp-server",
+  "name": "@romysaputra/edgequake-mcp",
   "version": "0.2.0",
   "description": "MCP server for EdgeQuake Graph-RAG — use EdgeQuake as persistent agent memory",
   "type": "module",
@@ -40,11 +40,11 @@
     "knowledge-graph",
     "agent-memory"
   ],
-  "author": "EdgeQuake Team",
+  "author": "Romy Saputra Sihananda",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/raphaelmansuy/edgequake.git",
+    "url": "git+https://github.com/RomySaputraSihananda/edgequake.git",
     "directory": "mcp"
   },
   "publishConfig": {

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@romysaputra/edgequake-mcp",
+  "name": "@romysaputrasihanandaa/edgequake-mcp",
   "version": "0.2.0",
   "description": "MCP server for EdgeQuake Graph-RAG — use EdgeQuake as persistent agent memory",
   "type": "module",

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@romysaputrasihanandaa/edgequake-mcp",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "MCP server for EdgeQuake Graph-RAG — use EdgeQuake as persistent agent memory",
   "type": "module",
   "main": "./dist/index.js",

--- a/mcp/src/tools/query.ts
+++ b/mcp/src/tools/query.ts
@@ -36,10 +36,15 @@ export function registerQueryTools(server: McpServer): void {
         .optional()
         .describe("Prior conversation messages for multi-turn context"),
       topic: z
-        .string()
+        .enum([
+          "Politics", "Indonesia", "Psychology", "Business", "Communication",
+          "Technology", "Science", "SocialMedia", "Religion", "Media",
+          "AI", "Culinary", "Finance", "Literature", "Law",
+          "Sports", "Education", "History", "Uncategorized",
+        ])
         .optional()
         .describe(
-          "Filter query to documents with this enrichment topic (case-insensitive exact match). Example: 'Technology', 'Finance', 'Law'. Use this to scope questions to a specific subject area.",
+          "Filter query to documents with this enrichment topic. Must be one of the allowed values: Politics, Indonesia, Psychology, Business, Communication, Technology, Science, SocialMedia, Religion, Media, AI, Culinary, Finance, Literature, Law, Sports, Education, History, Uncategorized.",
         ),
       tags: z
         .array(z.string())

--- a/mcp/src/tools/query.ts
+++ b/mcp/src/tools/query.ts
@@ -56,6 +56,7 @@ export function registerQueryTools(server: McpServer): void {
     async (params) => {
       try {
         const client = await getClient();
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const result = await client.query.execute({
           query: params.query,
           mode: params.mode,
@@ -64,7 +65,7 @@ export function registerQueryTools(server: McpServer): void {
           conversation_history: params.conversation_history,
           topic: params.topic,
           tags: params.tags,
-        });
+        } as any);
 
         return {
           content: [

--- a/mcp/src/tools/query.ts
+++ b/mcp/src/tools/query.ts
@@ -35,6 +35,18 @@ export function registerQueryTools(server: McpServer): void {
         )
         .optional()
         .describe("Prior conversation messages for multi-turn context"),
+      topic: z
+        .string()
+        .optional()
+        .describe(
+          "Filter query to documents with this enrichment topic (case-insensitive exact match). Example: 'Technology', 'Finance', 'Law'. Use this to scope questions to a specific subject area.",
+        ),
+      tags: z
+        .array(z.string())
+        .optional()
+        .describe(
+          "Filter query to documents containing ANY of these enrichment tags (case-insensitive). Example: ['Machine Learning', 'Python']. Use to narrow results to specific subtopics.",
+        ),
     },
     async (params) => {
       try {
@@ -45,6 +57,8 @@ export function registerQueryTools(server: McpServer): void {
           max_results: params.max_results,
           include_references: params.include_references ?? true,
           conversation_history: params.conversation_history,
+          topic: params.topic,
+          tags: params.tags,
         });
 
         return {

--- a/mcp/src/tools/query.ts
+++ b/mcp/src/tools/query.ts
@@ -46,12 +46,6 @@ export function registerQueryTools(server: McpServer): void {
         .describe(
           "Filter query to documents with this enrichment topic. Must be one of the allowed values: Politics, Indonesia, Psychology, Business, Communication, Technology, Science, SocialMedia, Religion, Media, AI, Culinary, Finance, Literature, Law, Sports, Education, History, Uncategorized.",
         ),
-      tags: z
-        .array(z.string())
-        .optional()
-        .describe(
-          "Filter query to documents containing ANY of these enrichment tags (case-insensitive). Example: ['Machine Learning', 'Python']. Use to narrow results to specific subtopics.",
-        ),
     },
     async (params) => {
       try {
@@ -64,7 +58,6 @@ export function registerQueryTools(server: McpServer): void {
           include_references: params.include_references ?? true,
           conversation_history: params.conversation_history,
           topic: params.topic,
-          tags: params.tags,
         } as any);
 
         return {

--- a/sdks/typescript/src/types/query.ts
+++ b/sdks/typescript/src/types/query.ts
@@ -37,8 +37,6 @@ export interface QueryRequest {
   system_prompt?: string;
   /** Filter to documents with this enrichment topic. Must be one of the allowed EnrichmentTopic values. */
   topic?: EnrichmentTopic;
-  /** Filter to documents containing ANY of these enrichment tags (case-insensitive). Example: ["Machine Learning", "Python"]. */
-  tags?: string[];
 }
 
 export interface StreamQueryRequest {
@@ -48,8 +46,6 @@ export interface StreamQueryRequest {
   system_prompt?: string;
   /** Filter to documents with this enrichment topic. Must be one of the allowed EnrichmentTopic values. */
   topic?: EnrichmentTopic;
-  /** Filter to documents containing ANY of these enrichment tags (case-insensitive). Example: ["Machine Learning", "Python"]. */
-  tags?: string[];
 }
 
 // ── Shared Response Types ─────────────────────────────────────

--- a/sdks/typescript/src/types/query.ts
+++ b/sdks/typescript/src/types/query.ts
@@ -29,6 +29,10 @@ export interface QueryRequest {
   llm_model?: string;
   /** Optional system prompt to prepend to the LLM context (SPEC-004). */
   system_prompt?: string;
+  /** Filter to documents with this enrichment topic (case-insensitive). Example: "Technology", "Finance". */
+  topic?: string;
+  /** Filter to documents containing ANY of these enrichment tags (case-insensitive). Example: ["Machine Learning", "Python"]. */
+  tags?: string[];
 }
 
 export interface StreamQueryRequest {
@@ -36,6 +40,10 @@ export interface StreamQueryRequest {
   mode?: "naive" | "local" | "global" | "hybrid" | "mix";
   /** Optional system prompt to prepend to the LLM context (SPEC-004). */
   system_prompt?: string;
+  /** Filter to documents with this enrichment topic (case-insensitive). Example: "Technology", "Finance". */
+  topic?: string;
+  /** Filter to documents containing ANY of these enrichment tags (case-insensitive). Example: ["Machine Learning", "Python"]. */
+  tags?: string[];
 }
 
 // ── Shared Response Types ─────────────────────────────────────

--- a/sdks/typescript/src/types/query.ts
+++ b/sdks/typescript/src/types/query.ts
@@ -12,6 +12,12 @@ export interface ConversationMessage {
   content: string;
 }
 
+export type EnrichmentTopic =
+  | "Politics" | "Indonesia" | "Psychology" | "Business" | "Communication"
+  | "Technology" | "Science" | "SocialMedia" | "Religion" | "Media"
+  | "AI" | "Culinary" | "Finance" | "Literature" | "Law"
+  | "Sports" | "Education" | "History" | "Uncategorized";
+
 export interface QueryRequest {
   query: string;
   mode?: "naive" | "local" | "global" | "hybrid" | "mix";
@@ -29,8 +35,8 @@ export interface QueryRequest {
   llm_model?: string;
   /** Optional system prompt to prepend to the LLM context (SPEC-004). */
   system_prompt?: string;
-  /** Filter to documents with this enrichment topic (case-insensitive). Example: "Technology", "Finance". */
-  topic?: string;
+  /** Filter to documents with this enrichment topic. Must be one of the allowed EnrichmentTopic values. */
+  topic?: EnrichmentTopic;
   /** Filter to documents containing ANY of these enrichment tags (case-insensitive). Example: ["Machine Learning", "Python"]. */
   tags?: string[];
 }
@@ -40,8 +46,8 @@ export interface StreamQueryRequest {
   mode?: "naive" | "local" | "global" | "hybrid" | "mix";
   /** Optional system prompt to prepend to the LLM context (SPEC-004). */
   system_prompt?: string;
-  /** Filter to documents with this enrichment topic (case-insensitive). Example: "Technology", "Finance". */
-  topic?: string;
+  /** Filter to documents with this enrichment topic. Must be one of the allowed EnrichmentTopic values. */
+  topic?: EnrichmentTopic;
   /** Filter to documents containing ANY of these enrichment tags (case-insensitive). Example: ["Machine Learning", "Python"]. */
   tags?: string[];
 }


### PR DESCRIPTION
Queries always fell through to the system default model (e.g. gpt-5-mini)
even when the workspace had llm_provider and llm_model configured in the
database. llm_override was only created from the request body, skipping
the workspace-level config entirely.

Add workspace LLM as second priority in the override chain:
  1. request body llm_provider + llm_model  (highest)
  2. workspace.llm_provider + workspace.llm_model  ← new
  3. system default  (fallback)