### PR TITLE
fix(api): avoid per-document graph scan in bulk delete (#309)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed — Bulk delete scalability
+
+- **Bulk "Delete All Documents" no longer scans the full graph per document (#309)** — `DELETE /api/v1/documents` ran the per-document graph cascade (`cascade_remove_document_sources`) once for every document, each issuing full `_ag_label_vertex` / `_ag_label_edge` scans with `agtype_to_json(...)` and wildcard `LIKE` predicates. On large workspaces this became O(documents × graph_size), producing slow queries, statement timeouts, connection-pool exhaustion, and PostgreSQL/AGE OOM kills. The per-document cascade is now skipped whenever the authoritative workspace-scoped clear runs afterward — a single bounded `DETACH DELETE` (`clear_workspace`) that is both far cheaper and strictly more complete (it also removes orphaned rows the cascade missed). Document deleted-count, KV/vector cleanup, PDF/mm-asset cleanup, and cross-workspace isolation are unchanged.
+
 ---
 
 ## [0.19.0] — 2026-07-17

--- a/edgequake/crates/edgequake-api/src/handlers/documents/delete/bulk.rs
+++ b/edgequake/crates/edgequake-api/src/handlers/documents/delete/bulk.rs
@@ -89,6 +89,24 @@ pub async fn delete_all_documents(
     // Define stuck threshold: documents processing for > 1 hour are considered stuck
     let stuck_threshold_secs = 3600; // 1 hour
 
+    // Issue #309: Resolve the workspace UUID up front so we know whether the
+    // authoritative workspace-scoped graph clear will run after the loop.
+    //
+    // WHY: The per-document graph cascade (`cascade_remove_document_sources`) issues
+    // full `_ag_label_vertex` / `_ag_label_edge` scans with `agtype_to_json(...)` and
+    // wildcard `LIKE` predicates on every call. Running it once per document makes bulk
+    // delete O(documents × graph_size) — hundreds of repeated full-graph scans — which
+    // is what produces the slow queries, statement timeouts, connection-pool exhaustion,
+    // and PostgreSQL/AGE OOM reported on large workspaces.
+    //
+    // When a workspace clear will run, `clear_workspace` performs a single bounded
+    // `DETACH DELETE` that is both far cheaper and strictly more complete than the
+    // per-document cascade (it also removes orphaned rows the cascade misses — see the
+    // "First principle" note below). So we skip the redundant per-document cascade in
+    // that path and let the one bounded clear do the graph work.
+    let workspace_uuid = resolve_workspace_uuid(tenant_ctx.workspace_id.as_deref());
+    let skip_per_document_graph_cascade = workspace_uuid.is_some();
+
     for (metadata_key, metadata) in scoped_entries {
         let document_id = document_id_from_metadata_key(&metadata_key).unwrap_or_else(|| {
             metadata
@@ -228,26 +246,32 @@ pub async fn delete_all_documents(
             }
         }
 
-        // SPEC-006 P1: per-document bounded graph cascade (no post-hoc full scan)
-        let scope = DocumentSourceScope::from_document_id(document_id.clone());
-        match cascade_remove_document_sources(
-            &state.storage.graph_storage,
-            None,
-            Some(&tenant_ctx),
-            &scope,
-        )
-        .await
-        {
-            Ok(stats) => {
-                total_entities_removed += stats.entities_removed;
-                total_relationships_removed += stats.relationships_removed;
-            }
-            Err(e) => {
-                tracing::warn!(
-                    document_id = %document_id,
-                    error = %e,
-                    "Failed graph cascade during bulk delete"
-                );
+        // SPEC-006 P1: per-document bounded graph cascade (no post-hoc full scan).
+        //
+        // Issue #309: Skipped when the workspace-scoped graph clear will run after the
+        // loop — repeating this per-document full-graph scan is what times out / OOMs
+        // Postgres/AGE at scale, and the single `clear_workspace` below supersedes it.
+        if !skip_per_document_graph_cascade {
+            let scope = DocumentSourceScope::from_document_id(document_id.clone());
+            match cascade_remove_document_sources(
+                &state.storage.graph_storage,
+                None,
+                Some(&tenant_ctx),
+                &scope,
+            )
+            .await
+            {
+                Ok(stats) => {
+                    total_entities_removed += stats.entities_removed;
+                    total_relationships_removed += stats.relationships_removed;
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        document_id = %document_id,
+                        error = %e,
+                        "Failed graph cascade during bulk delete"
+                    );
+                }
             }
         }
 
@@ -318,7 +342,7 @@ pub async fn delete_all_documents(
 
     // First principle: zero documents in workspace ⇒ zero workspace-scoped graph entities.
     // Per-document source-prefix cascade misses orphans (no source_ids, PG-only rows, etc.).
-    if let Some(workspace_uuid) = resolve_workspace_uuid(tenant_ctx.workspace_id.as_deref()) {
+    if let Some(workspace_uuid) = workspace_uuid {
         #[cfg(feature = "postgres")]
         {
             let relational_deleted =

--- a/edgequake/crates/edgequake-api/tests/e2e_document_deletion.rs
+++ b/edgequake/crates/edgequake-api/tests/e2e_document_deletion.rs
@@ -4314,6 +4314,32 @@ async fn test_bulk_delete_only_clears_current_workspace_and_purges_tasks() {
     task.status = TaskStatus::Processing;
     state.tasks.storage.create_task(&task).await.unwrap();
 
+    // Issue #309: seed graph entities in both workspaces. Bulk delete must clear
+    // workspace_a's graph via the single workspace-scoped clear (the per-document
+    // cascade is skipped when that clear runs) while leaving workspace_b untouched.
+    let seed_node = |id: &str, ws: &str| {
+        let mut props = std::collections::HashMap::new();
+        props.insert("entity_type".to_string(), json!("CONCEPT"));
+        props.insert("workspace_id".to_string(), json!(ws));
+        props.insert("tenant_id".to_string(), json!(TEST_TENANT_ID));
+        props.insert("source_ids".to_string(), json!([format!("{}-chunk-0", doc_a)]));
+        (id.to_string(), props)
+    };
+    let (id_a, props_a) = seed_node("BULK_SCOPE_ENTITY_A", &workspace_a.to_string());
+    state
+        .storage
+        .graph_storage
+        .upsert_node(&id_a, props_a)
+        .await
+        .unwrap();
+    let (id_b, props_b) = seed_node("BULK_SCOPE_ENTITY_B", workspace_b);
+    state
+        .storage
+        .graph_storage
+        .upsert_node(&id_b, props_b)
+        .await
+        .unwrap();
+
     let (status, body) = delete_all_documents_http_scoped(&app, &workspace_a.to_string()).await;
     assert_eq!(status, StatusCode::OK);
     assert_eq!(body["deleted_count"].as_u64(), Some(1));
@@ -4338,6 +4364,29 @@ async fn test_bulk_delete_only_clears_current_workspace_and_purges_tasks() {
         .await
         .unwrap()
         .is_some());
+
+    // Issue #309: workspace_a graph entity is gone (cleared by the bounded
+    // workspace clear), workspace_b entity survives (cross-workspace isolation).
+    assert!(
+        state
+            .storage
+            .graph_storage
+            .get_node("BULK_SCOPE_ENTITY_A")
+            .await
+            .unwrap()
+            .is_none(),
+        "workspace_a graph entity should be cleared by bulk delete"
+    );
+    assert!(
+        state
+            .storage
+            .graph_storage
+            .get_node("BULK_SCOPE_ENTITY_B")
+            .await
+            .unwrap()
+            .is_some(),
+        "workspace_b graph entity must survive bulk delete scoped to workspace_a"
+    );
 
     println!("✅ OODA-37 TEST PASSED: Bulk delete stays in-scope and purges stale tasks");
 }


### PR DESCRIPTION
## Description

Bulk `DELETE /api/v1/documents` ran the per-document graph cascade
(`cascade_remove_document_sources`) once for every document. Each call issues full
`_ag_label_vertex` / `_ag_label_edge` scans with `agtype_to_json(...)` and wildcard
`LIKE` predicates, so bulk delete was **O(documents × graph_size)** — hundreds of
repeated full-graph scans. On large workspaces this caused slow queries, statement
timeouts, connection-pool exhaustion, and PostgreSQL/AGE OOM kills.

The handler already performs an authoritative workspace-scoped clear after the loop
(`clear_workspace`), a single bounded `DETACH DELETE` that is both far cheaper and
strictly more complete (it also removes orphaned rows the cascade misses). This PR
skips the redundant per-document cascade whenever that clear will run. Entity nodes
are stamped with the canonical resolved workspace UUID, which `clear_workspace`
filters on, so coverage is a strict superset — no behavior change beyond speed.

`deleted_count`, KV/vector cleanup, PDF/mm-asset cleanup, and cross-workspace
isolation are unchanged.

**Motivation / context:** reproduced on v0.19.0 with PostgreSQL/Apache AGE in Docker
(~199 documents, ~600 vertices / ~2200 edges) — bulk delete degraded to timeouts and
could OOM the database, while single-document deletion stayed fast.

Fixes #309

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (describe below)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes

## Additional context

**Change is minimal and localized:**
- `edgequake/crates/edgequake-api/src/handlers/documents/delete/bulk.rs` — hoist the
  workspace-UUID resolution above the loop; guard the per-document cascade behind
  `if !skip_per_document_graph_cascade`; reuse the hoisted UUID in the final clear.
- `edgequake/crates/edgequake-api/tests/e2e_document_deletion.rs` — extend
  `test_bulk_delete_only_clears_current_workspace_and_purges_tasks` (OODA-37) to seed
  graph entities in two workspaces and assert the scoped workspace graph is cleared
  while the other survives.
- `CHANGELOG.md` — entry under `[Unreleased]`.

**Why it's safe (strict-superset coverage):**
- The per-document cascade's node query already filters by `workspace_id` (tenant
  filter), so it could only ever touch nodes inside the workspace that
  `clear_workspace` wipes.
- Ingested nodes are stamped with `workspace_id_or_default()` (the canonical resolved
  UUID string), which `clear_workspace(resolved_uuid)` filters on — an exact match.
- In the legacy `"default"` alias case the cascade's raw-string filter wouldn't even
  have matched the UUID-stamped nodes, so `clear_workspace` was already the real
  cleanup path.
- `clear_workspace` already ran unconditionally after the loop before this change; the
  end state (workspace graph emptied) is identical, only the redundant pre-work is
  removed.

> ⚠️ **Test evidence pending:** this was authored in an environment without a Rust
> toolchain, so `cargo fmt` / `cargo clippy` / `cargo test` were **not run locally**
> (hence the two unchecked boxes). Please run before merge:
> ```bash
> cargo fmt
> cargo clippy --workspace --all-targets
> cargo test -p edgequake-api --test e2e_document_deletion
> ```
> The most relevant test is `test_bulk_delete_only_clears_current_workspace_and_purges_tasks`.