### PR TITLE
docs: fix broken star history chart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -478,4 +478,4 @@ Apache License, Version 2.0 — see [LICENSE](LICENSE).
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=raphaelmansuy/edgequake&type=date&legend=top-left)](https://www.star-history.com/#raphaelmansuy/edgequake&type=date&legend=top-left)
+[![Star History Chart](https://star-history.dera.page/svg?repos=raphaelmansuy/edgequake&type=date&legend=top-left)](https://star-history.dera.page/#raphaelmansuy/edgequake&type=date&legend=top-left)


### PR DESCRIPTION
The star history chart on the README is currently broken: the image fails to render because the service it depends on hit GitHub stargazer API restrictions. This change moves the chart and its wrapping link to a working service so visitors can see the project's growth again.

No functional code is affected, only the README.