### PR TITLE
release: v0.12.10 — Ollama sync upload timeout

### DIFF
--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -8,7 +8,7 @@ on:
       tag_name:
         description: 'Tag name to publish (e.g. v0.10.7)'
         required: true
-        default: 'v0.12.9'
+        default: 'v0.12.10'
 
 permissions:
   contents: read

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+## [0.12.10] — 2026-06-08
+
+### Fixed
+
+- **FIX-SYNC-OLLAMA-TIMEOUT** — Synchronous markdown upload uses provider-aware HTTP timeout: 600s for Ollama/LM Studio workspaces (was 120s → 408 in Docker E2E), 120s for cloud/mock. Override via `EDGEQUAKE_SYNC_PROCESSING_TIMEOUT_SECS`. SPEC-020 Playwright client timeout aligned for Ollama workspaces.
+
+### Operations
+
+- **CD:** Tag `v0.12.10` → GHCR multi-arch images + GitHub Release.
+
+---
+
 ## [0.12.9] — 2026-06-08
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@
 > **High-Performance Graph-RAG Framework in Rust**  
 > Transform documents into intelligent knowledge graphs for superior retrieval and generation
 
-[![Version](https://img.shields.io/badge/version-0.12.9-blue.svg?style=flat)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.12.10-blue.svg?style=flat)](CHANGELOG.md)
 [![Rust](https://img.shields.io/badge/rust-1.95+-orange.svg?style=flat&logo=rust)](https://www.rust-lang.org)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg?style=flat)](LICENSE)
 [![Build Status](https://img.shields.io/badge/build-passing-brightgreen.svg?style=flat)](https://github.com/raphaelmansuy/edgequake)
 [![Documentation](https://img.shields.io/badge/docs-available-blue.svg?style=flat)](docs/README.md)
 
-> **v0.12.9** — Docker Ollama workspace fix (loopback → host.docker.internal), audit enum PascalCase fix. See [CHANGELOG](CHANGELOG.md).
+> **v0.12.10** — Ollama sync upload timeout (600s), Docker networking + audit enum fixes. See [CHANGELOG](CHANGELOG.md).
 
 ## Release & CD Cycle
 
@@ -40,8 +40,8 @@ cd .. && make backend-bg frontend-bg && make spec013-proof-ui
 
 ```bash
 # Example
-git tag v0.12.9
-git push origin v0.12.9
+git tag v0.12.10
+git push origin v0.12.10
 ```
 
 This triggers `.github/workflows/release-docker.yml`, which:
@@ -51,10 +51,10 @@ This triggers `.github/workflows/release-docker.yml`, which:
 ### 4) Post-publish verification
 
 ```bash
-gh release view v0.12.9
-docker buildx imagetools inspect ghcr.io/raphaelmansuy/edgequake:0.12.9
-docker buildx imagetools inspect ghcr.io/raphaelmansuy/edgequake-frontend:0.12.9
-docker buildx imagetools inspect ghcr.io/raphaelmansuy/edgequake-postgres:0.12.9
+gh release view v0.12.10
+docker buildx imagetools inspect ghcr.io/raphaelmansuy/edgequake:0.12.10
+docker buildx imagetools inspect ghcr.io/raphaelmansuy/edgequake-frontend:0.12.10
+docker buildx imagetools inspect ghcr.io/raphaelmansuy/edgequake-postgres:0.12.10
 ```
 
 ---

--- a/edgequake/Cargo.lock
+++ b/edgequake/Cargo.lock
@@ -1649,7 +1649,7 @@ dependencies = [
 
 [[package]]
 name = "edgequake"
-version = "0.12.9"
+version = "0.12.10"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1673,7 +1673,7 @@ dependencies = [
 
 [[package]]
 name = "edgequake-api"
-version = "0.12.9"
+version = "0.12.10"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1739,7 +1739,7 @@ dependencies = [
 
 [[package]]
 name = "edgequake-auth"
-version = "0.12.9"
+version = "0.12.10"
 dependencies = [
  "argon2",
  "async-trait",
@@ -1757,7 +1757,7 @@ dependencies = [
 
 [[package]]
 name = "edgequake-core"
-version = "0.12.9"
+version = "0.12.10"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1821,7 +1821,7 @@ dependencies = [
 
 [[package]]
 name = "edgequake-observability"
-version = "0.12.9"
+version = "0.12.10"
 dependencies = [
  "http 1.4.0",
  "metrics",
@@ -1839,7 +1839,7 @@ dependencies = [
 
 [[package]]
 name = "edgequake-pdf"
-version = "0.12.9"
+version = "0.12.10"
 dependencies = [
  "async-trait",
  "edgeparse-core",
@@ -1883,7 +1883,7 @@ dependencies = [
 
 [[package]]
 name = "edgequake-pipeline"
-version = "0.12.9"
+version = "0.12.10"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1904,7 +1904,7 @@ dependencies = [
 
 [[package]]
 name = "edgequake-query"
-version = "0.12.9"
+version = "0.12.10"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1945,7 +1945,7 @@ dependencies = [
 
 [[package]]
 name = "edgequake-storage"
-version = "0.12.9"
+version = "0.12.10"
 dependencies = [
  "async-trait",
  "chrono",

--- a/edgequake/Cargo.toml
+++ b/edgequake/Cargo.toml
@@ -71,7 +71,7 @@ criterion = { workspace = true }
 tokio-test = { workspace = true }
 
 [workspace.package]
-version = "0.12.9"
+version = "0.12.10"
 edition = "2021"
 rust-version = "1.95"
 license = "Apache-2.0"

--- a/edgequake/crates/edgequake-api/src/handlers/documents/upload/text_upload.rs
+++ b/edgequake/crates/edgequake-api/src/handlers/documents/upload/text_upload.rs
@@ -276,29 +276,25 @@ pub async fn upload_document(
             .create_workspace_pipeline(&workspace_id_for_storage)
             .await;
 
-        // OODA-01: Add HTTP-level timeout to prevent indefinite hangs
-        // WHY: Large documents (100KB+) can take 5-10 minutes to process,
-        // but HTTP clients expect responses within 60-120 seconds.
-        // Without this timeout, requests hang indefinitely causing poor UX.
-        //
-        // Timeout Strategy:
-        // - 120 seconds (2 minutes): Conservative limit for synchronous mode
-        // - For larger documents, users should use async_processing: true
-        // - Timeout applies to ENTIRE pipeline, not just individual LLM calls
-        //
-        // See: specs/002-bullet-proof-ingestion-process.md
-        const SYNC_PROCESSING_TIMEOUT_SECS: u64 = 120;
+        let sync_llm_provider =
+            resolve_workspace_llm_provider_name(&state, &workspace_id_for_storage).await;
+        let sync_processing_timeout_secs =
+            crate::safety_limits::sync_processing_timeout_secs(&sync_llm_provider);
 
+        // OODA-01: Add HTTP-level timeout to prevent indefinite hangs.
+        // Provider-aware: Ollama/LM Studio get 600 s (Docker→host latency); cloud/mock 120 s.
+        // Override globally via EDGEQUAKE_SYNC_PROCESSING_TIMEOUT_SECS.
         let processing_start = std::time::Instant::now();
         debug!(
             document_id = %document_id,
             content_length = request.content.len(),
-            timeout_secs = SYNC_PROCESSING_TIMEOUT_SECS,
+            llm_provider = %sync_llm_provider,
+            timeout_secs = sync_processing_timeout_secs,
             "Starting synchronous document processing"
         );
 
         let result = tokio::time::timeout(
-            std::time::Duration::from_secs(SYNC_PROCESSING_TIMEOUT_SECS),
+            std::time::Duration::from_secs(sync_processing_timeout_secs),
             // SPEC-003: Use resilient processing with chunk-level error isolation
             // WHY: Map-reduce pattern continues processing even if some chunks fail
             workspace_pipeline.process_with_resilience(&document_id, &request.content, None),
@@ -308,16 +304,18 @@ pub async fn upload_document(
             let processing_time = processing_start.elapsed();
             warn!(
                 document_id = %document_id,
-                timeout_secs = SYNC_PROCESSING_TIMEOUT_SECS,
+                llm_provider = %sync_llm_provider,
+                timeout_secs = sync_processing_timeout_secs,
                 processing_time_secs = processing_time.as_secs(),
                 content_length = request.content.len(),
                 "Document processing timeout - consider using async mode for large documents"
             );
             ApiError::Timeout(format!(
-                "Document processing exceeded {} seconds. For large documents (>50KB), \
+                "Document processing exceeded {} seconds (provider: {}). For large documents (>50KB), \
                  use async_processing: true to avoid timeouts. \
                  Current document size: {} bytes",
-                SYNC_PROCESSING_TIMEOUT_SECS,
+                sync_processing_timeout_secs,
+                sync_llm_provider,
                 request.content.len()
             ))
         })??;
@@ -755,4 +753,14 @@ pub async fn upload_document(
             }),
         ))
     }
+}
+
+/// Resolve workspace LLM provider for sync-upload timeout selection.
+async fn resolve_workspace_llm_provider_name(state: &AppState, workspace_id: &str) -> String {
+    if let Some(workspace_uuid) = crate::middleware::resolve_workspace_uuid(Some(workspace_id)) {
+        if let Ok(Some(ws)) = state.workspace_service.get_workspace(workspace_uuid).await {
+            return ws.llm_provider;
+        }
+    }
+    state.query.llm_provider.name().to_string()
 }

--- a/edgequake/crates/edgequake-api/src/safety_limits.rs
+++ b/edgequake/crates/edgequake-api/src/safety_limits.rs
@@ -601,6 +601,41 @@ pub fn vision_outer_timeout_secs(provider_name: &str, page_count: usize) -> u64 
     computed.min(VISION_MAX_OUTER_TIMEOUT_SECS)
 }
 
+/// Default HTTP timeout for synchronous markdown/text upload processing (cloud/mock).
+pub const DEFAULT_SYNC_PROCESSING_TIMEOUT_SECS: u64 = 120;
+
+/// HTTP timeout for synchronous upload when workspace uses Ollama or LM Studio.
+///
+/// WHY: Local LLM extraction + embedding commonly exceeds 120 s (especially
+/// Docker → host Ollama). SPEC-020 Ollama proofs hit 408 at 120 s on v0.12.9.
+pub const LOCAL_SYNC_PROCESSING_TIMEOUT_SECS: u64 = 600;
+
+/// Returns `true` for local inference servers that need longer sync upload windows.
+pub fn is_slow_local_provider(provider_name: &str) -> bool {
+    matches!(
+        provider_name.to_ascii_lowercase().as_str(),
+        "ollama" | "lmstudio" | "lm-studio" | "lm_studio"
+    )
+}
+
+/// HTTP-level timeout for synchronous document upload (`async_processing: false`).
+///
+/// Reads `EDGEQUAKE_SYNC_PROCESSING_TIMEOUT_SECS` first (global override).
+/// Falls back to [`LOCAL_SYNC_PROCESSING_TIMEOUT_SECS`] for Ollama/LM Studio,
+/// [`DEFAULT_SYNC_PROCESSING_TIMEOUT_SECS`] for cloud and mock providers.
+pub fn sync_processing_timeout_secs(provider_name: &str) -> u64 {
+    if let Ok(val) = std::env::var("EDGEQUAKE_SYNC_PROCESSING_TIMEOUT_SECS") {
+        if let Ok(n) = val.parse::<u64>() {
+            return n.max(30);
+        }
+    }
+    if is_slow_local_provider(provider_name) {
+        LOCAL_SYNC_PROCESSING_TIMEOUT_SECS
+    } else {
+        DEFAULT_SYNC_PROCESSING_TIMEOUT_SECS
+    }
+}
+
 /// Returns the per-page LLM call timeout for vision/OCR requests.
 ///
 /// Reads `EDGEQUAKE_VISION_PAGE_TIMEOUT_SECS` first; falls back to:
@@ -767,5 +802,47 @@ pub fn default_model_for_provider(provider_name: &str) -> &'static str {
         "minimax" => "MiniMax-M2.7",
         "mock" => "mock-model",
         _ => "gpt-4.1-nano",
+    }
+}
+
+#[cfg(test)]
+mod sync_timeout_tests {
+    use super::*;
+    use serial_test::serial;
+
+    #[test]
+    #[serial]
+    fn sync_timeout_ollama_uses_extended_default() {
+        std::env::remove_var("EDGEQUAKE_SYNC_PROCESSING_TIMEOUT_SECS");
+        assert_eq!(
+            sync_processing_timeout_secs("ollama"),
+            LOCAL_SYNC_PROCESSING_TIMEOUT_SECS
+        );
+        assert_eq!(
+            sync_processing_timeout_secs("LMStudio"),
+            LOCAL_SYNC_PROCESSING_TIMEOUT_SECS
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn sync_timeout_mock_uses_cloud_default() {
+        std::env::remove_var("EDGEQUAKE_SYNC_PROCESSING_TIMEOUT_SECS");
+        assert_eq!(
+            sync_processing_timeout_secs("mock"),
+            DEFAULT_SYNC_PROCESSING_TIMEOUT_SECS
+        );
+        assert_eq!(
+            sync_processing_timeout_secs("openai"),
+            DEFAULT_SYNC_PROCESSING_TIMEOUT_SECS
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn sync_timeout_env_override_wins() {
+        std::env::set_var("EDGEQUAKE_SYNC_PROCESSING_TIMEOUT_SECS", "900");
+        assert_eq!(sync_processing_timeout_secs("ollama"), 900);
+        std::env::remove_var("EDGEQUAKE_SYNC_PROCESSING_TIMEOUT_SECS");
     }
 }

--- a/edgequake_webui/e2e/helpers/qc-workspace.ts
+++ b/edgequake_webui/e2e/helpers/qc-workspace.ts
@@ -113,10 +113,12 @@ export async function syncUploadMarkdown(
   entityCount: number;
   status: string;
 }> {
+  // Ollama/LM Studio sync uploads use 600s server timeout (v0.12.10+); mock stays 120s.
+  const uploadTimeoutMs = ctx.llmProvider === "ollama" ? 660_000 : 180_000;
   const upload = await request.post(`${BACKEND_URL}/api/v1/documents`, {
     headers: tenantHeaders(ctx.tenantId, ctx.workspaceId),
     data: { title, content, async_processing: false },
-    timeout: 180_000,
+    timeout: uploadTimeoutMs,
   });
   expect([200, 201]).toContain(upload.status());
   const body = (await upload.json()) as {


### PR DESCRIPTION
## Summary

- **FIX-SYNC-OLLAMA-TIMEOUT** — Sync markdown upload HTTP timeout is provider-aware: **600s** for Ollama/LM Studio workspaces (was 120s → 408 in Docker SPEC-020), **120s** for cloud/mock. Global override: `EDGEQUAKE_SYNC_PROCESSING_TIMEOUT_SECS`.
- SPEC-020 Playwright `syncUploadMarkdown` client timeout raised to 660s for Ollama workspaces.
- Version **0.12.10** + CHANGELOG.

## Test plan

- [x] `cargo test -p edgequake-api sync_timeout --lib`
- [ ] `make release-gates` (CI)
- [ ] Merge → tag `v0.12.10` → Docker SPEC-020 (target 24/24 with Ollama)


Made with [Cursor](https://cursor.com)