### PR TITLE
fix(release): pass postgres feature in proof scripts and gate checks

### DIFF
--- a/scripts/release_gates.sh
+++ b/scripts/release_gates.sh
@@ -35,7 +35,11 @@ for crate in "${CRATES[@]}"; do
       FEATURES=(--features postgres)
       ;;
   esac
-  (cd "$EQ" && cargo clippy -p "$crate" --lib "${FEATURES[@]}" -- -D warnings)
+  if ((${#FEATURES[@]})); then
+    (cd "$EQ" && cargo clippy -p "$crate" --lib "${FEATURES[@]}" -- -D warnings)
+  else
+    (cd "$EQ" && cargo clippy -p "$crate" --lib -- -D warnings)
+  fi
 done
 
 echo "== workspace lib tests =="

--- a/scripts/spec006_no_unguarded_community_api.sh
+++ b/scripts/spec006_no_unguarded_community_api.sh
@@ -28,6 +28,7 @@ fi
 
 WORKSPACE_VIOLATIONS=$(rg 'detect_communities_unchecked' "$ROOT/edgequake/crates" \
   --glob '!**/community.rs' \
+  --glob '!**/community_persist.rs' \
   --glob '!**/graph_community.rs' 2>/dev/null || true)
 
 if [[ -n "$WORKSPACE_VIOLATIONS" ]]; then

--- a/scripts/spec006_source_ids_migration.sh
+++ b/scripts/spec006_source_ids_migration.sh
@@ -53,8 +53,9 @@ rg -q 'verification failed' "$SUPPORT/verify.sql" || {
   exit 1
 }
 
-rg -q 'support/038/apply.sql' "$ROOT/edgequake/crates/edgequake-api/src/state/migration_bootstrap.rs" || {
-  echo "migration_bootstrap.rs must include_str support/038/apply.sql"
+BOOTSTRAP_MOD="$ROOT/edgequake/crates/edgequake-api/src/state/migration_bootstrap/mod.rs"
+rg -q 'support/038/apply.sql' "$BOOTSTRAP_MOD" || {
+  echo "migration_bootstrap/mod.rs must include_str support/038/apply.sql"
   exit 1
 }
 

--- a/specifications/006-ensure-perf/e2e/run_resource_proof.sh
+++ b/specifications/006-ensure-perf/e2e/run_resource_proof.sh
@@ -13,14 +13,14 @@ echo "== SPEC-006: edgequake-storage graph_scan_ops =="
 cargo test -p edgequake-storage graph_scan_ops --quiet
 
 echo "== SPEC-006: edgequake-api resource_safety proof =="
-cargo test -p edgequake-api resource_safety --quiet
-cargo test -p edgequake-api graph_materialization --lib --quiet
+cargo test -p edgequake-api resource_safety --features postgres --quiet
+cargo test -p edgequake-api graph_materialization --lib --features postgres --quiet
 
 echo "== SPEC-006: migration readiness battle test =="
 cargo test -p edgequake-api --test migration_readiness_proof --features postgres --quiet
 
 echo "== SPEC-006: e2e_document_deletion shared-entity smoke =="
-cargo test -p edgequake-api test_delete_preserves_shared_entities --quiet
+cargo test -p edgequake-api test_delete_preserves_shared_entities --features postgres --quiet
 
 postgres_bootstrap_ready() {
   if [[ -z "${DATABASE_URL:-}" && -z "${POSTGRES_PASSWORD:-}" ]]; then

--- a/specs/018-observability/e2e/run_observability_proof.sh
+++ b/specs/018-observability/e2e/run_observability_proof.sh
@@ -14,15 +14,15 @@ echo "== edgequake-tasks =="
 cargo test -p edgequake-tasks --lib
 
 echo "== edgequake-api observability =="
-cargo test -p edgequake-api --test observability_proof
-cargo test -p edgequake-api --lib test_request_id_header_added 2>/dev/null || \
-  cargo test -p edgequake-api --test integration_tests test_request_id_header_added
+cargo test -p edgequake-api --test observability_proof --features postgres
+cargo test -p edgequake-api --lib test_request_id_header_added --features postgres 2>/dev/null || \
+  cargo test -p edgequake-api --test integration_tests test_request_id_header_added --features postgres
 
 echo "== edgequake-audit =="
 cargo test -p edgequake-audit --lib
 
 echo "== edgequake-api lib (smoke) =="
-cargo test -p edgequake-api --lib -- handlers::query::tests::test_query_success
+cargo test -p edgequake-api --lib --features postgres -- handlers::query::tests::test_query_success
 
 echo "== edgequake-webui =="
 cd "$WEBUI"


### PR DESCRIPTION
## Summary
- Add `--features postgres` to edgequake-api invocations in SPEC-006 resource-proof and SPEC-018 observability-proof (fixes release-docker compile errors)
- Fix `release_gates.sh` empty FEATURES array crash under `set -u`
- Update SPEC-006 migration bootstrap lint for `migration_bootstrap/mod.rs` module split
- Allow `community_persist.rs` in sealed community detection workspace lint

## Test plan
- [x] `./scripts/spec006_source_ids_migration.sh`
- [x] `./scripts/spec006_no_unguarded_community_api.sh`
- [x] `cargo test -p edgequake-api --test observability_proof --features postgres`
- [ ] `RELEASE_SKIP_LIB_TESTS=1 ./scripts/release_gates.sh` (CI)
- [ ] `gh workflow run release-docker.yml -f tag_name=v0.13.0`


Made with [Cursor](https://cursor.com)