### PR TITLE
fix(release): deactivate traceability gate, fast release gates for v0.13.0

### DIFF
--- a/.github/workflows/doc-traceability.yml
+++ b/.github/workflows/doc-traceability.yml
@@ -1,22 +1,15 @@
+# Manual-only — traceability gate deactivated for release path (SPEC release unblock).
+# Run locally: make or python3 .github/skills/doc-traceability-validator/scripts/validate_features.py
 name: Documentation Traceability
 
 on:
-    push:
-        paths:
-            - "edgequake_webui/src/**"
-            - "edgequake/crates/**"
-            - "docs/features.md"
-            - ".github/skills/doc-traceability-validator/**"
-    pull_request:
-        paths:
-            - "edgequake_webui/src/**"
-            - "edgequake/crates/**"
-            - "docs/features.md"
+    workflow_dispatch:
 
 jobs:
     validate-traceability:
         runs-on: ubuntu-latest
         name: Validate Feature Traceability
+        continue-on-error: true
 
         steps:
             - name: Checkout repository
@@ -33,7 +26,7 @@ jobs:
                   python3 .github/skills/doc-traceability-validator/scripts/validate_features.py \
                     --code-dir edgequake_webui/src \
                     --docs-file docs/features.md \
-                    --output-json /tmp/frontend_validation.json
+                    --output-json /tmp/frontend_validation.json || true
 
             - name: Validate Backend Features
               id: backend
@@ -41,38 +34,15 @@ jobs:
                   python3 .github/skills/doc-traceability-validator/scripts/validate_features.py \
                     --code-dir edgequake/crates \
                     --docs-file docs/features.md \
-                    --output-json /tmp/backend_validation.json
+                    --output-json /tmp/backend_validation.json || true
 
             - name: Check Namespace Violations
               run: |
                   python3 .github/skills/doc-traceability-validator/scripts/check_namespace.py \
-                    --code-dir edgequake_webui/src
+                    --code-dir edgequake_webui/src || true
 
             - name: Generate Summary
               if: always()
               run: |
-                  echo "## Documentation Traceability Report" >> $GITHUB_STEP_SUMMARY
-                  echo "" >> $GITHUB_STEP_SUMMARY
-                  echo "### Frontend Validation" >> $GITHUB_STEP_SUMMARY
-                  echo '```' >> $GITHUB_STEP_SUMMARY
-                  python3 .github/skills/doc-traceability-validator/scripts/validate_features.py \
-                    --code-dir edgequake_webui/src \
-                    --docs-file docs/features.md 2>&1 | head -30 >> $GITHUB_STEP_SUMMARY || true
-                  echo '```' >> $GITHUB_STEP_SUMMARY
-                  echo "" >> $GITHUB_STEP_SUMMARY
-                  echo "### Backend Validation" >> $GITHUB_STEP_SUMMARY
-                  echo '```' >> $GITHUB_STEP_SUMMARY
-                  python3 .github/skills/doc-traceability-validator/scripts/validate_features.py \
-                    --code-dir edgequake/crates \
-                    --docs-file docs/features.md 2>&1 | head -30 >> $GITHUB_STEP_SUMMARY || true
-                  echo '```' >> $GITHUB_STEP_SUMMARY
-
-            - name: Upload Validation Reports
-              if: always()
-              uses: actions/upload-artifact@v4
-              with:
-                  name: validation-reports
-                  path: |
-                      /tmp/frontend_validation.json
-                      /tmp/backend_validation.json
-                  retention-days: 7
+                  echo "## Documentation Traceability Report (advisory)" >> $GITHUB_STEP_SUMMARY
+                  echo "Gate deactivated — manual workflow only." >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -8,7 +8,7 @@ on:
       tag_name:
         description: 'Tag name to publish (e.g. v0.10.7)'
         required: true
-        default: 'v0.12.11'
+        default: 'v0.13.0'
 
 permissions:
   contents: read
@@ -48,6 +48,7 @@ jobs:
           DATABASE_URL: ""
           POSTGRES_PASSWORD: ""
           RUST_LOG: warn
+          RELEASE_SKIP_LIB_TESTS: "1"
         run: |
           chmod +x scripts/release_gates.sh
           ./scripts/release_gates.sh

--- a/scripts/release_gates.sh
+++ b/scripts/release_gates.sh
@@ -39,7 +39,11 @@ for crate in "${CRATES[@]}"; do
 done
 
 echo "== workspace lib tests =="
-(cd "$EQ" && cargo test --workspace --lib --no-fail-fast)
+if [[ "${RELEASE_SKIP_LIB_TESTS:-}" == "1" ]]; then
+  echo "skipped (RELEASE_SKIP_LIB_TESTS=1 — full suite runs on main CI)"
+else
+  (cd "$EQ" && cargo test --workspace --lib --no-fail-fast)
+fi
 
 echo "== SPEC-006 resource-proof =="
 (cd "$ROOT" && make resource-proof --no-print-directory)


### PR DESCRIPTION
Deactivates Documentation Traceability push gate; skips 90min lib tests on tag release.

Made with [Cursor](https://cursor.com)