### PR TITLE
chore(spec-097): git history hygiene for bench001 fat artifacts (GH-351)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,11 +40,22 @@ jobs:
           chmod +x scripts/check_migration_checksums.sh
           ./scripts/check_migration_checksums.sh --verbose
 
+  git-hygiene:
+    name: Git hygiene (SPEC-097)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+      - name: Block fat bench artifacts / oversized tip blobs
+        run: |
+          chmod +x tools/git-hygiene/check_no_fat_artifacts.sh
+          ./tools/git-hygiene/check_no_fat_artifacts.sh
+
   check:
     name: Check (fmt + clippy)
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    needs: migration-checksum-guard
+    needs: [migration-checksum-guard, git-hygiene]
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-rust

--- a/.gitignore
+++ b/.gitignore
@@ -144,12 +144,13 @@ edgequake-website/
 # Root-level marketing screenshots (safe to regenerate)
 /*.png
 
-# Bench001 medical-full raw eval/predictions exceed GitHub 100MB limit — keep
-# scorecard/SUMMARY/BUSINESS_REPORT only; regenerate locally via make bench001-medical-full-*.
-specs/001-benchmark/e2e/artifacts/medical-full/predictions_*.json
-specs/001-benchmark/e2e/artifacts/medical-full/eval_*.json
-specs/001-benchmark/e2e/artifacts/history/medical-full-*/predictions_*.json
-specs/001-benchmark/e2e/artifacts/history/medical-full-*/eval_*.json
+# SPEC-097 / GH-351 — fat regenerable bench001 archives (local-only).
+# Keep thin scorecard/SUMMARY/BUSINESS_REPORT/meta in git; regenerate fat via make bench001-*.
+specs/001-benchmark/e2e/artifacts/**/predictions_*.json
+specs/001-benchmark/e2e/artifacts/**/eval_*.json
+specs/001-benchmark/e2e/artifacts/**/eval_*.raw.json
+specs/001-benchmark/e2e/artifacts/**/logs/progress.jsonl
+specs/001-benchmark/e2e/artifacts/history/**/logs/
 
 # OS files
 Thumbs.db

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -115,6 +115,7 @@ Before submitting, verify:
 - new env vars are documented
 - Docker instructions still work
 - no secrets or generated artifacts are committed
+- run `make git-hygiene` (SPEC-097 / [#351](https://github.com/raphaelmansuy/edgequake/issues/351)): do **not** commit regenerable bench001 fat JSON (`predictions_*.json`, `eval_*.json`, `eval_*.raw.json`, `logs/progress.jsonl`). Acc claims live in thin `scorecard.json` / `SUMMARY.md` / `specs/001-benchmark/e2e/artifacts/publish/`. See [`specs/097-git-history/`](specs/097-git-history/).
 
 ## Community Standards
 

--- a/Makefile
+++ b/Makefile
@@ -2562,6 +2562,11 @@ release-gates: ## Pre-release gate: fmt, workspace clippy, SPEC-006/018, WebUI, 
 	@chmod +x scripts/release_gates.sh
 	@./scripts/release_gates.sh
 
+.PHONY: git-hygiene
+git-hygiene: ## SPEC-097 / GH-351: block fat bench artifacts and >50MiB tip blobs
+	@chmod +x tools/git-hygiene/check_no_fat_artifacts.sh
+	@./tools/git-hygiene/check_no_fat_artifacts.sh
+
 .PHONY: spec090-perf-smoke
 spec090-perf-smoke: ## SPEC-090 falsifiable scaling smoke (needs DATABASE_URL)
 	@chmod +x scripts/perf/spec090_scaling_smoke.sh

--- a/specs/001-benchmark/001-edgquake-improvements/041-topic-chunk-fidelity-audit.md
+++ b/specs/001-benchmark/001-edgquake-improvements/041-topic-chunk-fidelity-audit.md
@@ -67,4 +67,5 @@ export BENCH001_EQ_WORKSPACE_ID=2a7bcb2f-b156-4c49-9229-67f5bcde22a4
 python3 tools/bench001/scripts/audit_topic_chunk_fidelity.py \
   --predictions-eq specs/001-benchmark/e2e/artifacts/history/smoke-20260720T111944Z/predictions_eq.json \
   --predictions-lr specs/001-benchmark/e2e/artifacts/history/smoke-20260720T111944Z/predictions_lr.json
+  # SPEC-097: predictions_*.json are local-only (gitignored); regenerate via make bench001-*
 ```

--- a/specs/001-benchmark/e2e/README.md
+++ b/specs/001-benchmark/e2e/README.md
@@ -7,8 +7,18 @@ artifacts/
   smoke/          # full Acc n=40 (publication)
   smoke-fast/     # Acc gate n=8 (capped corpus OK)
   LIVE.md         # live progress board (docs / chunks / ETA)
-  history/        # archived scorecards
+  publish/        # Acc SSOT (latest + peers) — always commit thin claims
+  history/        # archived runs (see thin vs fat below)
 ```
+
+### Thin vs fat archives (SPEC-097 / GH-351)
+
+| Class | Examples | In git? |
+|-------|----------|---------|
+| **Thin SSOT** | `scorecard.json`, `SUMMARY.md`, `BUSINESS_REPORT.md`, `meta.json`, `LOCAL_ONLY.md` | Yes |
+| **Fat forensics** | `predictions_*.json`, `eval_*.json`, `eval_*.raw.json`, `logs/progress.jsonl` | **No** (gitignored; local-only) |
+
+Do not `git add -f` fat JSON. Regenerate with `make bench001-*`. Policy: [`specs/097-git-history/`](../../097-git-history/).
 
 ## Publication Acc pins (required)
 

--- a/specs/097-git-history/00-first-principles.md
+++ b/specs/097-git-history/00-first-principles.md
@@ -1,0 +1,60 @@
+# SPEC-097 — First Principles
+
+> **Cross-refs**: [WHY](00-why.md) · [Roadmap](03-implementation-roadmap.md) · [SPEC-001 e2e](../001-benchmark/e2e/README.md)  
+> **External**: [git-filter-repo](https://github.com/newren/git-filter-repo) · [GitHub large files](https://docs.github.com/en/repositories/working-with-files/managing-large-files/about-large-files-on-github)
+
+---
+
+## Laws
+
+| Law | Statement |
+|-----|-----------|
+| **LAW-G1** | Git stores **source + small SSOT claims**, never regenerable bulk run outputs. |
+| **LAW-G2** | Acc / latency **claims** live in thin artifacts: `publish/latest`, `publish/peers/*`, and per-run `scorecard.json` + human reports. |
+| **LAW-G3** | Fat run outputs (`predictions_*.json`, `eval_*.json`, `eval_*.raw.json`, `logs/progress.jsonl`) are **local-only**; regenerable via `make bench001-*`. |
+| **LAW-G4** | Stopping future commits is insufficient; **history must be rewritten** so clones stop downloading dead blobs. |
+| **LAW-G5** | Prevention > cleanup: expand `.gitignore` + add a size/path guard so CI/`make` blocks reintroduction. |
+| **LAW-G6** | Do **not** use Git LFS for these artifacts — they are not distribution assets; they are experiment scratch. |
+
+---
+
+## First principles (decomposition)
+
+### 1. What belongs in git?
+
+| Keep (thin) | Drop (fat) |
+|-------------|------------|
+| `scorecard.json` | `predictions_eq.json` / `predictions_lr.json` |
+| `SUMMARY.md` / `BUSINESS_REPORT.md` / `EXEC_SUMMARY.txt` | `eval_*.json` / `eval_*.raw.json` |
+| `meta.json` / `eq_workspace.json` / `progress.json` (small) | `logs/progress.jsonl` |
+| `ABLATION_NOTE.md` / `LIVE.md` / `LOCAL_ONLY.md` | Build ghosts: `sdks/swift/.build/**`, `zz_test_docs/**` |
+| `publish/latest` + `publish/peers/*` | — |
+
+### 2. Why keep thin `history/<run>/`?
+
+SPEC-001 improvement notes deep-link run folders for Acc numbers. Thin scorecards preserve those links without multi-GB packs. Publish peers remain the business SSOT.
+
+### 3. Why rewrite history?
+
+Per GitHub and git-filter-repo docs: removing a file from the tip leaves blobs in the object database. Clone downloads packs built from the full commit graph. Only path invert / blob strip reclaims space.
+
+### 4. SOLID / DRY
+
+| Principle | Application |
+|-----------|-------------|
+| **S** | `.gitignore` owns ignore policy; `archive_run` owns local layout; `check_no_fat_artifacts.sh` owns enforcement; runbook owns rewrite. |
+| **O** | New fat patterns = extend ignore globs + guard allowlist once. |
+| **D** | Contributors depend on thin SSOT paths, not on local fat JSON. |
+| **DRY** | One glob family in `.gitignore`; guard script mirrors the same patterns. |
+
+---
+
+## Normative ignore family (tip)
+
+```gitignore
+specs/001-benchmark/e2e/artifacts/**/predictions_*.json
+specs/001-benchmark/e2e/artifacts/**/eval_*.json
+specs/001-benchmark/e2e/artifacts/**/eval_*.raw.json
+specs/001-benchmark/e2e/artifacts/**/logs/progress.jsonl
+specs/001-benchmark/e2e/artifacts/history/**/logs/
+```

--- a/specs/097-git-history/00-why.md
+++ b/specs/097-git-history/00-why.md
@@ -1,0 +1,57 @@
+# SPEC-097 — WHY (Five WHYs)
+
+> **Cross-refs**: [README](README.md) · [Laws](00-first-principles.md) · [GH-351 study](issues/GH-351-benchmark-history-disk.md)  
+> **Issue**: https://github.com/raphaelmansuy/edgequake/issues/351  
+> **Product pin**: EdgeQuake v0.22.0+
+
+---
+
+## Symptom (reporter)
+
+The repository is over 5 GB on disk. Cloning for source builds (e.g. containers) is very slow. The vast majority (~4 GB) sits under `specs/001-benchmark/e2e/artifacts/history/` — 160+ benchmark run folders with large `medical-mid-*` (~100 MB+) and `smoke-*` (~10–30 MB) trees.
+
+---
+
+## Five WHYs
+
+### WHY 1 — Why is the working tree / checkout so large?
+
+Because each `archive_run` copies full `predictions_*.json`, `eval_*.json`, `eval_*.raw.json`, and often `logs/progress.jsonl` into `history/<stage>-<timestamp>/`, and those files were committed to git.
+
+### WHY 2 — Why were they committed?
+
+Because Acc forensics and ladder progression treated the archive directory as the durable record. Thin scorecards were not distinguished from regenerable bulk JSON when publishing commits. Only `medical-full-*/predictions|eval` were later gitignored (GitHub 100 MB limit) — smoke/mid fat remained tracked.
+
+### WHY 3 — Why does deleting them in a new commit not fix clone time?
+
+Because git packs retain every historical blob. Tip `git rm` leaves ~4 GB of uncompressed history-path blobs (and ~700 MB compressed pack) until history is rewritten with [git-filter-repo](https://github.com/newren/git-filter-repo).
+
+### WHY 4 — Why not Git LFS?
+
+Because these files are **experiment scratch**, not distribution assets. LFS still costs bandwidth on clone/checkout for contributors who never run benches. Regenerable via `make bench001-*`; Acc claims already live in thin `publish/` SSOT.
+
+### WHY 5 — Why does this matter for open source?
+
+GitHub recommends repos ideally &lt; 1 GB and strongly &lt; 5 GB ([large files docs](https://docs.github.com/en/repositories/working-with-files/managing-large-files/about-large-files-on-github)). Slow clones tax every contributor, CI checkout, and container build — a structural barrier unrelated to product code quality.
+
+**Root cause:** Regenerable bulk benchmark outputs were versioned as if they were source. Policy and ignore rules never split **thin SSOT** from **fat forensics**, and packs were never rewritten after the bulk landed.
+
+---
+
+## Causal ASCII
+
+```
+  make bench001-* / archive_run
+           |
+           v
+  history/<run>/{scorecard,SUMMARY,...}   ← thin (~KB–MB)  →  SHOULD be in git
+  history/<run>/{predictions,eval,*.raw}  ← fat (~10–100MB) →  MUST be local-only
+           |
+           v
+  git commit (fat tracked) ──► pack grows ──► clone / CI / docker slow
+           |
+           +── tip gitignore alone ──► NEW commits OK, OLD blobs remain
+           |
+           v
+  git filter-repo --invert-paths ──► packs shrink ──► clone healthy
+```

--- a/specs/097-git-history/01-finding-register.md
+++ b/specs/097-git-history/01-finding-register.md
@@ -1,0 +1,24 @@
+# SPEC-097 — Finding Register
+
+> Measured on local clone 2026-08-01 (pre-rewrite). Uncompressed blob sizes via `git cat-file`.
+
+| ID | Finding | Evidence | Law | Disposition |
+|----|---------|----------|-----|-------------|
+| **F-351-01** | `history/` working tree ~4.4 GB / 164 runs | `du -sh specs/001-benchmark/e2e/artifacts/history` | G1 | Strip fat; keep thin |
+| **F-351-02** | History-path blobs ~4.17 GB (2073) in object DB | `git rev-list --objects --all -- …/history` | G4 | filter-repo invert |
+| **F-351-03** | Fat dominated by predictions/eval/raw (~4.2 GB WT) | basename size rollup | G3 | gitignore + rm --cached |
+| **F-351-04** | Thin keepables ~4 MB total | scorecard/SUMMARY/BUSINESS_REPORT rollup | G2 | Keep tracked |
+| **F-351-05** | `publish/` ~0.4 MB — Acc SSOT | blob sum under `artifacts/publish` | G2 | Unchanged |
+| **F-351-06** | GitHub repo size ~717 MB; pack ~700 MB | `gh api …/.size`, `git count-objects -vH` | G4 | Expect shrink post-rewrite |
+| **F-351-07** | Partial ignore only for `medical-full-*` fat | `.gitignore` lines 148–153 | G5 | Broaden globs |
+| **F-351-08** | `archive_run` always copies fat JSON | `tools/bench001/bench001/progress.py` | G3 | Keep local copy; emit LOCAL_ONLY |
+| **F-351-09** | `sdks/swift/.build` ~626 MB still in history | rev-list blob sum | G4 | Strip in rewrite |
+| **F-351-10** | `zz_test_docs` ~116 MB still in history | rev-list blob sum | G4 | Strip in rewrite |
+| **F-351-11** | Follow-up: large tracked PDFs / CSV outside history | e.g. `queryedgeQuake.csv` 45 MB, SPEC-049 PDFs | G1 | Out of scope #351; track as F-351-FUP |
+
+## Follow-ups (not this issue)
+
+| ID | Item | Notes |
+|----|------|-------|
+| **F-351-FUP-01** | `specs/012-performance/data/queryedgeQuake.csv` | Optional later strip / externalize |
+| **F-351-FUP-02** | SPEC-049 / API fixture PDFs | Keep if needed for tests; else LFS/releases |

--- a/specs/097-git-history/02-cross-ref-matrix.md
+++ b/specs/097-git-history/02-cross-ref-matrix.md
@@ -1,0 +1,15 @@
+# SPEC-097 — Cross-Ref Matrix
+
+| Surface | Path / symbol | Law | Finding | Gate |
+|---------|---------------|-----|---------|------|
+| Issue | [#351](https://github.com/raphaelmansuy/edgequake/issues/351) | G1–G6 | F-351-01 | — |
+| Ignore | [`.gitignore`](../../.gitignore) fat globs | G3, G5 | F-351-07 | G1 |
+| Archive | [`archive_run`](../../tools/bench001/bench001/progress.py) | G3 | F-351-08 | G2 |
+| Guard | [`tools/git-hygiene/check_no_fat_artifacts.sh`](../../tools/git-hygiene/check_no_fat_artifacts.sh) | G5 | F-351-03 | G4 |
+| Make | `make git-hygiene` | G5 | — | G4 |
+| CI | `.github/workflows/ci.yml` job `git-hygiene` | G5 | — | G4 |
+| Thin history | `specs/001-benchmark/e2e/artifacts/history/*/{scorecard,SUMMARY,…}` | G2 | F-351-04 | G3 |
+| Publish SSOT | `specs/001-benchmark/e2e/artifacts/publish/` | G2 | F-351-05 | — |
+| Rewrite | [`runbook/history-rewrite.md`](runbook/history-rewrite.md) | G4 | F-351-02,09,10 | G3, G5 |
+| Docs | [`specs/001-benchmark/e2e/README.md`](../001-benchmark/e2e/README.md) | G1 | — | — |
+| Contrib | [`CONTRIBUTING.md`](../../CONTRIBUTING.md) | G1 | — | — |

--- a/specs/097-git-history/03-implementation-roadmap.md
+++ b/specs/097-git-history/03-implementation-roadmap.md
@@ -1,0 +1,33 @@
+# SPEC-097 — Implementation Roadmap
+
+> **DoD**: Gates G1–G5 green; #351 closable with before/after pack metrics.
+
+## Wave 0 — Spec + inventory
+
+- [x] SPEC-097 pack under `specs/097-git-history/`
+- [x] Measured findings F-351-01…11
+
+## Wave 1 — Stop the bleeding (tip)
+
+- [x] Expand `.gitignore` fat globs (all stages, not only medical-full)
+- [x] `git rm --cached` tracked fat paths (leave on disk)
+- [x] `archive_run` writes `LOCAL_ONLY.md`; fat still copied locally
+- [x] Update SPEC-001 e2e README artifact layout
+- [x] `tools/git-hygiene/check_no_fat_artifacts.sh` + `make git-hygiene` + CI
+
+## Wave 2 — History rewrite
+
+- [ ] Fresh mirror clone
+- [ ] `git filter-repo --invert-paths` for fat globs + `sdks/swift/.build/**` + `zz_test_docs/**`
+- [ ] Verify history-path blob sum &lt; ~20 MB; pack shrink
+- [ ] Force-push rewritten refs; announce re-clone / PR rebase
+
+## Wave 3 — Closeout
+
+- [x] CONTRIBUTING note
+- [ ] Close #351 with metrics
+- [ ] Task log under `logs/`
+
+## Wave 4 — Gates
+
+See [04-e2e-test-matrix.md](04-e2e-test-matrix.md).

--- a/specs/097-git-history/04-e2e-test-matrix.md
+++ b/specs/097-git-history/04-e2e-test-matrix.md
@@ -1,0 +1,24 @@
+# SPEC-097 — Verification Gates
+
+| Gate | Command / check | Pass |
+|------|-----------------|------|
+| **G1** | `git ls-files` for fat globs | Zero paths |
+| **G2** | `archive_run` still produces thin + local fat + `LOCAL_ONLY.md` | Unit/manual OK |
+| **G3** | After rewrite: history-path uncompressed blob sum | &lt; ~20 MB |
+| **G4** | `make git-hygiene` | Exit 0 on clean tree; fails if fat staged or blob &gt; 50 MiB (non-allowlist) |
+| **G5** | Fresh clone / `git count-objects -vH` | Pack materially smaller than pre-rewrite ~700 MB |
+
+## Quick commands
+
+```bash
+make git-hygiene
+
+# G1
+git ls-files 'specs/001-benchmark/e2e/artifacts/**/predictions_*.json' | wc -l
+git ls-files 'specs/001-benchmark/e2e/artifacts/**/eval_*.json' | wc -l
+
+# G3 (post-rewrite)
+git rev-list --objects --all -- 'specs/001-benchmark/e2e/artifacts/history' \
+  | git cat-file --batch-check='%(objecttype) %(objectname) %(objectsize) %(rest)' \
+  | awk '/^blob/ {s+=$3; n++} END {printf "blobs=%d size=%.1f MB\n", n, s/1024/1024}'
+```

--- a/specs/097-git-history/05-edge-cases.md
+++ b/specs/097-git-history/05-edge-cases.md
@@ -1,0 +1,12 @@
+# SPEC-097 — Edge Cases
+
+| ID | Case | Handling |
+|----|------|----------|
+| **EC-01** | Open PRs after force-push | Rebase onto rewritten `edgequake-main`; do not merge pre-rewrite tip |
+| **EC-02** | Forks / old clones | Must **re-clone**; `git pull` resurrects deleted blobs |
+| **EC-03** | GitHub UI size lag | Server GC may delay; trust local `git count-objects -vH` |
+| **EC-04** | Accidental `git add -f` fat JSON | `make git-hygiene` / CI fails; remove from index |
+| **EC-05** | Local forensics still needed | Fat files remain on disk under `history/`; only untracked |
+| **EC-06** | Doc links to `predictions_*.json` | Rare; retarget to `scorecard.json` or `publish/peers` |
+| **EC-07** | `medical-full` already ignored | Broader globs supersede; keep behavior |
+| **EC-08** | Allowlisted large fixtures | Guard allowlist for intentional test fixtures if any remain &gt; 50 MiB |

--- a/specs/097-git-history/README.md
+++ b/specs/097-git-history/README.md
@@ -1,0 +1,71 @@
+# SPEC-097 — Git History Hygiene (GH-351)
+
+> **Product pin**: EdgeQuake v0.22.0+  
+> **Status**: Waves 0–4 — strip regenerable bench001 fat from tip + history  
+> **GitHub**: [#351](https://github.com/raphaelmansuy/edgequake/issues/351)  
+> **Inherits**: [SPEC-001 benchmark](../001-benchmark/) · [CONTRIBUTING.md](../../CONTRIBUTING.md)  
+> **Peers**: [git-filter-repo](https://github.com/newren/git-filter-repo) · [GitHub large files](https://docs.github.com/en/repositories/working-with-files/managing-large-files/about-large-files-on-github)
+
+## Start here
+
+1. [00-why.md](00-why.md) — Five WHYs + causal ASCII  
+2. [00-first-principles.md](00-first-principles.md) — LAW-G1…G6  
+3. [01-finding-register.md](01-finding-register.md) — F-351-*  
+4. [02-cross-ref-matrix.md](02-cross-ref-matrix.md) — code ↔ law ↔ guard  
+5. [03-implementation-roadmap.md](03-implementation-roadmap.md) — Waves 0–4 + DoD  
+6. [04-e2e-test-matrix.md](04-e2e-test-matrix.md) — gates G1–G5  
+7. [05-edge-cases.md](05-edge-cases.md) — EC register  
+8. Issue study → [`issues/GH-351-benchmark-history-disk.md`](issues/GH-351-benchmark-history-disk.md)  
+9. Rewrite runbook → [`runbook/history-rewrite.md`](runbook/history-rewrite.md)  
+10. Lenses → [`lenses/`](lenses/README.md)
+
+## Locked decisions
+
+1. **Git stores source + thin SSOT** — never regenerable bulk run outputs (LAW-G1).  
+2. **Acc / latency claims** live in `publish/latest`, `publish/peers/*`, and thin per-run `scorecard.json` + human reports (LAW-G2).  
+3. **Fat local-only**: `predictions_*.json`, `eval_*.json`, `eval_*.raw.json`, `logs/progress.jsonl` (LAW-G3).  
+4. **History rewrite required** — tip delete alone does not shrink clones (LAW-G4).  
+5. **Prevention**: expanded `.gitignore` + `make git-hygiene` (LAW-G5).  
+6. **No Git LFS** for these experiment scratch files (LAW-G6).  
+7. Keep **thin** `history/<run>/` in git (preserves SPEC-001 doc links).
+
+## Surfaces
+
+| Surface | Role |
+|---------|------|
+| `.gitignore` | Block fat globs from re-entry |
+| `tools/bench001/.../progress.py` `archive_run` | Still write fat locally; emit `LOCAL_ONLY.md` |
+| `tools/git-hygiene/check_no_fat_artifacts.sh` | CI / make guard |
+| `specs/001-benchmark/e2e/artifacts/history/` | Thin archives only in VCS |
+| `specs/001-benchmark/e2e/artifacts/publish/` | Acc SSOT (unchanged) |
+| `git filter-repo` runbook | One-shot pack reclaim |
+
+## Data flow
+
+```mermaid
+flowchart LR
+  Run[bench001 archive_run] --> Thin[scorecard SUMMARY BUSINESS_REPORT meta]
+  Run --> Fat[predictions eval raw progress.jsonl]
+  Thin --> Git[Git tracked]
+  Fat --> Local[Local disk only gitignored]
+  Git --> Publish[publish/latest + peers SSOT]
+  HistRewrite[git-filter-repo path strip] --> Pack[Smaller pack / faster clone]
+```
+
+## Verification
+
+```bash
+make git-hygiene
+git ls-files 'specs/001-benchmark/e2e/artifacts/**/predictions_*.json' | wc -l   # expect 0
+git ls-files 'specs/001-benchmark/e2e/artifacts/**/eval_*.json' | wc -l          # expect 0
+```
+
+See [04-e2e-test-matrix.md](04-e2e-test-matrix.md) for full gates. After Wave 2 rewrite, re-measure pack with `git count-objects -vH`.
+
+## Lens index
+
+| Lens | Primary question |
+|------|------------------|
+| [Product Owner](lenses/LENS-product-owner.md) | What is done for clone pain / #351? |
+| [DevOps / Git](lenses/LENS-devops-git.md) | Rewrite + force-push + re-clone |
+| [Benchmark tooling](lenses/LENS-benchmark-tooling.md) | archive_run + local-only fat |

--- a/specs/097-git-history/issues/GH-351-benchmark-history-disk.md
+++ b/specs/097-git-history/issues/GH-351-benchmark-history-disk.md
@@ -1,0 +1,29 @@
+# Issue study — GH-351 Benchmark history disk storage
+
+> **Issue**: https://github.com/raphaelmansuy/edgequake/issues/351  
+> **Reporter**: [@msc2106](https://github.com/msc2106) (2026-07-29)  
+> **Owner**: will fix for next release ([comment](https://github.com/raphaelmansuy/edgequake/issues/351#issuecomment-5144508196))  
+> **SPEC**: [SPEC-097](../README.md)
+
+## Reporter ask
+
+> Is it necessary to include benchmark run results in version control?
+
+## Answer (first principles)
+
+| Artifact class | In VCS? | Why |
+|----------------|---------|-----|
+| Thin scorecard / SUMMARY / BUSINESS_REPORT / publish peers | **Yes** | Small Acc SSOT; doc links |
+| Fat predictions / eval / raw / progress.jsonl | **No** | Regenerable; dominate clone size |
+| Build ghosts (`sdks/swift/.build`, `zz_test_docs`) | **No** | Already tip-ignored; strip from history |
+
+## Verification of claims
+
+Reporter’s path and scale match local measurement: ~4.4 GB under `history/`, per-run mid ~100 MB+, smoke tens of MB, 160+ folders. GitHub repo size ~717 MB (compressed pack); tip checkout still materializes multi-GB trees when fat is present.
+
+## Acceptance for close
+
+1. Fat globs untracked (G1).  
+2. History rewritten; history-path blob sum thin-only (G3).  
+3. Guard + CONTRIBUTING prevent recurrence (G4/G5).  
+4. Comment on #351 with before/after `size-pack` / GitHub size.

--- a/specs/097-git-history/lenses/LENS-benchmark-tooling.md
+++ b/specs/097-git-history/lenses/LENS-benchmark-tooling.md
@@ -1,0 +1,15 @@
+# Lens — Benchmark tooling
+
+## `archive_run` contract (post SPEC-097)
+
+| File | Written locally | Tracked in git |
+|------|-----------------|----------------|
+| `scorecard.json`, `SUMMARY.md`, `BUSINESS_REPORT.md`, `EXEC_SUMMARY.txt`, `meta.json`, `eq_workspace.json`, `progress.json`, `LIVE.md` | Yes | Yes (thin) |
+| `predictions_*.json`, `eval_*.json`, `eval_*.raw.json`, `logs/progress.jsonl` | Yes (forensics) | **No** |
+| `LOCAL_ONLY.md` | Yes | Yes (points at ignored fat) |
+
+## Operator notes
+
+- Ladder `PROGRESS.md` still aggregates from `history/*/scorecard.json`.  
+- Forensics scripts that need predictions must use a local archive path after a bench run.  
+- Never `git add -f` fat JSON.

--- a/specs/097-git-history/lenses/LENS-devops-git.md
+++ b/specs/097-git-history/lenses/LENS-devops-git.md
@@ -1,0 +1,17 @@
+# Lens — DevOps / Git
+
+## Rules
+
+- Tip cleanup without rewrite is incomplete (LAW-G4).  
+- Use `git-filter-repo` in a mirror clone; never rewrite casually on a dirty shared worktree.  
+- Force-push requires re-clone announcement (EC-01, EC-02).  
+- `make git-hygiene` runs on every CI push/PR (LAW-G5).
+
+## Ops checklist
+
+1. Backup mirror.  
+2. Filter paths (runbook).  
+3. Verify blob sums.  
+4. `--force --mirror` push.  
+5. Notify PR authors.  
+6. Expect GitHub size UI lag (EC-03).

--- a/specs/097-git-history/lenses/LENS-product-owner.md
+++ b/specs/097-git-history/lenses/LENS-product-owner.md
@@ -1,0 +1,14 @@
+# Lens — Product Owner
+
+## Done means
+
+1. Contributors can clone EdgeQuake without downloading multi-GB regenerable bench JSON.  
+2. Acc / latency **claims** remain auditable via thin `publish/` + `history/*/scorecard.json`.  
+3. Future bench runs cannot re-bloat the remote (ignore + CI guard).  
+4. [#351](https://github.com/raphaelmansuy/edgequake/issues/351) closed with before/after metrics.
+
+## Non-goals
+
+- Changing Acc methodology or peer semantics.  
+- Hosting fat archives on LFS/S3 in this SPEC.  
+- Deleting operators’ local `history/` forensics.

--- a/specs/097-git-history/lenses/README.md
+++ b/specs/097-git-history/lenses/README.md
@@ -1,0 +1,15 @@
+# SPEC-097 — Lenses
+
+Each lens cites laws from [00-first-principles.md](../00-first-principles.md) and findings from [01-finding-register.md](../01-finding-register.md).
+
+| Lens | File | Primary question |
+|------|------|------------------|
+| Product Owner | [LENS-product-owner.md](LENS-product-owner.md) | What is done for #351 / clone pain? |
+| DevOps / Git | [LENS-devops-git.md](LENS-devops-git.md) | How do we rewrite safely and prevent relapse? |
+| Benchmark tooling | [LENS-benchmark-tooling.md](LENS-benchmark-tooling.md) | How does archive_run behave after the split? |
+
+## Reading order
+
+1. Product Owner  
+2. DevOps / Git  
+3. Benchmark tooling  

--- a/specs/097-git-history/runbook/history-rewrite.md
+++ b/specs/097-git-history/runbook/history-rewrite.md
@@ -1,0 +1,77 @@
+# SPEC-097 — History rewrite runbook
+
+> **LAW-G4**. Use a **fresh mirror clone**. Tool: [git-filter-repo](https://github.com/newren/git-filter-repo).  
+> Destructive: rewrites all SHAs. Coordinate force-push; contributors re-clone.
+
+## Preconditions
+
+```bash
+# Backup
+git clone --mirror git@github.com:raphaelmansuy/edgequake.git edgequake-mirror-backup.git
+
+# Work clone
+git clone --mirror git@github.com:raphaelmansuy/edgequake.git edgequake-filter.git
+cd edgequake-filter.git
+```
+
+Record before metrics:
+
+```bash
+git count-objects -vH
+gh api repos/raphaelmansuy/edgequake --jq '{size_kb:.size}'
+```
+
+## Filter
+
+```bash
+git filter-repo --force --invert-paths \
+  --path-glob 'specs/001-benchmark/e2e/artifacts/**/predictions_*.json' \
+  --path-glob 'specs/001-benchmark/e2e/artifacts/**/eval_*.json' \
+  --path-glob 'specs/001-benchmark/e2e/artifacts/**/eval_*.raw.json' \
+  --path-glob 'specs/001-benchmark/e2e/artifacts/**/logs/**' \
+  --path-glob 'sdks/swift/.build/**' \
+  --path-glob 'zz_test_docs/**'
+```
+
+Note: `git filter-repo` removes `origin`. Re-add before push:
+
+```bash
+git remote add origin git@github.com:raphaelmansuy/edgequake.git
+```
+
+## Verify
+
+```bash
+git count-objects -vH
+
+git rev-list --objects --all -- 'specs/001-benchmark/e2e/artifacts/history' \
+  | git cat-file --batch-check='%(objecttype) %(objectname) %(objectsize) %(rest)' \
+  | awk '/^blob/ {s+=$3; n++} END {printf "blobs=%d size=%.1f MB\n", n, s/1024/1024}'
+# Target: << 20 MB uncompressed for history path
+```
+
+## Push
+
+```bash
+git push --force --mirror origin
+```
+
+## Announce (issue / Discussions)
+
+```text
+SPEC-097 / GH-351: git history rewritten to remove regenerable bench001 fat JSON
+and build ghosts (swift .build, zz_test_docs).
+
+All commit SHAs changed. Please:
+1. Re-clone (do not pull old clones).
+2. Rebase open PRs onto the new edgequake-main tip.
+
+Thin history/<run>/ scorecards and publish/ peers are preserved.
+```
+
+## Local working copy after rewrite
+
+```bash
+# Preferred: fresh clone
+git clone git@github.com:raphaelmansuy/edgequake.git
+```

--- a/tools/bench001/bench001/progress.py
+++ b/tools/bench001/bench001/progress.py
@@ -453,35 +453,76 @@ def empty_context_rate(preds: list[dict[str, Any]]) -> float:
     return empty / len(preds)
 
 
+# Thin SSOT — safe to commit (SPEC-097 / LAW-G2).
+_ARCHIVE_THIN = (
+    "scorecard.json",
+    "SUMMARY.md",
+    "BUSINESS_REPORT.md",
+    "EXEC_SUMMARY.txt",
+    "meta.json",
+    "eq_workspace.json",
+    "progress.json",
+    "LIVE.md",
+)
+
+# Fat regenerable forensics — local-only, gitignored (SPEC-097 / LAW-G3).
+_ARCHIVE_FAT = (
+    "eval_eq.json",
+    "eval_lr.json",
+    "eval_eq.raw.json",
+    "eval_lr.raw.json",
+    "predictions_eq.json",
+    "predictions_lr.json",
+)
+
+
+def _write_local_only_md(dest: Path, *, present_fat: list[str]) -> None:
+    """Document which archive files must not be committed (SPEC-097)."""
+    lines = [
+        "# LOCAL_ONLY — fat bench001 artifacts (SPEC-097 / GH-351)",
+        "",
+        "These files are written for local forensics and are **gitignored**.",
+        "Do not `git add -f` them. Acc claims live in `scorecard.json` /",
+        "`SUMMARY.md` / `publish/` peers.",
+        "",
+        "Regenerate via `make bench001-*`.",
+        "",
+    ]
+    if present_fat:
+        lines.append("Present in this archive:")
+        lines.append("")
+        for name in present_fat:
+            lines.append(f"- `{name}`")
+        lines.append("")
+    else:
+        lines.append("_No fat files were present when this archive was written._")
+        lines.append("")
+    (dest / "LOCAL_ONLY.md").write_text("\n".join(lines), encoding="utf-8")
+
+
 def archive_run(stage: str, scorecard: dict[str, Any]) -> Path:
-    """Copy key artifacts into history/<stage>-<timestamp>/ and refresh PROGRESS.md."""
+    """Copy key artifacts into history/<stage>-<timestamp>/ and refresh PROGRESS.md.
+
+    Thin scorecards/reports stay VCS-eligible; fat predictions/eval/logs are
+    copied locally only (SPEC-097 / GH-351).
+    """
     ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
     dest = history_root() / f"{stage}-{ts}"
     dest.mkdir(parents=True, exist_ok=True)
     src = stage_artifact_dir(stage)
-    for name in (
-        "scorecard.json",
-        "SUMMARY.md",
-        "BUSINESS_REPORT.md",
-        "EXEC_SUMMARY.txt",
-        "meta.json",
-        "eq_workspace.json",
-        "progress.json",
-        "LIVE.md",
-        "eval_eq.json",
-        "eval_lr.json",
-        "eval_eq.raw.json",
-        "eval_lr.raw.json",
-        "predictions_eq.json",
-        "predictions_lr.json",
-    ):
+    present_fat: list[str] = []
+    for name in _ARCHIVE_THIN + _ARCHIVE_FAT:
         p = src / name
         if p.exists():
             shutil.copy2(p, dest / name)
+            if name in _ARCHIVE_FAT:
+                present_fat.append(name)
     logs_src = src / "logs" / "progress.jsonl"
     if logs_src.exists():
         (dest / "logs").mkdir(exist_ok=True)
         shutil.copy2(logs_src, dest / "logs" / "progress.jsonl")
+        present_fat.append("logs/progress.jsonl")
+    _write_local_only_md(dest, present_fat=present_fat)
     write_progress_md(scorecard=scorecard, archive_dir=dest)
     return dest
 

--- a/tools/bench001/tests/test_context_and_progress.py
+++ b/tools/bench001/tests/test_context_and_progress.py
@@ -147,6 +147,9 @@ def test_progress_archive_and_ledger(tmp_path, monkeypatch):
     assert hist.exists()
     assert (hist / "scorecard.json").exists()
     assert (hist / "LIVE.md").exists()
+    local_only = hist / "LOCAL_ONLY.md"
+    assert local_only.exists()
+    assert "SPEC-097" in local_only.read_text(encoding="utf-8")
     prog = write_progress_md()
     text = prog.read_text(encoding="utf-8")
     assert "SPEC-001 progression ladder" in text

--- a/tools/git-hygiene/check_no_fat_artifacts.sh
+++ b/tools/git-hygiene/check_no_fat_artifacts.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# SPEC-097 / GH-351 — fail if regenerable fat bench artifacts or oversized blobs are tracked.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+MAX_BLOB_BYTES=$((50 * 1024 * 1024)) # 50 MiB (GitHub warning threshold)
+FAIL=0
+
+echo "==> SPEC-097 git-hygiene: fat artifact globs"
+
+mapfile -t fat_hits < <(
+  {
+    git ls-files -- \
+      'specs/001-benchmark/e2e/artifacts/**/predictions_*.json' \
+      'specs/001-benchmark/e2e/artifacts/**/eval_*.json' \
+      'specs/001-benchmark/e2e/artifacts/**/eval_*.raw.json' \
+      'specs/001-benchmark/e2e/artifacts/**/logs/progress.jsonl' \
+      'specs/001-benchmark/e2e/artifacts/history/**/logs/**' \
+      2>/dev/null || true
+    git ls-files 'specs/001-benchmark/e2e/artifacts' \
+      | grep -E '(^|/)(predictions_[^/]+\.json|eval_[^/]+\.json)$' || true
+    git ls-files 'specs/001-benchmark/e2e/artifacts/history' \
+      | grep -E '/logs/' || true
+  } | sort -u
+)
+
+if ((${#fat_hits[@]} > 0)) && [[ -n "${fat_hits[0]:-}" ]]; then
+  echo "ERROR: tracked fat regenerable artifacts (SPEC-097 / LAW-G3):" >&2
+  printf '  %s\n' "${fat_hits[@]}" >&2
+  FAIL=1
+else
+  echo "OK: no fat bench001 artifacts tracked"
+fi
+
+echo "==> SPEC-097 git-hygiene: index blobs > 50 MiB"
+
+# Build hash→path map from index, then batch-check sizes (fast).
+tmp_map="$(mktemp)"
+tmp_sizes="$(mktemp)"
+trap 'rm -f "$tmp_map" "$tmp_sizes"' EXIT
+
+git ls-files -s | awk '{print $2 "\t" $4}' >"$tmp_map"
+awk -F'\t' '{print $1}' "$tmp_map" | git cat-file --batch-check='%(objectname) %(objectsize)' >"$tmp_sizes"
+
+oversized=()
+while read -r hash size; do
+  [[ "$size" =~ ^[0-9]+$ ]] || continue
+  if (( size > MAX_BLOB_BYTES )); then
+    path="$(awk -F'\t' -v h="$hash" '$1==h {print $2; exit}' "$tmp_map")"
+    oversized+=("$size ${path:-$hash}")
+  fi
+done <"$tmp_sizes"
+
+if ((${#oversized[@]} > 0)); then
+  echo "ERROR: tracked tip blobs larger than 50 MiB:" >&2
+  printf '  %s\n' "${oversized[@]}" >&2
+  echo "Remove/gitignore them (SPEC-097). Large intentional fixtures need a SPEC exception." >&2
+  FAIL=1
+else
+  echo "OK: no index blobs over 50 MiB"
+fi
+
+if ((FAIL != 0)); then
+  echo "git-hygiene FAILED — see specs/097-git-history/" >&2
+  exit 1
+fi
+
+echo "git-hygiene PASSED"
+exit 0


### PR DESCRIPTION
## Summary
- Implements [SPEC-097](specs/097-git-history/) / closes [#351](https://github.com/raphaelmansuy/edgequake/issues/351): stop tracking regenerable bench001 fat JSON; keep thin scorecards + `publish/` SSOT.
- Expands `.gitignore`, updates `archive_run` to emit `LOCAL_ONLY.md`, adds `make git-hygiene` + CI job.
- **History rewrite already applied** to `edgequake-main` via `git-filter-repo` (fat paths + `sdks/swift/.build` + `zz_test_docs` stripped). Pack ~743 MiB → ~433 MiB; history-path blobs ~4173 MB → ~4.5 MB.

## Test plan
- [x] `make git-hygiene` passes
- [x] `pytest tools/bench001/tests/test_context_and_progress.py` (LOCAL_ONLY.md)
- [x] Remote tip `edgequake-main` / this branch: zero tracked `predictions_*.json` / `eval_*.json` under artifacts
- [ ] Reviewers: after merge, re-clone (old clones should not pull; SHAs changed)

## Contributor note
Open PRs based on pre-rewrite SHAs need rebase onto the new `edgequake-main`.