### PR TITLE
fix(docker): PG18+ container crash due to volume mount path (#280)

### DIFF
--- a/docker-compose.quickstart.yml
+++ b/docker-compose.quickstart.yml
@@ -44,7 +44,7 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-edgequake_secret}
       POSTGRES_DB:       edgequake
     volumes:
-      - edgequake-pg-data:/var/lib/postgresql/data
+      - edgequake-pg-data:/var/lib/postgresql
     networks:
       - edgequake
     healthcheck:

--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -467,7 +467,7 @@ services:
       POSTGRES_PASSWORD: edgequake
       POSTGRES_DB: edgequake
     volumes:
-      - postgres_data:/var/lib/postgresql/data
+      - postgres_data:/var/lib/postgresql
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U edgequake"]
       interval: 5s

--- a/docs/integrations/open-webui.md
+++ b/docs/integrations/open-webui.md
@@ -168,7 +168,7 @@ services:
       POSTGRES_PASSWORD: edgequake
       POSTGRES_DB: edgequake
     volumes:
-      - postgres_data:/var/lib/postgresql/data
+      - postgres_data:/var/lib/postgresql
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U edgequake"]
       interval: 5s

--- a/specs/042-update-age-pgvector/017-fix-pg18-volume-mount.md
+++ b/specs/042-update-age-pgvector/017-fix-pg18-volume-mount.md
@@ -1,0 +1,49 @@
+# SPEC-042/017 — Fix PG18+ Volume Mount Crash (#280)
+
+**Date:** 2026-07-04
+**Issue:** [#280](https://github.com/raphaelmansuy/edgequake/issues/280)
+**Upstream:** [docker-library/postgres#1259](https://github.com/docker-library/postgres/pull/1259)
+
+## 5-Why Root Cause Analysis
+
+| # | Why | Answer |
+|---|-----|--------|
+| 1 | Why does the PG18 container crash? | The entrypoint detects data at `/var/lib/postgresql/data` but PG18 expects `pg_ctlcluster` layout at `/var/lib/postgresql/18/docker` |
+| 2 | Why is data at the wrong path? | `docker-compose.quickstart.yml` hardcodes `edgequake-pg-data:/var/lib/postgresql/data` |
+| 3 | Why is it hardcoded? | Written when PG16 was default — `/var/lib/postgresql/data` was universal for PG<=17 |
+| 4 | Why wasn't it updated for PG18? | Internal compose files were parameterized, but the quickstart (user entry point) was missed |
+| 5 | Why was the quickstart missed? | No E2E test verifies volume persistence across container restarts for the quickstart compose file |
+
+**Root cause:** The `/var/lib/postgresql/data` mount path is incompatible with PG18+, which uses `pg_ctlcluster` directory layout.
+
+## First Principle
+
+The volume mount path **MUST match the `VOLUME` declaration** in the base Docker image:
+
+| PG Major | Base Image `VOLUME` | Correct Mount Path | Reason |
+|----------|--------------------|--------------------|--------|
+| PG<=17 | `/var/lib/postgresql/data` | `/var/lib/postgresql/data` | Traditional `PGDATA` layout |
+| PG18+ | `/var/lib/postgresql` | `/var/lib/postgresql` | New `pg_ctlcluster` layout ([docker-library/postgres#1259](https://github.com/docker-library/postgres/pull/1259)) |
+
+Mounting at a parent of the declared `VOLUME` path does NOT override the anonymous volume — data is lost on container recreation. This is a Docker design constraint.
+
+## Affected Files
+
+| File | Image Default | Old Mount | Fix |
+|------|--------------|-----------|-----|
+| `docker-compose.quickstart.yml` | PG18 (`latest`) | `/var/lib/postgresql/data` | `/var/lib/postgresql` |
+| `docs/cookbook.md` | PG18 example | `/var/lib/postgresql/data` | `/var/lib/postgresql` |
+| `docs/integrations/open-webui.md` | PG18 example | `/var/lib/postgresql/data` | `/var/lib/postgresql` |
+
+**No change needed:**
+- `edgequake/docker/docker-compose.test.yml` — uses `Dockerfile.postgres` (PG16), mount at `/var/lib/postgresql/data` is correct
+- `edgequake/docker/docker-compose.yml` — already parameterized `${POSTGRES_DATA_DIR:-/var/lib/postgresql}`
+- `edgequake/docker/docker-compose.prebuilt.yml` — already parameterized
+- `Makefile` — PG-major branching logic already correct
+
+## E2E Battle Test
+
+Verify for each profile:
+1. PG16: mount at `/var/lib/postgresql/data` — data persists across restart
+2. PG17: mount at `/var/lib/postgresql/data` — data persists across restart
+3. PG18: mount at `/var/lib/postgresql` — data persists across restart, no crash loop

--- a/specs/042-update-age-pgvector/e2e/run_pg18_volume_mount_proof.sh
+++ b/specs/042-update-age-pgvector/e2e/run_pg18_volume_mount_proof.sh
@@ -1,0 +1,201 @@
+#!/usr/bin/env bash
+# SPEC-042/017 — PG18 volume mount fix E2E proof (#280).
+#
+# Verifies that mounting at /var/lib/postgresql works for PG16, PG17, PG18:
+#   1. Fresh start — container boots, extensions load
+#   2. Write data — insert rows into a test table
+#   3. Restart — stop + start, data persists
+#   4. Clean up
+#
+# Usage:
+#   ./specs/042-update-age-pgvector/e2e/run_pg18_volume_mount_proof.sh [pg16|pg17|pg18|all]
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+REPORT_DIR="$ROOT/specs/042-update-age-pgvector/e2e/v0140-volume-proof"
+PROFILE="${1:-all}"
+PGPASSWORD="vol_proof_secret"
+VERSION="0.14.0"
+REGISTRY="ghcr.io/raphaelmansuy/edgequake-postgres"
+
+mkdir -p "$REPORT_DIR"
+log() { echo "[$(date +%H:%M:%S)] $*"; }
+
+run_profile() {
+  local profile="$1"
+  local image="${REGISTRY}:${VERSION}-${profile}"
+  local container="eq-vol-proof-${profile}-$$"
+  local volume="eq-vol-proof-${profile}-$$"
+  local report="$REPORT_DIR/${profile}-volume-report.txt"
+  local mount_path
+  case "$profile" in
+    pg18) mount_path="/var/lib/postgresql" ;;
+    *)    mount_path="/var/lib/postgresql/data" ;;
+  esac
+
+  log "=========================================="
+  log "VOLUME PROOF: $profile → mount at $mount_path"
+  log "=========================================="
+
+  {
+    echo "# v${VERSION} Volume Mount Proof — ${profile}"
+    echo "# Date: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    echo "# Image: $image"
+    echo "# Mount: $mount_path"
+    echo ""
+  } > "$report"
+
+  cleanup() {
+    docker rm -f "$container" >/dev/null 2>&1 || true
+    docker volume rm "$volume" >/dev/null 2>&1 || true
+  }
+  trap cleanup RETURN
+
+  docker volume create "$volume" >/dev/null
+
+  # ── Step 1: Fresh start ─────────────────────────────────────────────────────
+  log "  [1/4] Fresh start with volume mount at $mount_path..."
+  docker run -d --name "$container" \
+    -v "${volume}:${mount_path}" \
+    -e POSTGRES_USER=edgequake \
+    -e POSTGRES_PASSWORD="$PGPASSWORD" \
+    -e POSTGRES_DB=edgequake \
+    "$image" >/dev/null
+
+  for i in $(seq 1 60); do
+    if docker exec -e PGPASSWORD="$PGPASSWORD" "$container" \
+      psql -U edgequake -d edgequake -c 'SELECT 1' >/dev/null 2>&1; then
+      break
+    fi
+    if [ "$i" -eq 60 ]; then
+      log "FAIL: container did not start"
+      docker logs "$container" 2>&1 | tail -20
+      echo "FAIL [1/4] Container did not start" >> "$report"
+      return 1
+    fi
+    sleep 1
+  done
+  echo "PASS [1/4] Fresh start OK (${i}s)" >> "$report"
+
+  # ── Step 2: Create extensions + write data ──────────────────────────────────
+  log "  [2/4] Create extensions + write test data..."
+  docker exec -i -e PGPASSWORD="$PGPASSWORD" "$container" \
+    psql -U edgequake -d edgequake -v ON_ERROR_STOP=1 <<'SQL'
+CREATE EXTENSION IF NOT EXISTS vector;
+CREATE EXTENSION IF NOT EXISTS age;
+CREATE TABLE IF NOT EXISTS persistence_test (
+  id serial PRIMARY KEY,
+  payload text NOT NULL,
+  created_at timestamptz DEFAULT now()
+);
+INSERT INTO persistence_test (payload) VALUES
+  ('row-1-proof-of-persistence'),
+  ('row-2-proof-of-persistence'),
+  ('row-3-proof-of-persistence');
+SQL
+  row_count=$(docker exec -e PGPASSWORD="$PGPASSWORD" "$container" \
+    psql -U edgequake -d edgequake -tAc "SELECT count(*) FROM persistence_test;")
+  [ "$row_count" = "3" ] || { log "FAIL: expected 3 rows, got $row_count"; return 1; }
+  echo "PASS [2/4] Write: $row_count rows + extensions (vector, age)" >> "$report"
+
+  # ── Step 3: Stop + restart — data must persist ──────────────────────────────
+  log "  [3/4] Stop + restart — verify data persistence..."
+  docker stop "$container" >/dev/null
+  docker rm "$container" >/dev/null
+
+  docker run -d --name "$container" \
+    -v "${volume}:${mount_path}" \
+    -e POSTGRES_USER=edgequake \
+    -e POSTGRES_PASSWORD="$PGPASSWORD" \
+    -e POSTGRES_DB=edgequake \
+    "$image" >/dev/null
+
+  for i in $(seq 1 60); do
+    if docker exec -e PGPASSWORD="$PGPASSWORD" "$container" \
+      psql -U edgequake -d edgequake -c 'SELECT 1' >/dev/null 2>&1; then
+      break
+    fi
+    if [ "$i" -eq 60 ]; then
+      log "FAIL: container did not restart"
+      docker logs "$container" 2>&1 | tail -20
+      echo "FAIL [3/4] Container did not restart" >> "$report"
+      return 1
+    fi
+    sleep 1
+  done
+
+  row_count_after=$(docker exec -e PGPASSWORD="$PGPASSWORD" "$container" \
+    psql -U edgequake -d edgequake -tAc "SELECT count(*) FROM persistence_test;")
+  [ "$row_count_after" = "3" ] || {
+    log "FAIL: expected 3 rows after restart, got $row_count_after"
+    echo "FAIL [3/4] Data lost: expected 3, got $row_count_after" >> "$report"
+    return 1
+  }
+
+  ext_check=$(docker exec -e PGPASSWORD="$PGPASSWORD" "$container" \
+    psql -U edgequake -d edgequake -tAc \
+    "SELECT count(*) FROM pg_extension WHERE extname IN ('vector','age');")
+  [ "$ext_check" = "2" ] || {
+    log "FAIL: extensions missing after restart (got $ext_check)"
+    echo "FAIL [3/4] Extensions lost after restart" >> "$report"
+    return 1
+  }
+  echo "PASS [3/4] Restart: $row_count_after rows + $ext_check extensions persisted" >> "$report"
+
+  # ── Step 4: No crash-loop — container stays healthy ─────────────────────────
+  log "  [4/4] Health check — no crash loop..."
+  sleep 3
+  status=$(docker inspect --format='{{.State.Status}}' "$container" 2>/dev/null)
+  [ "$status" = "running" ] || {
+    log "FAIL: container status is '$status' (expected 'running')"
+    docker logs "$container" 2>&1 | tail -20
+    echo "FAIL [4/4] Container status: $status" >> "$report"
+    return 1
+  }
+  echo "PASS [4/4] Healthy: container status = $status (no crash loop)" >> "$report"
+
+  echo "" >> "$report"
+  echo "RESULT: ALL PASSED" >> "$report"
+  log "  ✓ $profile — ALL 4 CHECKS PASSED (mount at $mount_path)"
+}
+
+# ── Main ──────────────────────────────────────────────────────────────────────
+log "SPEC-042/017 Volume Mount Proof (#280)"
+log ""
+
+docker ps -aq --filter "name=eq-vol-proof-" 2>/dev/null | xargs -r docker rm -f >/dev/null 2>&1 || true
+
+failed=0
+case "$PROFILE" in
+  all)
+    for p in pg16 pg17 pg18; do
+      run_profile "$p" || failed=1
+    done
+    ;;
+  pg16|pg17|pg18)
+    run_profile "$PROFILE" || failed=1
+    ;;
+  *)
+    echo "Usage: $0 [pg16|pg17|pg18|all]"
+    exit 1
+    ;;
+esac
+
+echo ""
+log "=========================================="
+log "SUMMARY — Volume Mount Proof (#280)"
+log "=========================================="
+for f in "$REPORT_DIR"/*-volume-report.txt; do
+  [ -f "$f" ] || continue
+  profile=$(basename "$f" -volume-report.txt)
+  result=$(grep "^RESULT:" "$f" 2>/dev/null | head -1)
+  echo "  $profile: ${result:-UNKNOWN}"
+done
+echo ""
+
+if [ "$failed" -ne 0 ]; then
+  log "✗ SOME PROFILES FAILED"
+  exit 1
+fi
+
+log "✓ VOLUME MOUNT PROOF — ALL PROFILES PASSED (#280 fixed)"

--- a/specs/042-update-age-pgvector/e2e/v0140-volume-proof/pg16-volume-report.txt
+++ b/specs/042-update-age-pgvector/e2e/v0140-volume-proof/pg16-volume-report.txt
@@ -1,0 +1,11 @@
+# v0.14.0 Volume Mount Proof — pg16
+# Date: 2026-07-04T07:15:46Z
+# Image: ghcr.io/raphaelmansuy/edgequake-postgres:0.14.0-pg16
+# Mount: /var/lib/postgresql/data
+
+PASS [1/4] Fresh start OK (7s)
+PASS [2/4] Write: 3 rows + extensions (vector, age)
+PASS [3/4] Restart: 3 rows + 2 extensions persisted
+PASS [4/4] Healthy: container status = running (no crash loop)
+
+RESULT: ALL PASSED

--- a/specs/042-update-age-pgvector/e2e/v0140-volume-proof/pg17-volume-report.txt
+++ b/specs/042-update-age-pgvector/e2e/v0140-volume-proof/pg17-volume-report.txt
@@ -1,0 +1,11 @@
+# v0.14.0 Volume Mount Proof — pg17
+# Date: 2026-07-04T07:15:57Z
+# Image: ghcr.io/raphaelmansuy/edgequake-postgres:0.14.0-pg17
+# Mount: /var/lib/postgresql/data
+
+PASS [1/4] Fresh start OK (4s)
+PASS [2/4] Write: 3 rows + extensions (vector, age)
+PASS [3/4] Restart: 3 rows + 2 extensions persisted
+PASS [4/4] Healthy: container status = running (no crash loop)
+
+RESULT: ALL PASSED

--- a/specs/042-update-age-pgvector/e2e/v0140-volume-proof/pg18-volume-report.txt
+++ b/specs/042-update-age-pgvector/e2e/v0140-volume-proof/pg18-volume-report.txt
@@ -1,0 +1,11 @@
+# v0.14.0 Volume Mount Proof — pg18
+# Date: 2026-07-04T07:16:05Z
+# Image: ghcr.io/raphaelmansuy/edgequake-postgres:0.14.0-pg18
+# Mount: /var/lib/postgresql
+
+PASS [1/4] Fresh start OK (5s)
+PASS [2/4] Write: 3 rows + extensions (vector, age)
+PASS [3/4] Restart: 3 rows + 2 extensions persisted
+PASS [4/4] Healthy: container status = running (no crash loop)
+
+RESULT: ALL PASSED


### PR DESCRIPTION
## Summary

Fixes #280 — PostgreSQL 18+ containers crash with `pg_ctlcluster` compatibility error when the volume is mounted at `/var/lib/postgresql/data`.

**Root Cause (5-Why):**

| # | Why | Answer |
|---|-----|--------|
| 1 | Why does the PG18 container crash? | Entrypoint detects data at `/var/lib/postgresql/data` but PG18 expects `pg_ctlcluster` layout |
| 2 | Why is data at the wrong path? | `docker-compose.quickstart.yml` hardcodes `/var/lib/postgresql/data` |
| 3 | Why is it hardcoded? | Written for PG16, not updated when PG18 became default |
| 4 | Why wasn't it updated? | Internal compose files were parameterized, but quickstart was missed |
| 5 | Why was quickstart missed? | No E2E test verified volume persistence for the quickstart compose file |

**Fix:** Mount at `/var/lib/postgresql` for PG18+ images (quickstart, doc examples). PG<=17 test compose keeps `/var/lib/postgresql/data` because the base Docker image's `VOLUME` declaration at that path causes anonymous volume override if mounted at parent.

**Upstream:** [docker-library/postgres#1259](https://github.com/docker-library/postgres/pull/1259)

## Changes

- `docker-compose.quickstart.yml` — volume mount `/var/lib/postgresql/data` → `/var/lib/postgresql`
- `docs/cookbook.md` — updated example
- `docs/integrations/open-webui.md` — updated example
- New: `specs/042-update-age-pgvector/017-fix-pg18-volume-mount.md` — 5-Why + spec
- New: `run_pg18_volume_mount_proof.sh` — E2E proof script

## Test plan

- [x] PG16: mount at `/var/lib/postgresql/data` — data persists across restart
- [x] PG17: mount at `/var/lib/postgresql/data` — data persists across restart
- [x] PG18: mount at `/var/lib/postgresql` — data persists, no crash loop
- [x] All 4 checks passed per profile (fresh start, write, restart persistence, health)


Made with [Cursor](https://cursor.com)