### PR TITLE
release: v0.12.9 — audit enum + Docker Ollama host fix

### DIFF
--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -8,7 +8,7 @@ on:
       tag_name:
         description: 'Tag name to publish (e.g. v0.10.7)'
         required: true
-        default: 'v0.12.8'
+        default: 'v0.12.9'
 
 permissions:
   contents: read

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+## [0.12.9] — 2026-06-08
+
+### Fixed
+
+- **FIX-AUDIT-ENUM** — Audit logger inserts PascalCase enum labels (`DocumentUpload`, `WorkspaceAccess`, …) matching Postgres `audit_event_type` / `audit_result` / `audit_severity`. Lowercase writes (`documentupload`) caused silent insert failures.
+- **FIX-DOCKER-OLLAMA** — At startup inside Docker, `normalize_local_provider_hosts_for_docker()` rewrites loopback `OLLAMA_HOST` / `OLLAMA_EMBEDDING_HOST` / `LMSTUDIO_HOST` (`localhost`, `127.x.x.x`) to `host.docker.internal` and sets a Docker-safe default when unset. Fixes workspace-scoped Ollama pipelines hitting `http://localhost:11434` inside the API container (SPEC-020 tests 10, 19, 22 on GHCR images).
+
+### Operations
+
+- **CD:** Tag `v0.12.9` → `release-docker.yml` preflight gates → GHCR multi-arch images + GitHub Release.
+
+---
+
 ## [0.12.8] — 2026-06-08
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@
 > **High-Performance Graph-RAG Framework in Rust**  
 > Transform documents into intelligent knowledge graphs for superior retrieval and generation
 
-[![Version](https://img.shields.io/badge/version-0.12.8-blue.svg?style=flat)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.12.9-blue.svg?style=flat)](CHANGELOG.md)
 [![Rust](https://img.shields.io/badge/rust-1.95+-orange.svg?style=flat&logo=rust)](https://www.rust-lang.org)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg?style=flat)](LICENSE)
 [![Build Status](https://img.shields.io/badge/build-passing-brightgreen.svg?style=flat)](https://github.com/raphaelmansuy/edgequake)
 [![Documentation](https://img.shields.io/badge/docs-available-blue.svg?style=flat)](docs/README.md)
 
-> **v0.12.8** — SPEC-020 full E2E quality control (24 tests), migration-038 auto-repair, graph scope + delete cascade fixes, dev proxy hardening. SPEC-018 observability proofs in release CI. See [CHANGELOG](CHANGELOG.md).
+> **v0.12.9** — Docker Ollama workspace fix (loopback → host.docker.internal), audit enum PascalCase fix. See [CHANGELOG](CHANGELOG.md).
 
 ## Release & CD Cycle
 
@@ -40,8 +40,8 @@ cd .. && make backend-bg frontend-bg && make spec013-proof-ui
 
 ```bash
 # Example
-git tag v0.12.8
-git push origin v0.12.8
+git tag v0.12.9
+git push origin v0.12.9
 ```
 
 This triggers `.github/workflows/release-docker.yml`, which:
@@ -51,10 +51,10 @@ This triggers `.github/workflows/release-docker.yml`, which:
 ### 4) Post-publish verification
 
 ```bash
-gh release view v0.12.8
-docker buildx imagetools inspect ghcr.io/raphaelmansuy/edgequake:0.12.8
-docker buildx imagetools inspect ghcr.io/raphaelmansuy/edgequake-frontend:0.12.8
-docker buildx imagetools inspect ghcr.io/raphaelmansuy/edgequake-postgres:0.12.8
+gh release view v0.12.9
+docker buildx imagetools inspect ghcr.io/raphaelmansuy/edgequake:0.12.9
+docker buildx imagetools inspect ghcr.io/raphaelmansuy/edgequake-frontend:0.12.9
+docker buildx imagetools inspect ghcr.io/raphaelmansuy/edgequake-postgres:0.12.9
 ```
 
 ---

--- a/edgequake/Cargo.lock
+++ b/edgequake/Cargo.lock
@@ -1649,7 +1649,7 @@ dependencies = [
 
 [[package]]
 name = "edgequake"
-version = "0.12.8"
+version = "0.12.9"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1673,7 +1673,7 @@ dependencies = [
 
 [[package]]
 name = "edgequake-api"
-version = "0.12.8"
+version = "0.12.9"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1739,7 +1739,7 @@ dependencies = [
 
 [[package]]
 name = "edgequake-auth"
-version = "0.12.8"
+version = "0.12.9"
 dependencies = [
  "argon2",
  "async-trait",
@@ -1757,7 +1757,7 @@ dependencies = [
 
 [[package]]
 name = "edgequake-core"
-version = "0.12.8"
+version = "0.12.9"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1821,7 +1821,7 @@ dependencies = [
 
 [[package]]
 name = "edgequake-observability"
-version = "0.12.8"
+version = "0.12.9"
 dependencies = [
  "http 1.4.0",
  "metrics",
@@ -1839,7 +1839,7 @@ dependencies = [
 
 [[package]]
 name = "edgequake-pdf"
-version = "0.12.8"
+version = "0.12.9"
 dependencies = [
  "async-trait",
  "edgeparse-core",
@@ -1883,7 +1883,7 @@ dependencies = [
 
 [[package]]
 name = "edgequake-pipeline"
-version = "0.12.8"
+version = "0.12.9"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1904,7 +1904,7 @@ dependencies = [
 
 [[package]]
 name = "edgequake-query"
-version = "0.12.8"
+version = "0.12.9"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1945,7 +1945,7 @@ dependencies = [
 
 [[package]]
 name = "edgequake-storage"
-version = "0.12.8"
+version = "0.12.9"
 dependencies = [
  "async-trait",
  "chrono",

--- a/edgequake/Cargo.toml
+++ b/edgequake/Cargo.toml
@@ -71,7 +71,7 @@ criterion = { workspace = true }
 tokio-test = { workspace = true }
 
 [workspace.package]
-version = "0.12.8"
+version = "0.12.9"
 edition = "2021"
 rust-version = "1.95"
 license = "Apache-2.0"

--- a/edgequake/crates/edgequake-api/src/state/memory.rs
+++ b/edgequake/crates/edgequake-api/src/state/memory.rs
@@ -137,6 +137,7 @@ impl AppState {
 
         // FIX #166: Recognize EDGEQUAKE_CHAT_* as aliases for the standard LLM env vars.
         super::provider_setup::apply_chat_env_aliases();
+        super::provider_setup::normalize_local_provider_hosts_for_docker();
 
         // Use ProviderFactory for auto-detection
         let (llm_provider, embedding_provider) =

--- a/edgequake/crates/edgequake-api/src/state/postgres.rs
+++ b/edgequake/crates/edgequake-api/src/state/postgres.rs
@@ -97,6 +97,7 @@ impl AppState {
 
         // FIX #166: Recognize EDGEQUAKE_CHAT_* as aliases for the standard LLM env vars.
         super::provider_setup::apply_chat_env_aliases();
+        super::provider_setup::normalize_local_provider_hosts_for_docker();
 
         // Create providers via factory (auto-detects from environment)
         let (llm_provider, embedding_provider) =

--- a/edgequake/crates/edgequake-api/src/state/provider_setup.rs
+++ b/edgequake/crates/edgequake-api/src/state/provider_setup.rs
@@ -276,9 +276,7 @@ pub fn apply_chat_env_aliases() {
 fn is_running_in_docker() -> bool {
     std::path::Path::new("/.dockerenv").exists()
         || std::env::var("EDGEQUAKE_IN_DOCKER").is_ok_and(|value| {
-            !value.trim().is_empty()
-                && value != "0"
-                && !value.eq_ignore_ascii_case("false")
+            !value.trim().is_empty() && value != "0" && !value.eq_ignore_ascii_case("false")
         })
 }
 
@@ -295,8 +293,7 @@ fn rewrite_loopback_host_for_docker(raw: &str) -> Option<String> {
 
     let mut parsed = url::Url::parse(trimmed).ok()?;
     let host = parsed.host_str()?;
-    let is_loopback =
-        host.eq_ignore_ascii_case("localhost") || host.starts_with("127.");
+    let is_loopback = host.eq_ignore_ascii_case("localhost") || host.starts_with("127.");
     if !is_loopback {
         return None;
     }

--- a/edgequake/crates/edgequake-api/src/state/provider_setup.rs
+++ b/edgequake/crates/edgequake-api/src/state/provider_setup.rs
@@ -272,6 +272,99 @@ pub fn apply_chat_env_aliases() {
     }
 }
 
+/// Returns true when the process runs inside a Docker container.
+fn is_running_in_docker() -> bool {
+    std::path::Path::new("/.dockerenv").exists()
+        || std::env::var("EDGEQUAKE_IN_DOCKER").is_ok_and(|value| {
+            !value.trim().is_empty()
+                && value != "0"
+                && !value.eq_ignore_ascii_case("false")
+        })
+}
+
+/// Rewrite loopback hostnames in a provider URL to `host.docker.internal`.
+///
+/// WHY: `localhost` / `127.x.x.x` inside a container refers to the container itself,
+/// not the host where Ollama/LM Studio runs. Workspace-scoped providers use the same
+/// `OLLAMA_HOST` env var as the server default (`ProviderFactory::create_llm_provider`).
+fn rewrite_loopback_host_for_docker(raw: &str) -> Option<String> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    let mut parsed = url::Url::parse(trimmed).ok()?;
+    let host = parsed.host_str()?;
+    let is_loopback =
+        host.eq_ignore_ascii_case("localhost") || host.starts_with("127.");
+    if !is_loopback {
+        return None;
+    }
+
+    parsed.set_host(Some("host.docker.internal")).ok()?;
+    Some(parsed.to_string())
+}
+
+/// Normalize local LLM provider host env vars for Docker networking.
+///
+/// Must run BEFORE `ProviderFactory::from_env()` and any workspace provider creation
+/// so every Ollama/LM Studio client (server default + per-workspace pipeline) shares
+/// the same host resolution semantics.
+pub fn normalize_local_provider_hosts_for_docker() {
+    if !is_running_in_docker() {
+        return;
+    }
+
+    const OLLAMA_DEFAULT: &str = "http://localhost:11434";
+    const LMSTUDIO_DEFAULT: &str = "http://localhost:1234";
+    const DOCKER_OLLAMA: &str = "http://host.docker.internal:11434";
+    const DOCKER_LMSTUDIO: &str = "http://host.docker.internal:1234";
+
+    let ollama_raw = std::env::var("OLLAMA_HOST").unwrap_or_else(|_| OLLAMA_DEFAULT.to_string());
+    if let Some(rewritten) = rewrite_loopback_host_for_docker(&ollama_raw) {
+        tracing::info!(
+            env_var = "OLLAMA_HOST",
+            from = %ollama_raw,
+            to = %rewritten,
+            "Rewrote loopback Ollama host for Docker"
+        );
+        std::env::set_var("OLLAMA_HOST", &rewritten);
+    } else if std::env::var("OLLAMA_HOST").is_err() {
+        tracing::info!(
+            env_var = "OLLAMA_HOST",
+            to = DOCKER_OLLAMA,
+            "Set default Ollama host for Docker (factory fallback is container localhost)"
+        );
+        std::env::set_var("OLLAMA_HOST", DOCKER_OLLAMA);
+    }
+
+    if let Ok(raw) = std::env::var("OLLAMA_EMBEDDING_HOST") {
+        if let Some(rewritten) = rewrite_loopback_host_for_docker(&raw) {
+            tracing::info!(
+                env_var = "OLLAMA_EMBEDDING_HOST",
+                from = %raw,
+                to = %rewritten,
+                "Rewrote loopback Ollama embedding host for Docker"
+            );
+            std::env::set_var("OLLAMA_EMBEDDING_HOST", rewritten);
+        }
+    }
+
+    let lmstudio_raw =
+        std::env::var("LMSTUDIO_HOST").unwrap_or_else(|_| LMSTUDIO_DEFAULT.to_string());
+    if let Some(rewritten) = rewrite_loopback_host_for_docker(&lmstudio_raw) {
+        tracing::info!(
+            env_var = "LMSTUDIO_HOST",
+            from = %lmstudio_raw,
+            to = %rewritten,
+            "Rewrote loopback LM Studio host for Docker"
+        );
+        std::env::set_var("LMSTUDIO_HOST", &rewritten);
+    } else if std::env::var("LMSTUDIO_HOST").is_err() {
+        std::env::set_var("LMSTUDIO_HOST", DOCKER_LMSTUDIO);
+    }
+}
+
 /// Resolve the embedding model name for a named provider.
 ///
 /// # Priority (First Principle: most-specific wins)
@@ -624,5 +717,25 @@ mod tests {
             "Env override must win over well-known table"
         );
         std::env::remove_var("EDGEQUAKE_EMBEDDING_DIMENSION");
+    }
+
+    #[test]
+    fn rewrite_loopback_host_for_docker_localhost() {
+        let rewritten =
+            rewrite_loopback_host_for_docker("http://localhost:11434").expect("rewritten");
+        assert_eq!(rewritten, "http://host.docker.internal:11434/");
+    }
+
+    #[test]
+    fn rewrite_loopback_host_for_docker_127() {
+        let rewritten =
+            rewrite_loopback_host_for_docker("http://127.0.0.1:1234").expect("rewritten");
+        assert_eq!(rewritten, "http://host.docker.internal:1234/");
+    }
+
+    #[test]
+    fn rewrite_loopback_host_for_docker_remote_unchanged() {
+        assert!(rewrite_loopback_host_for_docker("http://my-gpu:11434").is_none());
+        assert!(rewrite_loopback_host_for_docker("http://host.docker.internal:11434").is_none());
     }
 }

--- a/edgequake/crates/edgequake-audit/src/logger.rs
+++ b/edgequake/crates/edgequake-audit/src/logger.rs
@@ -76,11 +76,16 @@ async fn audit_worker(pool: Pool<Postgres>, mut receiver: mpsc::UnboundedReceive
     );
 }
 
+/// PostgreSQL `audit_*` enums use PascalCase labels (see migrations/001_init_database.sql).
+fn audit_enum_label<T: std::fmt::Debug>(value: &T) -> String {
+    format!("{value:?}")
+}
+
 /// Write a single audit event to the database
 async fn write_audit_event(pool: &Pool<Postgres>, event: &AuditEvent) -> Result<()> {
-    let event_type = format!("{:?}", event.event_type).to_lowercase();
-    let result = format!("{:?}", event.result).to_lowercase();
-    let severity = format!("{:?}", event.severity).to_lowercase();
+    let event_type = audit_enum_label(&event.event_type);
+    let result = audit_enum_label(&event.result);
+    let severity = audit_enum_label(&event.severity);
 
     sqlx::query(
         r#"
@@ -337,5 +342,25 @@ mod tests {
         let query = AuditQuery::default();
         assert_eq!(query.limit, 100);
         assert!(query.tenant_id.is_none());
+    }
+
+    #[test]
+    fn audit_enum_labels_match_postgres_pascal_case() {
+        use crate::event::{AuditEventType, AuditResult, AuditSeverity};
+
+        assert_eq!(
+            audit_enum_label(&AuditEventType::DocumentUpload),
+            "DocumentUpload"
+        );
+        assert_eq!(
+            audit_enum_label(&AuditEventType::WorkspaceAccess),
+            "WorkspaceAccess"
+        );
+        assert_eq!(
+            audit_enum_label(&AuditEventType::Authorization),
+            "Authorization"
+        );
+        assert_eq!(audit_enum_label(&AuditResult::Success), "Success");
+        assert_eq!(audit_enum_label(&AuditSeverity::Critical), "Critical");
     }
 }


### PR DESCRIPTION
## Summary

- **FIX-AUDIT-ENUM** — Audit logger writes PascalCase labels (`DocumentUpload`, …) matching Postgres enums; lowercase inserts were failing silently.
- **FIX-DOCKER-OLLAMA** — `normalize_local_provider_hosts_for_docker()` rewrites loopback `OLLAMA_HOST` / `OLLAMA_EMBEDDING_HOST` / `LMSTUDIO_HOST` to `host.docker.internal` at startup so workspace-scoped Ollama pipelines work inside Docker (SPEC-020 tests 10, 19, 22).
- Version bump to **0.12.9** + CHANGELOG.

## Test plan

- [x] `cargo test -p edgequake-audit -p edgequake-api --lib`
- [ ] `make release-gates` (CI)
- [ ] Merge → tag `v0.12.9` → verify CD
- [ ] Docker Playwright SPEC-020 with Ollama workspaces (target 24/24)


Made with [Cursor](https://cursor.com)