### PR TITLE
refactor: normalize tenant and workspace ID handling across document …

### DIFF
--- a/edgequake/crates/edgequake-api/src/handlers/documents/delete/bulk.rs
+++ b/edgequake/crates/edgequake-api/src/handlers/documents/delete/bulk.rs
@@ -228,12 +228,14 @@ pub async fn delete_all_documents(
             }
         }
 
-        // SPEC-006 P1: per-document bounded graph cascade (no post-hoc full scan)
+        // SPEC-006 P1: per-document bounded graph cascade (no post-hoc full scan).
+        // WHY tenant_ctx = None (#305): ownership already checked; source-prefix
+        // cascade must not miss nodes with legacy `"default"` / missing tenant props.
         let scope = DocumentSourceScope::from_document_id(document_id.clone());
         match cascade_remove_document_sources(
             &state.storage.graph_storage,
             None,
-            Some(&tenant_ctx),
+            None,
             &scope,
         )
         .await

--- a/edgequake/crates/edgequake-api/src/handlers/documents/delete/single.rs
+++ b/edgequake/crates/edgequake-api/src/handlers/documents/delete/single.rs
@@ -399,10 +399,16 @@ pub async fn delete_document(
     // cleanup below is the authoritative data removal; graph rows are best-effort
     // and can be reconciled later. This fixes the "delete returns 500 even though
     // the document is gone" symptom seen on large ingestions.
+    //
+    // WHY tenant_ctx = None (#305): document ownership was already verified via
+    // metadata_matches_tenant_context / relational_scope above. Passing the raw
+    // request tenant filter made cascade miss AGE nodes whose workspace_id is
+    // the canonical UUID while the header still says `"default"` (or nodes that
+    // lack tenant properties entirely). Source-prefix scope is document-unique.
     let cascade_stats = match cascade_remove_document_sources(
         &state.storage.graph_storage,
         Some(&workspace_vector_storage),
-        Some(&tenant_ctx),
+        None,
         &scope,
     )
     .await
@@ -902,6 +908,83 @@ mod tests {
         assert!(
             !keys_after.contains(&alt_lineage_key),
             "lineage under json id prefix"
+        );
+    }
+
+    /// #305: DELETE must cascade-remove exclusive Knowledge Graph entities.
+    #[tokio::test]
+    async fn test_delete_document_removes_exclusive_graph_entities() {
+        use edgequake_storage::traits::GraphStorageMutateOps;
+        use std::collections::HashMap;
+
+        let state = AppState::test_state();
+        let doc_id = "doc-305-delete-cascade";
+        let metadata_key = metadata_key_for_document(doc_id);
+        let chunk_key = format!("{}-chunk-0", doc_id);
+
+        state
+            .storage
+            .kv_storage
+            .upsert(&[
+                (
+                    metadata_key.clone(),
+                    json!({
+                        "id": doc_id,
+                        "status": "completed",
+                        "workspace_id": "default",
+                        "tenant_id": "default",
+                    }),
+                ),
+                (chunk_key.clone(), json!({"content": "chunk"})),
+            ])
+            .await
+            .unwrap();
+
+        let mut props = HashMap::new();
+        props.insert(
+            "source_ids".to_string(),
+            json!([format!("{}-chunk-0", doc_id)]),
+        );
+        props.insert("entity_type".to_string(), json!("PERSON"));
+        // Store canonical UUID while request may use `"default"` — cascade must
+        // still find and remove the node.
+        props.insert(
+            "workspace_id".to_string(),
+            json!(crate::middleware::default_workspace_uuid().to_string()),
+        );
+        state
+            .storage
+            .graph_storage
+            .upsert_node("EXCLUSIVE_ENTITY_305", props)
+            .await
+            .unwrap();
+
+        let result = delete_document(
+            State(state.clone()),
+            axum::extract::Path(doc_id.to_string()),
+            TenantContext {
+                tenant_id: Some("default".to_string()),
+                workspace_id: Some("default".to_string()),
+                user_id: None,
+            },
+        )
+        .await
+        .expect("delete should succeed");
+
+        assert!(result.deleted);
+        assert!(
+            result.entities_affected >= 1,
+            "exclusive entity must be cascade-removed, got entities_affected={}",
+            result.entities_affected
+        );
+        assert!(
+            !state
+                .storage
+                .graph_storage
+                .has_node("EXCLUSIVE_ENTITY_305")
+                .await
+                .unwrap(),
+            "Knowledge Graph must not retain entities from deleted documents (#305)"
         );
     }
 }

--- a/edgequake/crates/edgequake-api/src/handlers/documents/recovery/reprocess.rs
+++ b/edgequake/crates/edgequake-api/src/handlers/documents/recovery/reprocess.rs
@@ -180,11 +180,11 @@ pub(crate) async fn run_reprocess_failed(
 
     // Requeue documents for processing
     for (doc_id, _doc_key) in &docs_to_reprocess {
-        let workspace_id_for_tasks = tenant_ctx
-            .workspace_id
-            .as_deref()
-            .unwrap_or("default")
-            .to_string();
+        // WHY (#304): never pass the literal `"default"` alias into Uuid::parse_str —
+        // that returns ValidationError after early-admit already wrote status=processing,
+        // leaving the document stuck with "Reprocess has no effect".
+        let workspace_id_for_tasks = tenant_ctx.workspace_id_or_default();
+        let tenant_id_for_tasks = tenant_ctx.tenant_id_or_default();
 
         // Read metadata early so soft single-flight can see pdf_id before any purge.
         let metadata_key =
@@ -416,18 +416,28 @@ pub(crate) async fn run_reprocess_failed(
             .and_then(|v| v.as_str())
             .map(|s| s.to_string());
 
-        // Use tenant context for workspace_id, fallback to "default"
-        let workspace_id = tenant_ctx
-            .workspace_id
-            .clone()
-            .unwrap_or_else(|| "default".to_string());
-        let tenant_id = tenant_ctx
-            .tenant_id
-            .clone()
-            .unwrap_or_else(|| "default".to_string());
+        // Prefer document metadata workspace/tenant when present (canonical UUIDs),
+        // otherwise fall back to the request context helpers that resolve `"default"`.
+        let workspace_id = metadata_opt
+            .as_ref()
+            .and_then(|m| m.get("workspace_id"))
+            .and_then(|v| v.as_str())
+            .and_then(|s| crate::middleware::resolve_workspace_uuid(Some(s)))
+            .map(|u| u.to_string())
+            .unwrap_or_else(|| workspace_id_for_tasks.clone());
+        let tenant_id = metadata_opt
+            .as_ref()
+            .and_then(|m| m.get("tenant_id"))
+            .and_then(|v| v.as_str())
+            .and_then(|s| crate::middleware::resolve_tenant_uuid(Some(s)))
+            .map(|u| u.to_string())
+            .unwrap_or_else(|| tenant_id_for_tasks.clone());
 
-        // FIX-REBUILD: Route PDF documents through PdfProcessing for full re-extraction
-        let task_created = if source_type.as_deref() == Some("pdf") {
+        // FIX-REBUILD: Route PDF documents through PdfProcessing for full re-extraction.
+        // WHY (#304): interrupted uploads may have `pdf_id` but missing/empty
+        // `source_type` or KV content — still treat as PDF so Reprocess enqueues work.
+        let is_pdf_document = source_type.as_deref() == Some("pdf") || pdf_id_str.is_some();
+        let task_created = if is_pdf_document {
             if let Some(ref pid_str) = pdf_id_str {
                 if let Ok(pdf_id_uuid) = uuid::Uuid::parse_str(pid_str) {
                     // Edge case: empty-markdown fallback.
@@ -437,10 +447,30 @@ pub(crate) async fn run_reprocess_failed(
                     // to Full so the PDF is re-converted from scratch. This is a
                     // safe, idempotent promotion: Full is a strict superset of
                     // EntitiesOnly's work.
+                    //
+                    // Also upgrade when the doc was interrupted by server restart
+                    // (#304): checkpoints/markdown are often incomplete after a kill.
                     #[allow(unused_mut)]
                     let mut reprocess_mode = reprocess_mode;
                     #[allow(unused_mut)]
                     let mut restart_from_scratch = restart_from_scratch;
+                    let interrupted_by_restart = metadata_opt
+                        .as_ref()
+                        .and_then(|m| m.get("error_message"))
+                        .and_then(|v| v.as_str())
+                        .is_some_and(|msg| {
+                            msg.contains("Interrupted by server restart")
+                                || msg.contains("Server restarted")
+                        });
+                    if !restart_from_scratch && interrupted_by_restart {
+                        tracing::info!(
+                            document_id = %doc_id,
+                            pdf_id = %pid_str,
+                            "Reprocess after server-restart interrupt — upgrading to full re-conversion (#304)"
+                        );
+                        reprocess_mode = edgequake_tasks::ReprocessMode::Full;
+                        restart_from_scratch = true;
+                    }
                     if !restart_from_scratch {
                         // `pdf_storage` is only present under the `postgres` feature
                         // (StorageRuntime::pdf_storage is `#[cfg(feature = "postgres")]`).
@@ -472,6 +502,26 @@ pub(crate) async fn run_reprocess_failed(
                                     pdf_id = %pid_str,
                                     "Reprocess entities requested but cached markdown is empty — upgrading to full re-conversion"
                                 );
+                                reprocess_mode = edgequake_tasks::ReprocessMode::Full;
+                                restart_from_scratch = true;
+                            }
+                        }
+                        // Without postgres / when KV content is also missing, promote
+                        // so soft reprocess does not no-op after interrupt (#304).
+                        #[cfg(not(feature = "postgres"))]
+                        {
+                            let content_missing = state
+                                .storage
+                                .kv_storage
+                                .get_by_id(&content_key)
+                                .await?
+                                .and_then(|v| {
+                                    v.get("content")
+                                        .and_then(|c| c.as_str())
+                                        .map(|s| s.trim().is_empty())
+                                })
+                                .unwrap_or(true);
+                            if content_missing {
                                 reprocess_mode = edgequake_tasks::ReprocessMode::Full;
                                 restart_from_scratch = true;
                             }

--- a/edgequake/crates/edgequake-api/src/services/document_graph_cascade.rs
+++ b/edgequake/crates/edgequake-api/src/services/document_graph_cascade.rs
@@ -60,11 +60,25 @@ pub struct CascadeStats {
     pub embeddings_deleted: usize,
 }
 
+/// Normalize tenant/workspace filter IDs to canonical UUIDs.
+///
+/// WHY (#305): request headers and stored graph properties often disagree on the
+/// legacy `"default"` alias vs the built-in UUID. Strict AGE property equality
+/// then finds **zero** nodes during cascade delete, leaving the Knowledge Graph
+/// intact after the document KV row is gone.
+fn canonical_tenant_filter_id(raw: Option<&str>) -> Option<String> {
+    crate::middleware::resolve_tenant_uuid(raw).map(|u| u.to_string())
+}
+
+fn canonical_workspace_filter_id(raw: Option<&str>) -> Option<String> {
+    crate::middleware::resolve_workspace_uuid(raw).map(|u| u.to_string())
+}
+
 pub fn node_list_filter(tenant_ctx: Option<&TenantContext>) -> NodeListFilter {
     match tenant_ctx {
         Some(ctx) => NodeListFilter {
-            tenant_id: ctx.tenant_id.clone(),
-            workspace_id: ctx.workspace_id.clone(),
+            tenant_id: canonical_tenant_filter_id(ctx.tenant_id.as_deref()),
+            workspace_id: canonical_workspace_filter_id(ctx.workspace_id.as_deref()),
             entity_type: None,
             search: None,
             community_ids: None,
@@ -76,8 +90,8 @@ pub fn node_list_filter(tenant_ctx: Option<&TenantContext>) -> NodeListFilter {
 pub fn edge_list_filter(tenant_ctx: Option<&TenantContext>) -> EdgeListFilter {
     match tenant_ctx {
         Some(ctx) => EdgeListFilter {
-            tenant_id: ctx.tenant_id.clone(),
-            workspace_id: ctx.workspace_id.clone(),
+            tenant_id: canonical_tenant_filter_id(ctx.tenant_id.as_deref()),
+            workspace_id: canonical_workspace_filter_id(ctx.workspace_id.as_deref()),
             relationship_type: None,
         },
         None => EdgeListFilter::default(),
@@ -143,6 +157,18 @@ fn edge_key(edge: &GraphEdge) -> (String, String) {
 }
 
 /// Cascade remove document sources from graph entities and relationships.
+///
+/// # Isolation (#305)
+/// Prefer calling with `tenant_ctx = None` after the document has already been
+/// authorization-checked: source-prefix scope is document-unique and must not
+/// miss graph rows whose `tenant_id`/`workspace_id` properties are absent or
+/// still use the legacy `"default"` alias. When a tenant filter is supplied,
+/// IDs are canonicalized to UUIDs first.
+///
+/// # Resilience
+/// Per-node/edge mutation failures are logged and skipped so one AGE hiccup
+/// cannot abort the whole cascade (which previously left the full KG intact
+/// while KV delete still succeeded).
 pub async fn cascade_remove_document_sources(
     graph: &Arc<dyn GraphStorage>,
     vector_storage: Option<&Arc<dyn VectorStorage>>,
@@ -150,7 +176,20 @@ pub async fn cascade_remove_document_sources(
     scope: &DocumentSourceScope,
 ) -> ApiResult<CascadeStats> {
     let mut stats = CascadeStats::default();
-    let affected_nodes = find_document_nodes(graph, tenant_ctx, scope).await?;
+    // First try with the caller's filter; if it finds nothing, fall back to an
+    // unscoped source-prefix scan. Document IDs are globally unique, so this
+    // cannot leak another tenant's nodes — it only repairs filter mismatches.
+    let mut affected_nodes = find_document_nodes(graph, tenant_ctx, scope).await?;
+    if affected_nodes.is_empty() && tenant_ctx.is_some() {
+        affected_nodes = find_document_nodes(graph, None, scope).await?;
+        if !affected_nodes.is_empty() {
+            tracing::warn!(
+                document_id = %scope.document_id,
+                found = affected_nodes.len(),
+                "Graph cascade: tenant/workspace filter missed nodes; using source-prefix fallback (#305)"
+            );
+        }
+    }
 
     let mut deleted_node_ids = HashSet::new();
 
@@ -161,7 +200,15 @@ pub async fn cascade_remove_document_sources(
         }
         let remaining = remaining_sources_after_removal(&node.properties, scope);
         if remaining.is_empty() {
-            graph.delete_node(&node.id).await.map_err(ApiError::from)?;
+            if let Err(e) = graph.delete_node(&node.id).await {
+                tracing::warn!(
+                    node_id = %node.id,
+                    document_id = %scope.document_id,
+                    error = %e,
+                    "Cascade delete_node failed (continuing)"
+                );
+                continue;
+            }
             if let Some(vs) = vector_storage {
                 let _ = vs.delete_entity(&node.id).await;
                 stats.embeddings_deleted += 1;
@@ -175,52 +222,102 @@ pub async fn cascade_remove_document_sources(
                 &mut updated_props,
                 &remaining,
             );
-            graph
-                .upsert_node(&node.id, updated_props)
-                .await
-                .map_err(ApiError::from)?;
+            if let Err(e) = graph.upsert_node(&node.id, updated_props).await {
+                tracing::warn!(
+                    node_id = %node.id,
+                    document_id = %scope.document_id,
+                    error = %e,
+                    "Cascade upsert_node failed (continuing)"
+                );
+                continue;
+            }
             stats.entities_updated += 1;
         }
     }
 
     let mut edges_to_process: HashMap<(String, String), GraphEdge> = HashMap::new();
-    for edge in find_document_edges(graph, tenant_ctx, scope).await? {
+    let mut doc_edges = find_document_edges(graph, tenant_ctx, scope).await?;
+    if doc_edges.is_empty() && tenant_ctx.is_some() {
+        doc_edges = find_document_edges(graph, None, scope).await?;
+    }
+    for edge in doc_edges {
         edges_to_process.insert(edge_key(&edge), edge);
     }
 
     if !deleted_node_ids.is_empty() {
         let ids: Vec<String> = deleted_node_ids.iter().cloned().collect();
-        for edge in graph
-            .get_edges_for_nodes_batch(&ids)
-            .await
-            .map_err(ApiError::from)?
-        {
-            edges_to_process.insert(edge_key(&edge), edge);
+        match graph.get_edges_for_nodes_batch(&ids).await {
+            Ok(edges) => {
+                for edge in edges {
+                    edges_to_process.insert(edge_key(&edge), edge);
+                }
+            }
+            Err(e) => {
+                tracing::warn!(
+                    document_id = %scope.document_id,
+                    error = %e,
+                    "Cascade get_edges_for_nodes_batch failed (continuing)"
+                );
+            }
         }
     }
 
     for edge in edges_to_process.into_values() {
-        let source_exists = graph.has_node(&edge.source).await.map_err(ApiError::from)?;
-        let target_exists = graph.has_node(&edge.target).await.map_err(ApiError::from)?;
+        let source_exists = match graph.has_node(&edge.source).await {
+            Ok(v) => v,
+            Err(e) => {
+                tracing::warn!(
+                    edge_source = %edge.source,
+                    error = %e,
+                    "Cascade has_node(source) failed (continuing)"
+                );
+                continue;
+            }
+        };
+        let target_exists = match graph.has_node(&edge.target).await {
+            Ok(v) => v,
+            Err(e) => {
+                tracing::warn!(
+                    edge_target = %edge.target,
+                    error = %e,
+                    "Cascade has_node(target) failed (continuing)"
+                );
+                continue;
+            }
+        };
         if !source_exists || !target_exists {
-            graph
-                .delete_edge(&edge.source, &edge.target)
-                .await
-                .map_err(ApiError::from)?;
+            if let Err(e) = graph.delete_edge(&edge.source, &edge.target).await {
+                tracing::warn!(
+                    edge_source = %edge.source,
+                    edge_target = %edge.target,
+                    error = %e,
+                    "Cascade delete_edge (orphan endpoints) failed (continuing)"
+                );
+                continue;
+            }
             stats.relationships_removed += 1;
             continue;
         }
 
         let sources = collect_source_references(&edge.properties);
+        // Edges often lack source_ids after merge (lineage UI). If both endpoints
+        // were exclusive to this document and deleted above, the orphan-endpoint
+        // branch already removed the edge. If only one endpoint remains (shared
+        // entity), keep the edge unless provenance says this doc owned it alone.
         if sources.is_empty() {
             continue;
         }
         let remaining = remaining_sources_after_removal(&edge.properties, scope);
         if remaining.is_empty() {
-            graph
-                .delete_edge(&edge.source, &edge.target)
-                .await
-                .map_err(ApiError::from)?;
+            if let Err(e) = graph.delete_edge(&edge.source, &edge.target).await {
+                tracing::warn!(
+                    edge_source = %edge.source,
+                    edge_target = %edge.target,
+                    error = %e,
+                    "Cascade delete_edge failed (continuing)"
+                );
+                continue;
+            }
             stats.relationships_removed += 1;
         } else if remaining.len() < sources.len() {
             let mut updated_props = edge.properties.clone();
@@ -228,10 +325,18 @@ pub async fn cascade_remove_document_sources(
                 &mut updated_props,
                 &remaining,
             );
-            graph
+            if let Err(e) = graph
                 .upsert_edge(&edge.source, &edge.target, updated_props)
                 .await
-                .map_err(ApiError::from)?;
+            {
+                tracing::warn!(
+                    edge_source = %edge.source,
+                    edge_target = %edge.target,
+                    error = %e,
+                    "Cascade upsert_edge failed (continuing)"
+                );
+                continue;
+            }
             stats.relationships_updated += 1;
         }
     }
@@ -447,5 +552,88 @@ mod tests {
         assert_eq!(edges.len(), 1);
         assert_eq!(edges[0].source, "LIGHTRAG");
         assert_eq!(edges[0].target, "RETRIEVAL");
+    }
+
+    #[test]
+    fn node_list_filter_canonicalizes_default_alias() {
+        let ctx = TenantContext {
+            tenant_id: Some("default".to_string()),
+            workspace_id: Some("default".to_string()),
+            user_id: None,
+        };
+        let filter = node_list_filter(Some(&ctx));
+        // Strict equality must never leave the literal "default" alias.
+        assert_ne!(filter.workspace_id.as_deref(), Some("default"));
+        assert_ne!(filter.tenant_id.as_deref(), Some("default"));
+        let expected_ws = crate::middleware::default_workspace_uuid().to_string();
+        let expected_tenant = crate::middleware::default_tenant_uuid().to_string();
+        assert_eq!(filter.workspace_id.as_deref(), Some(expected_ws.as_str()));
+        assert_eq!(filter.tenant_id.as_deref(), Some(expected_tenant.as_str()));
+    }
+
+    /// #305: cascade must remove exclusive entities even when the request
+    /// tenant filter says `"default"` while nodes store the canonical UUID
+    /// (or omit tenant props entirely).
+    #[tokio::test]
+    async fn cascade_removes_exclusive_nodes_despite_default_alias_filter() {
+        use edgequake_storage::traits::GraphStorageMutateOps;
+        use edgequake_storage::MemoryGraphStorage;
+
+        let graph: Arc<dyn GraphStorage> = Arc::new(MemoryGraphStorage::new("cascade-305"));
+        let doc_id = "doc-305-orphan";
+        let scope = DocumentSourceScope::from_document_id(doc_id);
+        let ws_uuid = crate::middleware::default_workspace_uuid().to_string();
+
+        let mut props = HashMap::new();
+        props.insert(
+            "source_ids".to_string(),
+            serde_json::json!([format!("{doc_id}-chunk-0")]),
+        );
+        props.insert("workspace_id".to_string(), serde_json::json!(ws_uuid));
+        props.insert("entity_type".to_string(), serde_json::json!("PERSON"));
+        graph
+            .upsert_node("ORPHAN_ENTITY", props)
+            .await
+            .expect("node");
+
+        // Mismatched filter: literal "default" would miss UUID-scoped nodes on
+        // Postgres AGE. Memory backend ignores filters, so we also assert the
+        // None path used by delete handlers.
+        let stats = cascade_remove_document_sources(&graph, None, None, &scope)
+            .await
+            .expect("cascade");
+        assert_eq!(stats.entities_removed, 1);
+        assert!(!graph.has_node("ORPHAN_ENTITY").await.expect("has"));
+    }
+
+    /// Shared entities keep remaining sources after cascade.
+    #[tokio::test]
+    async fn cascade_preserves_shared_entity_sources() {
+        use edgequake_storage::traits::GraphStorageMutateOps;
+        use edgequake_storage::MemoryGraphStorage;
+
+        let graph: Arc<dyn GraphStorage> = Arc::new(MemoryGraphStorage::new("cascade-shared"));
+        let doc_a = "doc-a";
+        let doc_b = "doc-b";
+        let scope = DocumentSourceScope::from_document_id(doc_a);
+
+        let mut props = HashMap::new();
+        props.insert(
+            "source_ids".to_string(),
+            serde_json::json!([format!("{doc_a}-chunk-0"), format!("{doc_b}-chunk-0")]),
+        );
+        graph
+            .upsert_node("SHARED", props)
+            .await
+            .expect("node");
+
+        let stats = cascade_remove_document_sources(&graph, None, None, &scope)
+            .await
+            .expect("cascade");
+        assert_eq!(stats.entities_removed, 0);
+        assert_eq!(stats.entities_updated, 1);
+        let node = graph.get_node("SHARED").await.expect("get").expect("exists");
+        let remaining = collect_source_references(&node.properties);
+        assert_eq!(remaining, vec![format!("{doc_b}-chunk-0")]);
     }
 }

--- a/edgequake/crates/edgequake-api/src/services/pending_doc_task_reconcile.rs
+++ b/edgequake/crates/edgequake-api/src/services/pending_doc_task_reconcile.rs
@@ -92,9 +92,14 @@ pub async fn has_active_task_for_document(
 }
 
 fn parse_uuid_field(meta: &Value, key: &str) -> Option<Uuid> {
-    meta.get(key)
-        .and_then(|v| v.as_str())
-        .and_then(|s| Uuid::parse_str(s).ok())
+    let raw = meta.get(key).and_then(|v| v.as_str())?;
+    match key {
+        // WHY (#304): document metadata often stores the legacy `"default"` alias.
+        // Uuid::parse_str("default") fails → recovery enqueue is skipped forever.
+        "workspace_id" => crate::middleware::resolve_workspace_uuid(Some(raw)),
+        "tenant_id" => crate::middleware::resolve_tenant_uuid(Some(raw)),
+        _ => Uuid::parse_str(raw).ok(),
+    }
 }
 
 fn meta_str<'a>(meta: &'a Value, key: &str) -> Option<&'a str> {
@@ -222,16 +227,10 @@ pub async fn ensure_task_for_pending_document(
         }
     }
 
-    let tenant_id = parse_uuid_field(metadata, "tenant_id").ok_or_else(|| {
-        ApiError::ValidationError(format!(
-            "document {document_id} missing tenant_id for recovery enqueue"
-        ))
-    })?;
-    let workspace_id = workspace_id.ok_or_else(|| {
-        ApiError::ValidationError(format!(
-            "document {document_id} missing workspace_id for recovery enqueue"
-        ))
-    })?;
+    let tenant_id = parse_uuid_field(metadata, "tenant_id")
+        .unwrap_or_else(crate::middleware::default_tenant_uuid);
+    let workspace_id =
+        workspace_id.unwrap_or_else(crate::middleware::default_workspace_uuid);
 
     let title = meta_str(metadata, "title")
         .or_else(|| meta_str(metadata, "file_name"))
@@ -556,6 +555,44 @@ mod tests {
         assert!(!is_orphan_waiting_status("processing"));
         assert!(!is_orphan_waiting_status("failed"));
         assert!(!is_orphan_waiting_status("completed"));
+    }
+
+    #[test]
+    fn parse_uuid_field_resolves_default_alias() {
+        let meta = json!({
+            "tenant_id": "default",
+            "workspace_id": "default",
+        });
+        assert_eq!(
+            parse_uuid_field(&meta, "workspace_id"),
+            Some(crate::middleware::default_workspace_uuid())
+        );
+        assert_eq!(
+            parse_uuid_field(&meta, "tenant_id"),
+            Some(crate::middleware::default_tenant_uuid())
+        );
+    }
+
+    #[test]
+    fn build_pdf_recovery_accepts_default_workspace_alias() {
+        let meta = json!({
+            "id": "doc-1",
+            "tenant_id": "default",
+            "workspace_id": "default",
+            "source_type": "pdf",
+            "pdf_id": "33333333-3333-3333-3333-333333333333",
+            "title": "paper.pdf",
+            "status": "pending"
+        });
+        let built = build_recovery_task_from_metadata("doc-1", &meta, "batch", "test");
+        assert!(
+            built.is_some(),
+            "recovery must accept legacy default alias (#304)"
+        );
+        let (ty, _, tenant, workspace) = built.unwrap();
+        assert_eq!(ty, TaskType::PdfProcessing);
+        assert_eq!(tenant, crate::middleware::default_tenant_uuid());
+        assert_eq!(workspace, crate::middleware::default_workspace_uuid());
     }
 
     #[test]

--- a/edgequake/crates/edgequake-api/tests/e2e_spec054_pending_task_reconcile.rs
+++ b/edgequake/crates/edgequake-api/tests/e2e_spec054_pending_task_reconcile.rs
@@ -522,3 +522,78 @@ async fn spec054_298_pdf_reconcile_preserves_metadata_vision_provider() {
     );
     assert_eq!(built.vision_provider, "mistral");
 }
+
+/// #304: Reprocess must enqueue work for docs marked "Interrupted by server restart"
+/// even when metadata uses the legacy `"default"` workspace/tenant alias.
+#[tokio::test]
+async fn issue_304_reprocess_interrupted_doc_with_default_alias() {
+    let state = AppState::test_state();
+    let app = Server::new(test_config(), state.clone()).build_router();
+    let doc_id = "issue-304-interrupted-default";
+
+    let metadata = json!({
+        "id": doc_id,
+        "title": "interrupted.md",
+        "status": "failed",
+        "current_stage": "failed",
+        "error_message": "Interrupted by server restart — use Reprocess to resume",
+        "stage_message": "Interrupted during 'extracting' stage by server restart. Use Reprocess to resume from checkpoint.",
+        "tenant_id": "default",
+        "workspace_id": "default",
+        "source_type": "text",
+        "updated_at": "2020-01-01T00:00:00Z",
+    });
+    state
+        .storage
+        .kv_storage
+        .upsert(&[
+            (format!("{doc_id}-metadata"), metadata),
+            (
+                format!("{doc_id}-content"),
+                json!({ "content": "Resume me after restart" }),
+            ),
+        ])
+        .await
+        .expect("seed interrupted doc");
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v1/documents/reprocess")
+                .header("Content-Type", "application/json")
+                .header("X-Tenant-ID", "default")
+                .header("X-Workspace-ID", "default")
+                .body(Body::from(
+                    json!({
+                        "document_id": doc_id,
+                        "force": true,
+                        "max_documents": 1,
+                        "mode": "entities"
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert!(
+        response.status().is_success(),
+        "reprocess must not 400 on default alias, got {}",
+        response.status()
+    );
+    let body = axum::body::to_bytes(response.into_body(), 1024 * 1024)
+        .await
+        .unwrap();
+    let parsed: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    let requeued = parsed["requeued"].as_u64().unwrap_or(0);
+    assert!(
+        requeued >= 1,
+        "falsifiable (#304): interrupted doc with default alias must requeue, body={parsed}"
+    );
+    assert!(
+        parsed["task_id"].as_str().is_some(),
+        "must return a task_id so UI can track progress"
+    );
+}


### PR DESCRIPTION
## Summary

- Fix document DELETE leaving Knowledge Graph entities/relationships behind when documents are removed via API/UI (**#305**).
- Fix Reprocess having no effect for documents interrupted by server/container restart (**#304**).
- Resolve legacy `"default"` tenant/workspace aliases to canonical UUIDs so cascade delete and reprocess enqueue stay consistent.
- Make graph cascade resilient: per-node/edge failures are logged and skipped instead of aborting the whole cleanup.
- Promote interrupted PDF reprocess to Full when needed so processing can resume without re-upload.

## Description

### #305 — Orphaned Knowledge Graph after document delete

Deleting a document removed KV/document rows but often left AGE nodes and edges intact. Cascade used a strict tenant/workspace filter; request headers with `"default"` frequently did not match stored graph properties (canonical UUID or missing props), so cascade found **0 nodes** while document delete still succeeded.

**Fix:** After ownership checks, cascade by document source-prefix (no fragile tenant filter mismatch). Canonicalize `"default"` → UUID when filters are used. Continue cascade on individual mutation errors.

### #304 — Reprocess after restart does nothing

On restart, in-flight docs are marked failed with *Interrupted by server restart — use Reprocess to resume*. Reprocess then called `Uuid::parse_str("default")`, which fails **after** early-admit already set status to processing — leaving the document stuck so Reprocess looked like a no-op.

**Fix:** Use `workspace_id_or_default()` / `tenant_id_or_default()` and resolve aliases from metadata. Accept `"default"` in recovery enqueue. Auto-upgrade interrupted PDFs to Full reprocess when appropriate.

Fixes #305  
Fixes #304

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (describe below)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes

## Test plan

- [x] `cargo test -p edgequake-api --lib cascade`
- [x] `cargo test -p edgequake-api --lib pending_doc_task_reconcile`
- [x] `cargo test -p edgequake-api --lib exclusive_graph`
- [x] `cargo test -p edgequake-api --test e2e_spec054_pending_task_reconcile issue_304`
- [ ] Manual: upload → confirm KG entities → DELETE → confirm exclusive entities/edges removed
- [ ] Manual: interrupt mid-process (restart container) → click Reprocess → processing resumes

## Additional context

**Files:** `document_graph_cascade.rs`, `delete/single.rs`, `delete/bulk.rs`, `recovery/reprocess.rs`, `pending_doc_task_reconcile.rs` + regression tests.

**Ops (optional):** `EDGEQUAKE_STARTUP_AUTO_RESUME=1` auto-resumes interrupted docs on boot; Reprocess should work without it after this fix.