### PR TITLE
release: v0.14.1 — fix PG18+ volume mount crash (#280)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+## [0.14.1] — 2026-07-04
+
+### Fixed
+
+- **PG18+ volume mount crash** ([#280](https://github.com/raphaelmansuy/edgequake/issues/280)) — `docker-compose.quickstart.yml` mounted at `/var/lib/postgresql/data` which is incompatible with PG18+ `pg_ctlcluster` layout ([docker-library/postgres#1259](https://github.com/docker-library/postgres/pull/1259)). Fixed to `/var/lib/postgresql` for PG18+ images. 5-Why analysis and E2E volume persistence proof in [SPEC-042/017](specs/042-update-age-pgvector/017-fix-pg18-volume-mount.md).
+- **README fact-check** — corrected 3 inaccuracies: `edgequake-llm` → `edgequake-observability` (local crate), "6 domain presets" → "5", removed dead doc link.
+- **README refocus** — reduced from 979 → 325 lines; Docker quick start as hero, collapsible deployment options, restored architecture diagram. Release & CD content extracted to `docs/operations/release-and-cd.md`.
+
+---
+
 ## [0.14.0] — 2026-07-03
 
 SPEC-042 PostgreSQL triple-track release — PG18 default, multi-tier CI/CD, HNSW dimension guard ([#275](https://github.com/raphaelmansuy/edgequake/issues/275)).

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 > **High-Performance Graph-RAG Framework in Rust**  
 > Transform documents into intelligent knowledge graphs for superior retrieval and generation
 
-[![Version](https://img.shields.io/badge/version-0.14.0-blue.svg?style=flat)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.14.1-blue.svg?style=flat)](CHANGELOG.md)
 [![Rust](https://img.shields.io/badge/rust-1.95+-orange.svg?style=flat&logo=rust)](https://www.rust-lang.org)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg?style=flat)](LICENSE)
 [![Build Status](https://img.shields.io/badge/build-passing-brightgreen.svg?style=flat)](https://github.com/raphaelmansuy/edgequake)

--- a/edgequake/Cargo.lock
+++ b/edgequake/Cargo.lock
@@ -1789,7 +1789,7 @@ dependencies = [
 
 [[package]]
 name = "edgequake"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1814,7 +1814,7 @@ dependencies = [
 
 [[package]]
 name = "edgequake-api"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1885,7 +1885,7 @@ dependencies = [
 
 [[package]]
 name = "edgequake-auth"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "argon2",
  "async-trait",
@@ -1903,7 +1903,7 @@ dependencies = [
 
 [[package]]
 name = "edgequake-core"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1967,7 +1967,7 @@ dependencies = [
 
 [[package]]
 name = "edgequake-observability"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "http 1.4.2",
  "metrics",
@@ -1985,7 +1985,7 @@ dependencies = [
 
 [[package]]
 name = "edgequake-pdf"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2028,7 +2028,7 @@ dependencies = [
 
 [[package]]
 name = "edgequake-pipeline"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2049,7 +2049,7 @@ dependencies = [
 
 [[package]]
 name = "edgequake-query"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2090,7 +2090,7 @@ dependencies = [
 
 [[package]]
 name = "edgequake-storage"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "async-trait",
  "chrono",

--- a/edgequake/Cargo.toml
+++ b/edgequake/Cargo.toml
@@ -72,7 +72,7 @@ criterion = { workspace = true }
 tokio-test = { workspace = true }
 
 [workspace.package]
-version = "0.14.0"
+version = "0.14.1"
 edition = "2021"
 rust-version = "1.95"
 license = "Apache-2.0"

--- a/edgequake_webui/package.json
+++ b/edgequake_webui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "edgequake_webui",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Summary

Release v0.14.1 patch addressing PG18+ Docker container crash.

- Fix PG18+ volume mount crash (#280) — `docker-compose.quickstart.yml` now mounts at `/var/lib/postgresql` for PG18+ compatibility
- README fact-check corrections (3 inaccuracies fixed)
- README restructured for end-user focus (979 → 325 lines)

## Test plan

- [x] PG16/PG17/PG18 volume persistence E2E proof (all 4 checks × 3 tiers)
- [x] CI checks pass


Made with [Cursor](https://cursor.com)