### PR TITLE
Add named OrcaRouter provider (OpenAI-compatible gateway)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -82,6 +82,16 @@ VLM_PROCESS_ENABLE=true
 #   - Embedding: text-embedding-3-small (1536 dimensions)
 
 # -----------------------------------------------------------------------------
+# Option 1b: OrcaRouter (Cloud gateway, requires API key)
+# -----------------------------------------------------------------------------
+# OrcaRouter is a unified AI gateway exposing frontier models via an
+# OpenAI-compatible API. https://www.orcarouter.ai
+# EDGEQUAKE_LLM_PROVIDER=orcarouter
+# EDGEQUAKE_LLM_MODEL=orcarouter/auto
+# ORCAROUTER_API_KEY=sk-orca-your-key-here
+# ORCAROUTER_BASE_URL=https://api.orcarouter.ai/v1
+
+# -----------------------------------------------------------------------------
 # Option 2: Ollama (Local/remote, self-hosted) - RECOMMENDED FOR DEVELOPMENT
 # -----------------------------------------------------------------------------
 OLLAMA_HOST=http://localhost:11434

--- a/docs/operations/configuration.md
+++ b/docs/operations/configuration.md
@@ -203,6 +203,13 @@ Design reference: [SPEC-043 §011 — Vertex AI Authentication](../specs/043-upd
 | `OPENROUTER_API_KEY`  | String | None                        | OpenRouter API key (required) |
 | `OPENROUTER_BASE_URL` | String | `https://openrouter.ai/api` | API endpoint                  |
 
+#### OrcaRouter
+
+| Variable              | Type   | Default                       | Description                             |
+| --------------------- | ------ | ----------------------------- | --------------------------------------- |
+| `ORCAROUTER_API_KEY`  | String | None                          | OrcaRouter API key (`sk-orca-…`) (required) |
+| `ORCAROUTER_BASE_URL` | String | `https://api.orcarouter.ai/v1` | API endpoint                            |
+
 #### MiniMax
 
 | Variable           | Type   | Default                     | Description                                                |
@@ -533,6 +540,7 @@ image_per_unit = 0.0
 | `vertexai`   | Google Vertex AI (enterprise) | **Identity** — `GOOGLE_CLOUD_PROJECT` + ADC/SA (no static API key) |
 | `xai`        | xAI Grok models         | `XAI_API_KEY`          |
 | `openrouter` | OpenRouter aggregator   | `OPENROUTER_API_KEY`   |
+| `orcarouter` | OrcaRouter AI gateway   | `ORCAROUTER_API_KEY`   |
 | `minimax`    | MiniMax AI models       | `MINIMAX_API_KEY`      |
 | `azure`      | Azure OpenAI            | `AZURE_OPENAI_API_KEY` |
 | `ollama`     | Ollama local models     | None (local)           |
@@ -812,6 +820,44 @@ supports_streaming = true
 input_per_1k = 0.00015
 output_per_1k = 0.0006
 ```
+
+### OrcaRouter
+
+```toml
+[[providers]]
+name = "orcarouter"
+display_name = "OrcaRouter"
+type = "openaicompatible"
+api_base = "https://api.orcarouter.ai/v1"
+api_key_env = "ORCAROUTER_API_KEY"
+enabled = true
+priority = 19
+
+[[providers.models]]
+name = "orcarouter/auto"
+display_name = "OrcaRouter Auto"
+model_type = "llm"
+tags = ["recommended"]
+
+[providers.models.capabilities]
+context_length = 200000
+max_output_tokens = 32768
+supports_vision = true
+supports_streaming = true
+
+[providers.models.cost]
+input_per_1k = 0.0
+output_per_1k = 0.0
+```
+
+OrcaRouter ([orcarouter.ai](https://www.orcarouter.ai)) is a unified AI gateway
+that exposes frontier models through an OpenAI-compatible chat completions API at
+`https://api.orcarouter.ai/v1`. It also runs gateway-level, zero-trust security for
+AI agents on the same endpoint — screening every prompt/response and governing every
+tool call on a default-deny basis, with no application code changes.
+
+Set `ORCAROUTER_API_KEY` (an `sk-orca-…` key) to use the OrcaRouter provider. The
+model `orcarouter/auto` routes automatically to a suitable model.
 
 ---
 

--- a/edgequake/crates/edgequake-api/src/attribution.rs
+++ b/edgequake/crates/edgequake-api/src/attribution.rs
@@ -221,6 +221,7 @@ fn humanize_provider_id(id: &str) -> String {
         "gemini" => "Google Gemini".into(),
         "vertexai" => "Google Vertex AI".into(),
         "openrouter" => "OpenRouter".into(),
+        "orcarouter" => "OrcaRouter".into(),
         "mistral" => "Mistral AI".into(),
         "nvidia" => "NVIDIA NIM".into(),
         "cohere" => "Cohere".into(),

--- a/edgequake/crates/edgequake-api/src/openapi_examples.rs
+++ b/edgequake/crates/edgequake-api/src/openapi_examples.rs
@@ -157,6 +157,13 @@ fn domain_examples() -> HashMap<&'static str, Value> {
                         "attribution_support": "full",
                         "headers": ["HTTP-Referer", "X-OpenRouter-Title", "X-Title"],
                         "body_fields": []
+                    },
+                    {
+                        "id": "orcarouter",
+                        "display_name": "OrcaRouter",
+                        "attribution_support": "full",
+                        "headers": [],
+                        "body_fields": []
                     }
                 ],
                 "ingress_headers": [

--- a/edgequake/crates/edgequake-api/src/providers/credentials.rs
+++ b/edgequake/crates/edgequake-api/src/providers/credentials.rs
@@ -102,6 +102,7 @@ pub fn llm_provider_credentials_configured_by_name(provider_name: &str) -> bool 
         "nvidia" => env_non_empty("NVIDIA_API_KEY"),
         "cohere" => env_non_empty("COHERE_API_KEY"),
         "jina" => env_non_empty("JINA_API_KEY"),
+        "orcarouter" => env_non_empty("ORCAROUTER_API_KEY"),
         "huggingface" | "hf" => env_non_empty("HF_TOKEN") || env_non_empty("HUGGINGFACE_TOKEN"),
         "vscode-copilot" | "copilot" => true,
         _ => true,
@@ -338,6 +339,16 @@ mod tests {
     #[test]
     fn mock_always_configured() {
         assert!(llm_provider_credentials_configured_by_name("mock"));
+    }
+
+    #[test]
+    fn orcarouter_requires_orca_key_env() {
+        let prev = save_env("ORCAROUTER_API_KEY");
+        std::env::remove_var("ORCAROUTER_API_KEY");
+        assert!(!llm_provider_credentials_configured_by_name("orcarouter"));
+        std::env::set_var("ORCAROUTER_API_KEY", "sk-orca-test");
+        assert!(llm_provider_credentials_configured_by_name("orcarouter"));
+        restore_env("ORCAROUTER_API_KEY", prev);
     }
 
     #[test]

--- a/edgequake/crates/edgequake-api/src/safety_limits.rs
+++ b/edgequake/crates/edgequake-api/src/safety_limits.rs
@@ -462,6 +462,7 @@ fn check_api_key(provider_name: &str) -> Result<()> {
         "mistral" => ("MISTRAL_API_KEY", "Mistral"),
         "xai" => ("XAI_API_KEY", "xAI"),
         "openrouter" => ("OPENROUTER_API_KEY", "OpenRouter"),
+        "orcarouter" => ("ORCAROUTER_API_KEY", "OrcaRouter"),
         "nvidia" => ("NVIDIA_API_KEY", "NVIDIA NIM"),
         "cohere" => ("COHERE_API_KEY", "Cohere"),
         "jina" => ("JINA_API_KEY", "Jina AI"),
@@ -491,10 +492,50 @@ fn create_inner_llm_provider(
     if provider == "vertexai" || provider == "vertex" {
         return create_vertex_llm_via_adc(model, ctx);
     }
+    if provider == "orcarouter" {
+        return create_orcarouter_llm_provider(model, ctx);
+    }
     match ctx {
         Some(ctx) => ProviderFactory::create_llm_provider_with_context(provider_name, model, ctx),
         None => ProviderFactory::create_llm_provider(provider_name, model),
     }
+}
+
+/// Create an OrcaRouter LLM provider (OpenAI-compatible gateway).
+///
+/// OrcaRouter (<https://www.orcarouter.ai>) is a unified AI gateway exposing an
+/// OpenAI-compatible chat completions API at `https://api.orcarouter.ai/v1`. It
+/// authenticates with `Authorization: Bearer` using an `sk-orca-…` key read from
+/// the `ORCAROUTER_API_KEY` environment variable.
+fn create_orcarouter_llm_provider(
+    model: &str,
+    ctx: Option<ApplicationContext>,
+) -> Result<Arc<dyn LLMProvider>> {
+    let config = edgequake_llm::ProviderConfig {
+        name: "orcarouter".to_string(),
+        display_name: "OrcaRouter".to_string(),
+        provider_type: edgequake_llm::ConfigProviderType::OpenAICompatible,
+        api_key_env: Some("ORCAROUTER_API_KEY".to_string()),
+        api_key: None,
+        base_url: Some("https://api.orcarouter.ai/v1".to_string()),
+        base_url_env: None,
+        default_llm_model: Some(model.to_string()),
+        default_embedding_model: None,
+        models: Vec::new(),
+        enabled: true,
+        priority: 19,
+        description: "OrcaRouter - unified AI gateway for frontier models".to_string(),
+        settings: Default::default(),
+        headers: Default::default(),
+        timeout_seconds: 120,
+        supports_thinking: false,
+    };
+    let mut provider = edgequake_llm::OpenAICompatibleProvider::from_config(config)?;
+    provider = provider.with_model(model);
+    if let Some(ctx) = ctx {
+        provider = provider.with_application_context(ctx);
+    }
+    Ok(Arc::new(provider))
 }
 
 fn create_vertex_llm_via_adc(
@@ -1253,6 +1294,7 @@ pub fn default_model_for_provider(provider_name: &str) -> &'static str {
         "gemini" => "gemini-2.5-flash",
         "xai" => "grok-4-1-fast",
         "openrouter" => "openai/gpt-4o-mini",
+        "orcarouter" => "orcarouter/auto",
         "mistral" => "mistral-small-latest",
         "ollama" => "gemma4:latest",
         "lmstudio" | "lm-studio" | "lm_studio" => "gemma-3n-e4b-it",
@@ -1397,5 +1439,20 @@ mod issue255_gateway_model_tests {
         clear_gateway_env();
         assert!(is_model_provider_mismatch("openai", "gemma3:latest"));
         clear_gateway_env();
+    }
+
+    #[test]
+    #[serial]
+    fn orcarouter_gateway_slash_model_not_mismatch() {
+        clear_gateway_env();
+        // orcarouter/auto is a gateway-routed model — never flagged as a mismatch.
+        assert!(!is_model_provider_mismatch("orcarouter", "orcarouter/auto"));
+        clear_gateway_env();
+    }
+
+    #[test]
+    #[serial]
+    fn orcarouter_default_model_is_auto() {
+        assert_eq!(default_model_for_provider("orcarouter"), "orcarouter/auto");
     }
 }

--- a/edgequake/docs/configuration.md
+++ b/edgequake/docs/configuration.md
@@ -122,6 +122,7 @@ Structured roles (extract/summary/keyword/vlm) default to the **lowest supported
 | Vertex AI    | `vertexai` | **Identity** | Enterprise — `GOOGLE_CLOUD_PROJECT` + ADC/SA (see below) |
 | Mistral      | `mistral`  | API key      | Requires `MISTRAL_API_KEY`                               |
 | Azure OpenAI | `azure`    | API key      | Set `base_url` to your Azure endpoint                    |
+| OrcaRouter   | `orcarouter` | API key   | OpenAI-compatible gateway — `ORCAROUTER_API_KEY`, `https://api.orcarouter.ai/v1` |
 | Ollama       | `ollama`   | None (local) | Set `base_url` to `http://localhost:11434`               |
 
 ### Google Vertex AI (identity auth)

--- a/edgequake/models.toml
+++ b/edgequake/models.toml
@@ -29,6 +29,7 @@
 #   - xAI: grok-4.3 (LLM)
 #   - MiniMax: MiniMax-M2.7 (LLM)
 #   - OpenRouter: openai/gpt-4o-mini (LLM)
+#   - OrcaRouter: orcarouter/auto (LLM)
 #   - Ollama: gemma4:latest (LLM), embeddinggemma (embedding)
 #   - LM Studio: gemma-3n-e4b-it (LLM), text-embedding-nomic-embed-text-v1.5 (embedding)
 
@@ -2237,6 +2238,47 @@ embedding_dimension = 0
 [providers.models.cost]
 input_per_1k = 0.003
 output_per_1k = 0.003
+embedding_per_1k = 0.0
+image_per_unit = 0.0
+
+# =============================================================================
+# ORCAROUTER PROVIDER
+# =============================================================================
+# OrcaRouter - unified gateway for 200+ frontier models and AI-agent security
+# Requires: ORCAROUTER_API_KEY environment variable
+# OpenAI-compatible chat completions API (Bearer auth).
+
+[[providers]]
+name = "orcarouter"
+display_name = "OrcaRouter"
+type = "openaicompatible"
+api_base = "https://api.orcarouter.ai/v1"
+api_key_env = "ORCAROUTER_API_KEY"
+enabled = true
+priority = 19
+description = "OrcaRouter - unified AI gateway for frontier models with gateway-level, zero-trust security for AI agents"
+
+[[providers.models]]
+name = "orcarouter/auto"
+display_name = "Auto (via OrcaRouter)"
+model_type = "llm"
+description = "OrcaRouter automatic model routing"
+deprecated = false
+tags = ["recommended", "fast"]
+
+[providers.models.capabilities]
+context_length = 200000
+max_output_tokens = 32768
+supports_vision = true
+supports_function_calling = true
+supports_json_mode = true
+supports_streaming = true
+supports_system_message = true
+embedding_dimension = 0
+
+[providers.models.cost]
+input_per_1k = 0.0
+output_per_1k = 0.0
 embedding_per_1k = 0.0
 image_per_unit = 0.0
 


### PR DESCRIPTION
## Description

Add a first-class named `orcarouter` provider so EdgeQuake can route LLM traffic through the [OrcaRouter](https://www.orcarouter.ai) AI gateway. OrcaRouter exposes an OpenAI-compatible chat completions API at `https://api.orcarouter.ai/v1` and authenticates with a Bearer `sk-orca-…` key. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

This mirrors the existing named `openrouter` provider pattern rather than requiring users to fall back to a generic OpenAI-compatible endpoint.

### Changes

- **`edgequake/models.toml`**: new `[[providers]]` block for `orcarouter` (`type = "openaicompatible"`, `api_base = https://api.orcarouter.ai/v1`, `api_key_env = ORCAROUTER_API_KEY`) with an `orcarouter/auto` model card.
- **`edgequake-api` runtime dispatch** (`safety_limits.rs`): `create_inner_llm_provider` now builds an `OpenAICompatibleProvider` for `orcarouter` from the `ORCAROUTER_API_KEY` env var (the crate has no built-in `OrcaRouter` ProviderType, so this mirrors the existing `vertexai` special-case). Also wires `check_api_key`, `default_model_for_provider`, and the credentials gate.
- **`providers/credentials.rs`**: `orcarouter` maps to `ORCAROUTER_API_KEY`.
- **`attribution.rs` / `openapi_examples.rs`**: OrcaRouter display name + example provider entry.
- **Docs & config**: `.env.example`, `docs/operations/configuration.md`, and `docs/configuration.md` document the new provider.

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Other (describe below)

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes

### Test evidence

- `cargo check -p edgequake-api` passes; `cargo fmt --all -- --check` clean; no new clippy warnings.
- New unit tests: `credentials::tests::orcarouter_requires_orca_key_env`, `safety_limits::issue255_gateway_model_tests::orcarouter_gateway_slash_model_not_mismatch`, `orcarouter_default_model_is_auto` — all pass (10/10 in the scoped run).
- L3 live test against `https://api.orcarouter.ai/v1/chat/completions` with `orcarouter/auto` returned **HTTP 200** (`content = "ORCA-LIVE-OK"`).

Disclosure: I'm an engineer on the OrcaRouter team.
