### PR TITLE
fix(ci): release-docker quality-gates 90 min timeout

### DIFF
--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -18,7 +18,7 @@ jobs:
   # ── Preflight: fmt, clippy, tests, SPEC-006 + SPEC-018 proofs ─────────────────
   quality-gates:
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
Unblocks v0.13.0 GHCR publish — prior run cancelled at 45 min during release_gates.sh.

Made with [Cursor](https://cursor.com)