### PR TITLE
fix(release): pass release gates for v0.13.0

### DIFF
--- a/edgequake/crates/edgequake-api/src/handlers/pdf_upload/helpers.rs
+++ b/edgequake/crates/edgequake-api/src/handlers/pdf_upload/helpers.rs
@@ -128,14 +128,11 @@ pub(super) async fn create_pdf_processing_task(
 
     let resolved_backend = options.resolved_backend(workspace);
     let backend_explicit = options.pdf_parser_backend.is_some()
-        || workspace
-            .and_then(|ws| ws.pdf_parser_backend)
-            .is_some()
+        || workspace.and_then(|ws| ws.pdf_parser_backend).is_some()
         || edgequake_pdf::PdfParserBackend::from_env().is_some();
 
     let page_count_usize = page_count.unwrap_or(1).max(1) as usize;
-    let profile =
-        crate::services::LargeDocumentProfile::new(page_count_usize, file_size_bytes);
+    let profile = crate::services::LargeDocumentProfile::new(page_count_usize, file_size_bytes);
     let processing_timeout_secs =
         profile.task_timeout_secs(resolved_backend, &options.resolved_vision_provider());
 

--- a/edgequake/crates/edgequake-api/src/handlers/pdf_upload/upload.rs
+++ b/edgequake/crates/edgequake-api/src/handlers/pdf_upload/upload.rs
@@ -713,10 +713,7 @@ async fn process_pdf_upload_parts(
     let ingestion_estimate = {
         let pages = page_count.unwrap_or(1).max(1) as usize;
         let profile = crate::services::LargeDocumentProfile::new(pages, file_size_bytes);
-        Some(profile.ingestion_estimate(
-            resolved_backend,
-            &options.resolved_vision_provider(),
-        ))
+        Some(profile.ingestion_estimate(resolved_backend, &options.resolved_vision_provider()))
     };
 
     let tenant_for_audit = context

--- a/edgequake/crates/edgequake-api/src/processor/pdf_processing.rs
+++ b/edgequake/crates/edgequake-api/src/processor/pdf_processing.rs
@@ -505,8 +505,10 @@ impl DocumentTaskProcessor {
         // SPEC-038: born-digital PDFs default to Vision but often have embedded text.
         // Try EdgeParse first when routing is automatic to avoid O(pages × LLM) conversion.
         let mut precomputed_markdown: Option<String> = None;
-        if crate::services::should_try_edgeparse_before_vision(backend, data.pdf_parser_backend_explicit)
-        {
+        if crate::services::should_try_edgeparse_before_vision(
+            backend,
+            data.pdf_parser_backend_explicit,
+        ) {
             if let Some(markdown) =
                 crate::services::try_edgeparse_fast_path(&pdf_data, page_count, &filename).await
             {
@@ -530,86 +532,19 @@ impl DocumentTaskProcessor {
         }
 
         let converter = if precomputed_markdown.is_some() {
-            edgequake_pdf::create_pdf_converter(
-                edgequake_pdf::PdfParserBackend::EdgeParse,
-                None,
-            )
+            edgequake_pdf::create_pdf_converter(edgequake_pdf::PdfParserBackend::EdgeParse, None)
         } else {
             match backend {
-            edgequake_pdf::PdfParserBackend::Vision => {
-                if !data.enable_vision {
-                    let error = edgequake_tasks::TaskError::UnsupportedOperation(
-                        "Vision PDF extraction requires enable_vision=true.".to_string(),
-                    );
-                    let message = build_edgeparse_fallback_message(&data.vision_provider, &error);
-                    warn!(
-                        pdf_id = %data.pdf_id,
-                        "Vision disabled for requested vision extraction; falling back to EdgeParse"
-                    );
-                    let _ = self
-                        .update_document_status(&early_doc_id, "processing", Some(&message))
-                        .await;
-                    fallback_warning = Some(message);
-                    extraction_method = ExtractionMethod::EdgeParse;
-                    vision_model = None;
-                    edgequake_pdf::create_pdf_converter(
-                        edgequake_pdf::PdfParserBackend::EdgeParse,
-                        None,
-                    )
-                } else {
-                    #[cfg(feature = "vision")]
-                    {
-                        use crate::safety_limits::create_safe_vision_provider;
-
-                        match create_safe_vision_provider(
-                            &data.vision_provider,
-                            vision_model.as_deref().unwrap_or_default(),
-                        ) {
-                            Ok(provider) => {
-                                edgequake_pdf::create_pdf_converter(backend, Some(provider))
-                            }
-                            Err(e) => {
-                                let error = edgequake_tasks::TaskError::Processing(format!(
-                                    "Failed to create vision provider '{}': {e}",
-                                    data.vision_provider
-                                ));
-                                if !vision_fallback_allowed(backend, &error) {
-                                    return Err(error);
-                                }
-                                let message =
-                                    build_edgeparse_fallback_message(&data.vision_provider, &error);
-                                warn!(
-                                    pdf_id = %data.pdf_id,
-                                    error = %error,
-                                    "Vision provider setup failed; falling back to EdgeParse"
-                                );
-                                let _ = self
-                                    .update_document_status(
-                                        &early_doc_id,
-                                        "processing",
-                                        Some(&message),
-                                    )
-                                    .await;
-                                fallback_warning = Some(message);
-                                extraction_method = ExtractionMethod::EdgeParse;
-                                vision_model = None;
-                                edgequake_pdf::create_pdf_converter(
-                                    edgequake_pdf::PdfParserBackend::EdgeParse,
-                                    None,
-                                )
-                            }
-                        }
-                    }
-                    #[cfg(not(feature = "vision"))]
-                    {
+                edgequake_pdf::PdfParserBackend::Vision => {
+                    if !data.enable_vision {
                         let error = edgequake_tasks::TaskError::UnsupportedOperation(
-                            "Vision extraction requires the 'vision' feature flag".to_string(),
+                            "Vision PDF extraction requires enable_vision=true.".to_string(),
                         );
                         let message =
                             build_edgeparse_fallback_message(&data.vision_provider, &error);
                         warn!(
                             pdf_id = %data.pdf_id,
-                            "Vision feature is unavailable; falling back to EdgeParse"
+                            "Vision disabled for requested vision extraction; falling back to EdgeParse"
                         );
                         let _ = self
                             .update_document_status(&early_doc_id, "processing", Some(&message))
@@ -621,12 +556,79 @@ impl DocumentTaskProcessor {
                             edgequake_pdf::PdfParserBackend::EdgeParse,
                             None,
                         )
+                    } else {
+                        #[cfg(feature = "vision")]
+                        {
+                            use crate::safety_limits::create_safe_vision_provider;
+
+                            match create_safe_vision_provider(
+                                &data.vision_provider,
+                                vision_model.as_deref().unwrap_or_default(),
+                            ) {
+                                Ok(provider) => {
+                                    edgequake_pdf::create_pdf_converter(backend, Some(provider))
+                                }
+                                Err(e) => {
+                                    let error = edgequake_tasks::TaskError::Processing(format!(
+                                        "Failed to create vision provider '{}': {e}",
+                                        data.vision_provider
+                                    ));
+                                    if !vision_fallback_allowed(backend, &error) {
+                                        return Err(error);
+                                    }
+                                    let message = build_edgeparse_fallback_message(
+                                        &data.vision_provider,
+                                        &error,
+                                    );
+                                    warn!(
+                                        pdf_id = %data.pdf_id,
+                                        error = %error,
+                                        "Vision provider setup failed; falling back to EdgeParse"
+                                    );
+                                    let _ = self
+                                        .update_document_status(
+                                            &early_doc_id,
+                                            "processing",
+                                            Some(&message),
+                                        )
+                                        .await;
+                                    fallback_warning = Some(message);
+                                    extraction_method = ExtractionMethod::EdgeParse;
+                                    vision_model = None;
+                                    edgequake_pdf::create_pdf_converter(
+                                        edgequake_pdf::PdfParserBackend::EdgeParse,
+                                        None,
+                                    )
+                                }
+                            }
+                        }
+                        #[cfg(not(feature = "vision"))]
+                        {
+                            let error = edgequake_tasks::TaskError::UnsupportedOperation(
+                                "Vision extraction requires the 'vision' feature flag".to_string(),
+                            );
+                            let message =
+                                build_edgeparse_fallback_message(&data.vision_provider, &error);
+                            warn!(
+                                pdf_id = %data.pdf_id,
+                                "Vision feature is unavailable; falling back to EdgeParse"
+                            );
+                            let _ = self
+                                .update_document_status(&early_doc_id, "processing", Some(&message))
+                                .await;
+                            fallback_warning = Some(message);
+                            extraction_method = ExtractionMethod::EdgeParse;
+                            vision_model = None;
+                            edgequake_pdf::create_pdf_converter(
+                                edgequake_pdf::PdfParserBackend::EdgeParse,
+                                None,
+                            )
+                        }
                     }
                 }
-            }
-            edgequake_pdf::PdfParserBackend::EdgeParse => {
-                edgequake_pdf::create_pdf_converter(backend, None)
-            }
+                edgequake_pdf::PdfParserBackend::EdgeParse => {
+                    edgequake_pdf::create_pdf_converter(backend, None)
+                }
             }
         };
 
@@ -678,147 +680,147 @@ impl DocumentTaskProcessor {
             md
         } else {
             match extraction_method {
-            ExtractionMethod::Vision => {
-                // WHY: EDGEQUAKE_VISION_TIMEOUT_SECS is kept for backwards
-                // compatibility. When not set, use the provider-aware formula:
-                //   120 + (page_count × secs_per_page_for_provider)
-                // This gives ~3 720s for 120 pages with Ollama vs the previous
-                // 660s, matching the real hardware requirement.
-                // See ADR-04-002 in mission/04-heavy-pdf.md.
-                let base_timeout_secs: u64 = std::env::var("EDGEQUAKE_VISION_TIMEOUT_SECS")
-                    .ok()
-                    .and_then(|v| v.parse().ok())
-                    .unwrap_or(0);
-                let vision_timeout_secs = if base_timeout_secs > 0 {
-                    base_timeout_secs
-                } else {
-                    use crate::safety_limits::vision_outer_timeout_secs;
-                    vision_outer_timeout_secs(&data.vision_provider, page_count)
-                };
-                let vision_timeout = std::time::Duration::from_secs(vision_timeout_secs);
+                ExtractionMethod::Vision => {
+                    // WHY: EDGEQUAKE_VISION_TIMEOUT_SECS is kept for backwards
+                    // compatibility. When not set, use the provider-aware formula:
+                    //   120 + (page_count × secs_per_page_for_provider)
+                    // This gives ~3 720s for 120 pages with Ollama vs the previous
+                    // 660s, matching the real hardware requirement.
+                    // See ADR-04-002 in mission/04-heavy-pdf.md.
+                    let base_timeout_secs: u64 = std::env::var("EDGEQUAKE_VISION_TIMEOUT_SECS")
+                        .ok()
+                        .and_then(|v| v.parse().ok())
+                        .unwrap_or(0);
+                    let vision_timeout_secs = if base_timeout_secs > 0 {
+                        base_timeout_secs
+                    } else {
+                        use crate::safety_limits::vision_outer_timeout_secs;
+                        vision_outer_timeout_secs(&data.vision_provider, page_count)
+                    };
+                    let vision_timeout = std::time::Duration::from_secs(vision_timeout_secs);
 
-                let _vision_job_permit = if let Some(semaphore) = &self.pdf_vision {
+                    let _vision_job_permit = if let Some(semaphore) = &self.pdf_vision {
+                        info!(
+                            pdf_id = %data.pdf_id,
+                            max_concurrent_jobs = semaphore.max_concurrent(),
+                            "Waiting for vision PDF admission slot"
+                        );
+                        Some(semaphore.acquire_owned().await.ok_or_else(|| {
+                            edgequake_tasks::TaskError::Processing(
+                                "Vision PDF admission semaphore closed".to_string(),
+                            )
+                        })?)
+                    } else {
+                        None
+                    };
+
                     info!(
                         pdf_id = %data.pdf_id,
-                        max_concurrent_jobs = semaphore.max_concurrent(),
-                        "Waiting for vision PDF admission slot"
+                        vision_provider = %data.vision_provider,
+                        vision_model = %vision_model.clone().unwrap_or_default(),
+                        page_count = page_count,
+                        concurrency = concurrency,
+                        dpi = dpi,
+                        timeout_secs = vision_timeout_secs,
+                        "Starting Vision PDF conversion"
                     );
-                    Some(semaphore.acquire_owned().await.ok_or_else(|| {
-                        edgequake_tasks::TaskError::Processing(
-                            "Vision PDF admission semaphore closed".to_string(),
-                        )
-                    })?)
-                } else {
-                    None
-                };
 
-                info!(
-                    pdf_id = %data.pdf_id,
-                    vision_provider = %data.vision_provider,
-                    vision_model = %vision_model.clone().unwrap_or_default(),
-                    page_count = page_count,
-                    concurrency = concurrency,
-                    dpi = dpi,
-                    timeout_secs = vision_timeout_secs,
-                    "Starting Vision PDF conversion"
-                );
+                    match tokio::time::timeout(
+                        vision_timeout,
+                        converter.convert(&pdf_data, &conversion_config),
+                    )
+                    .await
+                    {
+                        Ok(Ok(markdown)) => markdown,
+                        Ok(Err(e)) => {
+                            let error = edgequake_tasks::TaskError::Processing(format!(
+                                "PDF conversion failed: {e}"
+                            ));
+                            if !vision_fallback_allowed(backend, &error) {
+                                return Err(error);
+                            }
 
-                match tokio::time::timeout(
-                    vision_timeout,
-                    converter.convert(&pdf_data, &conversion_config),
-                )
-                .await
-                {
-                    Ok(Ok(markdown)) => markdown,
-                    Ok(Err(e)) => {
-                        let error = edgequake_tasks::TaskError::Processing(format!(
-                            "PDF conversion failed: {e}"
-                        ));
-                        if !vision_fallback_allowed(backend, &error) {
-                            return Err(error);
+                            let message =
+                                build_edgeparse_fallback_message(&data.vision_provider, &error);
+                            warn!(
+                                pdf_id = %data.pdf_id,
+                                error = %error,
+                                "Vision conversion failed; falling back to EdgeParse"
+                            );
+                            let _ = self
+                                .update_document_status(&early_doc_id, "processing", Some(&message))
+                                .await;
+                            fallback_warning = Some(message);
+                            extraction_method = ExtractionMethod::EdgeParse;
+                            vision_model = None;
+
+                            edgequake_pdf::create_pdf_converter(
+                                edgequake_pdf::PdfParserBackend::EdgeParse,
+                                None,
+                            )
+                            .convert(&pdf_data, &edgeparse_config)
+                            .await
+                            .map_err(|e| {
+                                edgequake_tasks::TaskError::Processing(format!(
+                                    "PDF conversion failed after EdgeParse fallback: {e}"
+                                ))
+                            })?
                         }
-
-                        let message =
-                            build_edgeparse_fallback_message(&data.vision_provider, &error);
-                        warn!(
-                            pdf_id = %data.pdf_id,
-                            error = %error,
-                            "Vision conversion failed; falling back to EdgeParse"
-                        );
-                        let _ = self
-                            .update_document_status(&early_doc_id, "processing", Some(&message))
-                            .await;
-                        fallback_warning = Some(message);
-                        extraction_method = ExtractionMethod::EdgeParse;
-                        vision_model = None;
-
-                        edgequake_pdf::create_pdf_converter(
-                            edgequake_pdf::PdfParserBackend::EdgeParse,
-                            None,
-                        )
-                        .convert(&pdf_data, &edgeparse_config)
-                        .await
-                        .map_err(|e| {
-                            edgequake_tasks::TaskError::Processing(format!(
-                                "PDF conversion failed after EdgeParse fallback: {e}"
-                            ))
-                        })?
-                    }
-                    Err(_elapsed) => {
-                        let error = edgequake_tasks::TaskError::Timeout(format!(
+                        Err(_elapsed) => {
+                            let error = edgequake_tasks::TaskError::Timeout(format!(
                             "Vision extraction timed out after {}s for PDF {}. Provider '{}' may be unresponsive.",
                             vision_timeout.as_secs(),
                             data.pdf_id,
                             data.vision_provider
                         ));
-                        if !vision_fallback_allowed(backend, &error) {
-                            return Err(error);
+                            if !vision_fallback_allowed(backend, &error) {
+                                return Err(error);
+                            }
+
+                            let message =
+                                build_edgeparse_fallback_message(&data.vision_provider, &error);
+                            warn!(
+                                pdf_id = %data.pdf_id,
+                                timeout_secs = vision_timeout.as_secs(),
+                                "Vision extraction timed out; falling back to EdgeParse"
+                            );
+                            let _ = self
+                                .update_document_status(&early_doc_id, "processing", Some(&message))
+                                .await;
+                            fallback_warning = Some(message);
+                            extraction_method = ExtractionMethod::EdgeParse;
+                            vision_model = None;
+
+                            edgequake_pdf::create_pdf_converter(
+                                edgequake_pdf::PdfParserBackend::EdgeParse,
+                                None,
+                            )
+                            .convert(&pdf_data, &edgeparse_config)
+                            .await
+                            .map_err(|e| {
+                                edgequake_tasks::TaskError::Processing(format!(
+                                    "PDF conversion failed after EdgeParse fallback: {e}"
+                                ))
+                            })?
                         }
-
-                        let message =
-                            build_edgeparse_fallback_message(&data.vision_provider, &error);
-                        warn!(
-                            pdf_id = %data.pdf_id,
-                            timeout_secs = vision_timeout.as_secs(),
-                            "Vision extraction timed out; falling back to EdgeParse"
-                        );
-                        let _ = self
-                            .update_document_status(&early_doc_id, "processing", Some(&message))
-                            .await;
-                        fallback_warning = Some(message);
-                        extraction_method = ExtractionMethod::EdgeParse;
-                        vision_model = None;
-
-                        edgequake_pdf::create_pdf_converter(
-                            edgequake_pdf::PdfParserBackend::EdgeParse,
-                            None,
-                        )
+                    }
+                }
+                ExtractionMethod::EdgeParse | ExtractionMethod::Text | ExtractionMethod::Hybrid => {
+                    info!(
+                        pdf_id = %data.pdf_id,
+                        page_count = page_count,
+                        "Starting EdgeParse PDF conversion"
+                    );
+                    converter
                         .convert(&pdf_data, &edgeparse_config)
                         .await
                         .map_err(|e| {
                             edgequake_tasks::TaskError::Processing(format!(
-                                "PDF conversion failed after EdgeParse fallback: {e}"
+                                "PDF conversion failed: {e}"
                             ))
                         })?
-                    }
                 }
             }
-            ExtractionMethod::EdgeParse | ExtractionMethod::Text | ExtractionMethod::Hybrid => {
-                info!(
-                    pdf_id = %data.pdf_id,
-                    page_count = page_count,
-                    "Starting EdgeParse PDF conversion"
-                );
-                converter
-                    .convert(&pdf_data, &edgeparse_config)
-                    .await
-                    .map_err(|e| {
-                        edgequake_tasks::TaskError::Processing(format!(
-                            "PDF conversion failed: {e}"
-                        ))
-                    })?
-            }
-        }
         };
 
         let markdown = strip_nul_bytes(markdown);

--- a/edgequake/crates/edgequake-api/src/services/large_document_profile.rs
+++ b/edgequake/crates/edgequake-api/src/services/large_document_profile.rs
@@ -7,7 +7,9 @@ use edgequake_pdf::PdfParserBackend;
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
-use crate::safety_limits::{is_local_provider, vision_outer_timeout_secs, VISION_MAX_OUTER_TIMEOUT_SECS};
+use crate::safety_limits::{
+    is_local_provider, vision_outer_timeout_secs, VISION_MAX_OUTER_TIMEOUT_SECS,
+};
 
 /// Page-count threshold for large-PDF admission UX and gleaning policy.
 pub const LARGE_PDF_PAGE_THRESHOLD: usize = 100;
@@ -90,7 +92,9 @@ pub fn classify_ingestion_failure(error_msg: &str) -> IngestionFailureClass {
         }
         return IngestionFailureClass::TimeoutPhaseExtract;
     }
-    if lower.contains("provider") && (lower.contains("unavailable") || lower.contains("failed to create")) {
+    if lower.contains("provider")
+        && (lower.contains("unavailable") || lower.contains("failed to create"))
+    {
         return IngestionFailureClass::ProviderUnavailable;
     }
     IngestionFailureClass::Unknown
@@ -204,9 +208,7 @@ impl LargeDocumentProfile {
         backend: PdfParserBackend,
         backend_explicit: bool,
     ) -> bool {
-        Self::auto_routing_enabled()
-            && !backend_explicit
-            && backend == PdfParserBackend::Vision
+        Self::auto_routing_enabled() && !backend_explicit && backend == PdfParserBackend::Vision
     }
 
     /// Build upload-time estimate DTO.
@@ -271,13 +273,17 @@ mod tests {
         let pages = 603;
         let chars_per_page = LargeDocumentProfile::min_chars_per_page();
         let markdown = "x".repeat(pages * chars_per_page);
-        assert!(LargeDocumentProfile::markdown_has_text_layer(&markdown, pages));
+        assert!(LargeDocumentProfile::markdown_has_text_layer(
+            &markdown, pages
+        ));
     }
 
     #[test]
     fn sparse_markdown_not_born_digital() {
         let markdown = "short";
-        assert!(!LargeDocumentProfile::markdown_has_text_layer(&markdown, 603));
+        assert!(!LargeDocumentProfile::markdown_has_text_layer(
+            &markdown, 603
+        ));
     }
 
     #[test]

--- a/edgequake/crates/edgequake-api/src/services/mod.rs
+++ b/edgequake/crates/edgequake-api/src/services/mod.rs
@@ -26,13 +26,12 @@ pub mod graph_materialization;
 pub mod health_schema;
 pub mod identity_storage;
 pub mod ingest_admission;
-pub mod large_document_profile;
-pub mod pdf_auto_routing;
 pub mod ingestion_persist;
 pub mod injection_list;
 pub mod injection_process;
 pub mod isolation_context;
 pub mod job_registry;
+pub mod large_document_profile;
 pub mod list_pagination;
 pub mod login_lockout;
 pub mod message_context_mapper;
@@ -43,6 +42,7 @@ pub mod multimodal_markdown;
 pub mod oidc_flow;
 pub mod oidc_pending;
 pub mod pdf_admission_registry;
+pub mod pdf_auto_routing;
 pub mod pdf_lineage;
 pub mod pdf_workspace_dedup;
 pub mod query_context;
@@ -96,10 +96,6 @@ pub use graph_materialization::{
     admit_graph_materialization, graph_query_timeout, run_timed_graph_query,
     GraphMaterializationGuard,
 };
-pub use large_document_profile::{
-    classify_ingestion_failure, IngestionEstimate, IngestionFailureClass, LargeDocumentProfile,
-};
-pub use pdf_auto_routing::{should_try_edgeparse_before_vision, try_edgeparse_fast_path};
 pub use ingest_admission::{
     admit_pdf_processing_enqueue, persist_pdf_task_document_id,
     provision_queued_pdf_document_shell, resolve_pdf_ingest_document_id,
@@ -117,6 +113,9 @@ pub use injection_list::{
 pub use injection_process::{
     build_injection_metadata, injection_doc_id, injection_list_prefix, injection_meta_key,
     run_injection_pipeline, write_injection_status,
+};
+pub use large_document_profile::{
+    classify_ingestion_failure, IngestionEstimate, IngestionFailureClass, LargeDocumentProfile,
 };
 pub use message_context_mapper::{
     build_message_context_from_engine, message_context_from_subgraph,
@@ -141,6 +140,7 @@ pub use multimodal_admission::{
     resolve_upload_content, MultimodalAdmissionMeta, ResolvedUploadContent,
 };
 pub use pdf_admission_registry::PdfAdmissionRegistry;
+pub use pdf_auto_routing::{should_try_edgeparse_before_vision, try_edgeparse_fast_path};
 pub use pdf_workspace_dedup::{
     find_kv_document_id_for_pdf, recycle_orphan_workspace_pdf,
     workspace_has_visible_document_for_pdf,

--- a/edgequake/crates/edgequake-api/tests/spec038_large_pdf.rs
+++ b/edgequake/crates/edgequake-api/tests/spec038_large_pdf.rs
@@ -4,7 +4,7 @@
 //! `cargo test -p edgequake-api --features postgres --test spec038_large_pdf`
 
 use edgequake_api::services::{
-    classify_ingestion_failure, LargeDocumentProfile, IngestionFailureClass,
+    classify_ingestion_failure, IngestionFailureClass, LargeDocumentProfile,
 };
 use edgequake_pdf::PdfParserBackend;
 
@@ -57,12 +57,9 @@ fn spec038_gleaning_disabled_at_500_pages() {
 
 #[tokio::test]
 async fn spec038_auto_route_edgeparse_on_simple_pdf() {
-    let markdown = edgequake_api::services::try_edgeparse_fast_path(
-        SIMPLE_TEXT_PDF,
-        1,
-        "001_simple_text.pdf",
-    )
-    .await;
+    let markdown =
+        edgequake_api::services::try_edgeparse_fast_path(SIMPLE_TEXT_PDF, 1, "001_simple_text.pdf")
+            .await;
     assert!(
         markdown.is_some(),
         "born-digital fixture should produce markdown via EdgeParse fast path"
@@ -102,6 +99,12 @@ async fn spec038_reproducer_fixture_edgeparse_if_present() {
         path
     );
     let md = markdown.unwrap();
-    assert!(md.len() > 500_000, "expected >500KB markdown, got {}", md.len());
-    assert!(LargeDocumentProfile::markdown_has_text_layer(&md, page_count));
+    assert!(
+        md.len() > 500_000,
+        "expected >500KB markdown, got {}",
+        md.len()
+    );
+    assert!(LargeDocumentProfile::markdown_has_text_layer(
+        &md, page_count
+    ));
 }

--- a/edgequake_webui/e2e/document-status-notice.spec.ts
+++ b/edgequake_webui/e2e/document-status-notice.spec.ts
@@ -6,6 +6,7 @@
  */
 
 import { expect, test } from "@playwright/test";
+import { GOTO_OPTS } from "./helpers/app-ready";
 
 const MOCK_TENANT_ID = "tenant-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
 const MOCK_WORKSPACE_ID = "ws-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
@@ -22,7 +23,7 @@ const MOCK_TENANT = {
 const MOCK_WORKSPACE = {
   id: MOCK_WORKSPACE_ID,
   name: "Default Workspace",
-  slug: "default-workspace",
+  slug: "bootstrap-workspace",
   tenant_id: MOCK_TENANT_ID,
   created_at: "2026-01-01T00:00:00Z",
   updated_at: "2026-01-01T00:00:00Z",
@@ -198,8 +199,7 @@ test.describe("Document status notices", () => {
   test("processing doc with vision fallback does not show Failed badge", async ({
     page,
   }) => {
-    await page.goto("/documents");
-    await page.waitForLoadState("networkidle");
+    await page.goto("/documents", GOTO_OPTS);
 
     const spfRow = page.getByRole("row", { name: /SPF TOME II/i });
     await expect(spfRow).toBeVisible({ timeout: 15_000 });
@@ -211,8 +211,7 @@ test.describe("Document status notices", () => {
   });
 
   test("terminal failed doc still shows Failed badge", async ({ page }) => {
-    await page.goto("/documents");
-    await page.waitForLoadState("networkidle");
+    await page.goto("/documents", GOTO_OPTS);
 
     const failedRow = page.getByRole("row", { name: /broken\.pdf/i });
     await expect(failedRow).toBeVisible({ timeout: 15_000 });

--- a/edgequake_webui/e2e/spec021-ingest-resilience.spec.ts
+++ b/edgequake_webui/e2e/spec021-ingest-resilience.spec.ts
@@ -7,7 +7,7 @@
  */
 
 import { expect, test } from "@playwright/test";
-import { seedTenantStoreOnPage } from "./helpers/bootstrap-ui";
+import { seedTenantStoreOnPage } from "./helpers/spec013-bootstrap";
 
 const MOCK_TENANT_ID = "tenant-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
 const MOCK_WORKSPACE_ID = "ws-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";

--- a/edgequake_webui/e2e/spec032-page-chunking.spec.ts
+++ b/edgequake_webui/e2e/spec032-page-chunking.spec.ts
@@ -1,5 +1,6 @@
 /**
  * SPEC-032: Page-Aware PDF Chunking — E2E Tests
+ * @audit — exploratory UI captures; not chromium PR gate
  *
  * Proves the following invariants end-to-end:
  *

--- a/edgequake_webui/e2e/spec037-query-full-chunk.spec.ts
+++ b/edgequake_webui/e2e/spec037-query-full-chunk.spec.ts
@@ -51,7 +51,7 @@ function mockStreamBody(snippet: string): string {
 test.describe("SPEC-037 Full Passage Text", () => {
   test.beforeEach(async ({ page }) => {
     await gotoApp(page, "/query");
-    await page.waitForLoadState("networkidle");
+    await page.waitForLoadState("domcontentloaded");
   });
 
   test("toggle ON sends content_granularity agent in stream request", async ({ page }) => {

--- a/edgequake_webui/e2e/spec037-query-settings-scroll.spec.ts
+++ b/edgequake_webui/e2e/spec037-query-settings-scroll.spec.ts
@@ -10,7 +10,7 @@ import { spec037Screenshot } from "./helpers/screenshot-paths";
 test.describe("SPEC-037 Query Settings Scroll", () => {
   test.beforeEach(async ({ page }) => {
     await gotoApp(page, "/query");
-    await page.waitForLoadState("networkidle");
+    await page.waitForLoadState("domcontentloaded");
   });
 
   test("settings sheet scrolls to system prompt", async ({ page }) => {

--- a/edgequake_webui/e2e/workspace-duplicate-scope.spec.ts
+++ b/edgequake_webui/e2e/workspace-duplicate-scope.spec.ts
@@ -7,6 +7,7 @@
  */
 
 import { expect, test } from "@playwright/test";
+import { GOTO_OPTS } from "./helpers/app-ready";
 
 const MOCK_TENANT_ID = "tenant-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
 const MOCK_WORKSPACE_UUID = "00000000-0000-0000-0000-000000000003";
@@ -23,7 +24,7 @@ const MOCK_TENANT = {
 const MOCK_WORKSPACE = {
   id: MOCK_WORKSPACE_ID,
   name: "Default Workspace",
-  slug: "default-workspace",
+  slug: "bootstrap-workspace",
   tenant_id: MOCK_TENANT_ID,
   created_at: "2026-01-01T00:00:00Z",
   updated_at: "2026-01-01T00:00:00Z",
@@ -230,8 +231,7 @@ test.describe("Workspace duplicate scope", () => {
   test("lists UUID-scoped documents in workspace (not Documents 0)", async ({
     page,
   }) => {
-    await page.goto("/documents");
-    await page.waitForLoadState("networkidle");
+    await page.goto("/documents", GOTO_OPTS);
 
     await expect(page.getByText("Documents (1)")).toBeVisible({ timeout: 15_000 });
     await expect(page.getByRole("row", { name: /SPF TOME II/i })).toBeVisible();

--- a/edgequake_webui/src/lib/api/client-context.ts
+++ b/edgequake_webui/src/lib/api/client-context.ts
@@ -7,7 +7,7 @@
  * session state lives here. The request/response client and the streaming
  * client consume these helpers without owning the storage details.
  *
- * @implements FEAT0771 - Request/response interceptors (context injection)
+ * @implements FEAT0772 - Session context injection for API client
  * @implements SPEC-018 - W3C traceparent correlation
  */
 


### PR DESCRIPTION
## Summary
- `cargo fmt` fixes blocking release-docker quality-gates
- E2E flake lint clean (23 violations → 0)
- FEAT0771 traceability collision resolved (FEAT0772 on client-context)

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `python3 edgequake_webui/scripts/validate-e2e-flake.py`
- [ ] Re-tag `v0.13.0` after merge to retrigger Release — Docker (GHCR)


Made with [Cursor](https://cursor.com)