### PR TITLE
feat(langfuse): support Langfuse ≥2.x + cost sync

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2099,6 +2099,20 @@ langfuse-smoke: ## Health + GET /api/public/projects (headless init keys)
 		LANGFUSE_LOCAL_PROJECT_ID="$(LANGFUSE_LOCAL_PROJECT_ID)" \
 		$(ROOT_DIR)/scripts/langfuse_local_smoke.sh
 
+langfuse-sync-prices: ## Push models.toml pricing into Langfuse (fixes $0.00 cost)
+	@echo "$(YELLOW)→ Syncing EdgeQuake model prices into Langfuse...$(RESET)"
+	@# WHY: Langfuse prices observations from ITS OWN catalogue, and EdgeQuake never
+	@# emits cost attributes (LAW-124-12 — Langfuse stays the single source of truth
+	@# for cost). A self-hosted Langfuse only knows the models its bundled catalogue
+	@# shipped with: 3.1 carries a 2024 list (gpt-4o but no gpt-5, gemini-1.5 but no
+	@# 2.5, claude-3.5 but no 4.x, zero Mistral), so every newer model costs $$0.00.
+	@# This pushes models.toml pricing so cost works for every provider.
+	@set -a; [ -f "$(ROOT_DIR)/.env" ] && . "$(ROOT_DIR)/.env"; set +a; \
+	LANGFUSE_BASE_URL="$${LANGFUSE_BASE_URL:-$(LANGFUSE_UI_URL)}" \
+	LANGFUSE_PUBLIC_KEY="$${LANGFUSE_PUBLIC_KEY:-$(LANGFUSE_LOCAL_PK)}" \
+	LANGFUSE_SECRET_KEY="$${LANGFUSE_SECRET_KEY:-$(LANGFUSE_LOCAL_SK)}" \
+	python3 $(ROOT_DIR)/scripts/langfuse_sync_model_prices.py $(if $(DRY_RUN),--dry-run) $(if $(FORCE),--force)
+
 langfuse-reset: ## Delete local Langfuse volumes (CONFIRM=yes required)
 	@if [ "$(CONFIRM)" != "yes" ]; then \
 		echo "$(RED)Refusing to wipe Langfuse volumes.$(RESET)"; \

--- a/docs/documentation_interne/04-langfuse-kubernetes.md
+++ b/docs/documentation_interne/04-langfuse-kubernetes.md
@@ -1,57 +1,72 @@
 ---
-title: "EdgeQuake × Langfuse — Compatibilité, déploiement Kubernetes et remédiation"
-version: "1.0"
-date: "2026-08-26"
+title: "EdgeQuake × Langfuse — Compatibilité, suivi des coûts et déploiement Kubernetes"
+version: "2.0"
+date: "2026-08-27"
 produit: "EdgeQuake v0.26.1"
 methode: "Tests empiriques sur Langfuse 3.1.1, 3.225.5 et 4 — résultats reproductibles"
 ---
 
-# EdgeQuake × Langfuse — Compatibilité et déploiement Kubernetes
+# EdgeQuake × Langfuse — Compatibilité, coûts et Kubernetes
 
-> **Conclusion en une phrase** : EdgeQuake exporte ses traces **exclusivement** via
-> OTLP/HTTP sur `/api/public/otel/v1/traces`. Cet endpoint **n'existe pas dans
-> Langfuse 3.1** — aucune configuration Kubernetes ne peut compenser cette absence.
-> La correction est une **montée de version mineure** de Langfuse (3.1 → 3.225+),
-> sans changement de majeure.
+> **Conclusion en une phrase** : EdgeQuake sait exporter ses traces vers **toutes les
+> versions de Langfuse ≥ 2.x**, y compris **3.1**. Le transport est choisi
+> automatiquement au démarrage : OTLP quand l'endpoint existe, **API d'ingestion
+> native** sinon. Aucune montée de version n'est requise.
+
+> **Révision 2.0 — ce qui a changé.** La version 1.0 de ce document concluait que
+> Langfuse 3.1 était **incompatible** et qu'une montée en 3.225+ était obligatoire.
+> C'était exact à l'époque : EdgeQuake n'exportait qu'en OTLP. Depuis, un
+> **exportateur natif** a été ajouté (`langfuse_ingestion.rs`) et la contrainte a
+> disparu. Les sections traitant de la montée de version sont conservées à titre
+> d'option, plus d'obligation.
 
 ---
 
-## 1. Constat : pourquoi ça marche en local et pas chez le client
+## 1. Compatibilité par version
 
-| Environnement | Version Langfuse | `POST /api/public/otel/v1/traces` | Traces reçues |
-|---|---|---|---|
-| Poste de développement | **4** | 200 (avec auth) | ✅ oui |
-| **Client (Kubernetes)** | **3.1** | **404 — endpoint absent** | ❌ **non** |
-| Cible recommandée | **3.225.5** | 200 (avec auth) | ✅ **oui — validé de bout en bout** (§4.4) |
+| Version Langfuse | `/api/public/otel/v1/traces` | `/api/public/ingestion` | Transport retenu | Traces |
+|---|---|---|---|---|
+| **3.1.1** | **404 — absent** | ✅ 207 | **Ingestion** (auto) | ✅ **validé** |
+| **3.225.5** | ✅ 200 | ✅ | OTLP (auto) | ✅ validé |
+| **4.x** | ✅ 200 | ✅ | OTLP (auto) | ✅ validé |
 
-Le problème n'est **ni** le découpage en pods, **ni** le DNS, **ni** une NetworkPolicy :
-EdgeQuake pousse vers une URL qui n'est pas servie par Langfuse 3.1.
+L'endpoint OTLP n'existe qu'à partir de Langfuse **3.22x**. L'API d'ingestion native,
+elle, est présente **depuis la v2** — c'est le socle commun sur lequel s'appuie le
+repli.
 
-### Preuve
+### Sélection du transport
 
-Langfuse 3.1.1 déployé et interrogé :
+```bash
+EDGEQUAKE_LANGFUSE_API=auto        # défaut : sonde puis choisit
+                      =otlp        # force OTLP
+                      =ingestion   # force l'API native
 ```
-POST http://<langfuse>/api/public/otel/v1/traces
-  sans authentification → HTTP 404 (page HTML Next.js)
-  avec authentification → HTTP 404 (page HTML Next.js)
-```
 
-Langfuse 3.225.5, même requête :
+En `auto`, EdgeQuake envoie une requête de sonde sur l'endpoint OTLP au démarrage :
+
+- **404** → l'instance précède le support OTLP → bascule sur l'ingestion native
+- **toute autre réponse** (200, 401, 405) ou échec réseau → **conserve OTLP**
+
+> **Garde-fou volontaire** : seul un 404 déclenche la bascule. Une erreur
+> d'authentification ou une panne réseau ne doit pas changer silencieusement de
+> transport et masquer le vrai problème.
+
+Le transport retenu est journalisé au démarrage :
 ```
-  sans authentification → HTTP 401   (endpoint présent, auth exigée)
-  avec authentification → HTTP 200   {}
+Langfuse API auto-detected → Ingestion
+Langfuse native ingestion exporter enabled → http://…/api/public/ingestion
 ```
 
 ### Le code concerné
 
-`edgequake/crates/edgequake-observability/src/langfuse.rs:105-110`
+`edgequake/crates/edgequake-observability/src/langfuse.rs`
 ```rust
-pub fn otlp_endpoint(&self) -> String {
-    format!("{}/api/public/otel/v1/traces", self.base_url.trim_end_matches('/'))
-}
+pub enum LangfuseApi { Otlp, Ingestion, Auto }
+pub fn probe_langfuse_api(base_url: &str, auth_token: &str) -> LangfuseApi
 ```
-Chemin **en dur**, sans mécanisme de repli. Aucune variable d'environnement ne permet
-de le contourner.
+`edgequake/crates/edgequake-observability/src/langfuse_ingestion.rs` — exportateur
+`SpanExporter` traduisant les spans OTel en événements `trace-create` /
+`generation-create` / `span-create`.
 
 ---
 
@@ -99,79 +114,106 @@ Toute valeur autre que l'URL interne attendue est une anomalie bloquante.
 
 ---
 
-## 4. Options de remédiation
+## 4. Suivi des coûts
 
-| # | Option | Effort | Risque | Recommandation |
-|---|---|---|---|---|
-| **A** | **Monter Langfuse 3.1 → 3.225+** (même majeure) | Faible | Faible | ✅ **Retenue** |
-| B | Monter vers Langfuse 4 | Moyen | Moyen (rupture de schéma) | Si le client le planifiait déjà |
-| C | Collecteur OTel intermédiaire traduisant vers l'API d'ingestion Langfuse | Élevé | Élevé | ❌ Non — pas d'exportateur officiel, format propriétaire |
-| D | Désactiver l'export Langfuse | Nul | — | Repli temporaire (§4.3) |
+### 4.1 Pourquoi les coûts s'affichent à $0.00
 
-### 4.1 Option A — montée de version mineure *(recommandée)*
+Langfuse calcule le coût d'une observation à partir de **son propre catalogue de
+modèles**, et EdgeQuake **n'émet jamais** d'attribut de coût — c'est une règle
+explicite du code :
 
-Reste dans la majeure **3** : pas de migration de schéma majeure, pas de changement
-d'architecture (web + worker + PostgreSQL + ClickHouse + Redis + S3 déjà en place
-depuis la 3.0).
+```rust
+/// LAW-124-12: never emit these attribute keys (Langfuse cost ingestion).
+COST_ATTR_DENYLIST = ["gen_ai.usage.cost", "langfuse.observation.cost_details", …]
+```
+
+Langfuse reste ainsi la **source unique de vérité** pour les coûts. La conséquence :
+une instance auto-hébergée ne sait tarifer que les modèles présents dans le catalogue
+livré avec sa version. Langfuse **3.1 embarque une liste datant de 2024** :
+
+| Fournisseur | Présent en 3.1 | Absent |
+|---|---|---|
+| OpenAI | `gpt-4o`, `gpt-4`, `gpt-3.5` | `gpt-4.1`, `gpt-5.x` |
+| Google | `gemini-1.5-*` | `gemini-2.5-*` |
+| Anthropic | `claude-3.5-*` | `claude-sonnet-4-x`, `claude-opus-4-x` |
+| Mistral | *(aucun)* | tous |
+| xAI, MiniMax | *(aucun)* | tous |
+
+Tout modèle récent affiche donc **$0.00**, quels que soient les tokens remontés.
+
+### 4.2 Correctif : synchroniser les tarifs depuis `models.toml`
+
+`models.toml` contient déjà les tarifs de tous les fournisseurs supportés. Un script
+les pousse dans Langfuse via `POST /api/public/models` — **sans toucher au chemin
+d'export ni contourner LAW-124-12**.
+
+```bash
+make langfuse-sync-prices              # synchronise
+make langfuse-sync-prices DRY_RUN=1    # aperçu, n'écrit rien
+make langfuse-sync-prices FORCE=1      # réécrit les modèles déjà présents
+```
+
+Équivalent direct (utile en Kubernetes, hors dépôt) :
+```bash
+LANGFUSE_BASE_URL=https://langfuse.intra.example \
+LANGFUSE_PUBLIC_KEY=pk-lf-… LANGFUSE_SECRET_KEY=sk-lf-… \
+python3 scripts/langfuse_sync_model_prices.py
+```
+
+**Comportement** : conversion per-1k → per-token (Langfuse tarife au token), modèles
+d'embedding tarifés côté entrée uniquement, modèles locaux gratuits (Ollama,
+LM Studio) ignorés, idempotent — les modèles déjà connus sont sautés.
+
+**Résultat mesuré** — catalogue 88 → 133 modèles, puis :
+
+| Modèle | Tokens | Coût calculé |
+|---|---|---|
+| `gpt-5.4` | 10 000 / 1 000 | **$0.0400** |
+| `claude-sonnet-4-6` | 10 000 / 1 000 | **$0.0450** |
+| `gemini-2.5-flash` | 10 000 / 1 000 | **$0.0021** |
+| `mistral-small-latest` | 10 000 / 1 000 | **$0.0026** |
+
+> **À faire une fois par instance Langfuse**, et à rejouer après chaque ajout de
+> modèle dans `models.toml`.
+
+### 4.3 Limite connue : observations sans tokens
+
+Sans décompte de tokens, aucun coût n'est calculable, quel que soit le catalogue.
+Deux cas subsistent :
+
+| Observation | Cause | État |
+|---|---|---|
+| `query.embed` | l'API d'embedding ne remonte pas de décompte | Non résolu — un chiffre estimé serait trompeur dans un tableau de coûts |
+| `generate-answer` **via `/query/stream`** | la branche `llm.stream(&prompt)` ne renseigne pas l'usage, contrairement à `llm.chat()` | Non résolu |
+
+Le correctif propre passerait par `chat_with_tools_stream`, qui porte à la fois les
+rôles system/user **et** un `Done { usage }` — il résoudrait aussi le compromis
+streaming/fidélité de prompt. C'est une réécriture du chemin de génération, non
+engagée à ce jour.
+
+### 4.4 Repli : désactiver l'export
 
 ```yaml
-# Deployment langfuse-web ET langfuse-worker
+- name: EDGEQUAKE_LANGFUSE_ENABLED
+  value: "0"          # coupe l'export quelles que soient les clés
+```
+Le reste de l'observabilité (métriques Prometheus `/metrics`, journaux structurés,
+`retrieval_id` rejouable via `/api/v1/query/context/{id}`) demeure **pleinement
+opérationnel**.
+
+### 4.5 Montée de version Langfuse — désormais optionnelle
+
+La montée en 3.225+ n'est **plus nécessaire** pour le traçage. Elle reste pertinente
+pour bénéficier des correctifs amont et d'un catalogue de modèles plus récent.
+
+```yaml
 image: langfuse/langfuse:3.225.5          # web
 image: langfuse/langfuse-worker:3.225.5   # worker
 ```
 > Épingler une version exacte, jamais `:3` ni `:latest`.
 
-**Séquence :**
-1. Sauvegarde PostgreSQL et ClickHouse de Langfuse
-2. Mise à l'échelle à 0 du **worker**
-3. Montée du **web** (il applique les migrations au démarrage)
-4. Attente de `GET /api/public/health` → 200
-5. Remontée du worker
-6. Validation §6
-
-### 4.4 Validation de bout en bout sur Langfuse 3.225.5
-
-EdgeQuake v0.26.1 a été branché sur une instance Langfuse **3.225.5** réelle, puis
-soumis à une ingestion et une requête RAG. Résultat côté Langfuse :
-
-```
-┌─name────────────────┬─type───────┬──n─┐
-│ HTTP                │ SPAN       │ 32 │
-│ retrieval edgequake │ RETRIEVER  │  3 │
-│ query.rerank        │ SPAN       │  1 │
-│ query.fuse          │ SPAN       │  1 │
-│ generate-answer     │ GENERATION │  1 │
-│ query_pipeline      │ SPAN       │  1 │
-│ extract-keywords    │ GENERATION │  1 │
-│ query.embed         │ EMBEDDING  │  1 │
-│ query_execute       │ SPAN       │  1 │
-└─────────────────────┴────────────┴────┘
-```
-
-42 observations au total, avec **typage sémantique correct** : `RETRIEVER` pour la
-récupération RAG, `GENERATION` pour les appels LLM, `EMBEDDING` pour la vectorisation.
-
-> **La montée en 3.x suffit** : aucune adaptation d'EdgeQuake n'est nécessaire.
-
-### 4.2 Version minimale — à faire confirmer
-
-Testé : **3.1.1 = absent** · **3.225.5 = présent**. La version exacte d'apparition de
-l'endpoint se situe entre les deux et n'a pas été bissectée.
-
-**Recommandation opérationnelle** : viser la dernière **3.x** stable plutôt que la
-version minimale théorique — même effort de déploiement, davantage de correctifs.
-
-### 4.3 Option D — repli propre si la montée est impossible à court terme
-
-Pour éviter des exports qui échouent en boucle **et** tout risque de fuite vers le
-cloud :
-```yaml
-- name: EDGEQUAKE_LANGFUSE_ENABLED
-  value: "0"          # force_off : coupe l'export quelles que soient les clés
-```
-Le reste de l'observabilité (métriques Prometheus `/metrics`, journaux structurés,
-`retrieval_id` rejouable via `/api/v1/query/context/{id}`) demeure **pleinement
-opérationnel** — seul l'export Langfuse est suspendu.
+Séquence : sauvegarde PostgreSQL + ClickHouse → worker à 0 → montée du web (il applique
+les migrations) → `GET /api/public/health` 200 → remontée du worker → validation §6.
 
 ---
 
@@ -209,7 +251,7 @@ env:
 
 1. **Jamais `localhost`** — dans un pod, `localhost` désigne le pod lui-même.
 2. **Port du Service** (typiquement 3000), pas le port d'un mapping hôte local.
-3. **Pas de chemin ni de `/` final** — le code ajoute `/api/public/otel/v1/traces`.
+3. **Pas de chemin ni de `/` final** — le code ajoute lui-même le chemin du transport retenu (`/api/public/otel/v1/traces` ou `/api/public/ingestion`).
 4. **Jamais de valeur vide** — équivaut à « non défini » → repli vers Langfuse Cloud (§3).
 5. **Clés du projet de CETTE instance** — les clés d'une autre instance donnent un 401 silencieux.
 
@@ -284,8 +326,8 @@ Ne pas passer à l'étape suivante tant que la précédente échoue.
 
 | # | Contrôle | Commande | Attendu |
 |---|---|---|---|
-| 1 | **Version Langfuse** | `curl <svc>/api/public/health` | `version` ≥ 3.225 |
-| 2 | **Endpoint OTLP présent** | `curl -o /dev/null -w '%{http_code}' -X POST <svc>/api/public/otel/v1/traces -d '{}'` | **401** (pas 404) |
+| 1 | **Version Langfuse** | `curl <svc>/api/public/health` | toute version ≥ 2.x — informatif seulement |
+| 2 | **Transport retenu** | `kubectl logs deploy/edgequake \| grep 'Langfuse API auto-detected'` | `Otlp` ou `Ingestion` — un **404** sur l'endpoint OTLP est normal en 3.1 et déclenche le repli |
 | 3 | Variables injectées | `kubectl exec deploy/edgequake -- env \| grep LANGFUSE` | 3 variables **non vides** |
 | 4 | **Cible réelle** | `curl .../api/v1/settings/langfuse \| jq .base_url` | URL interne (**pas** cloud.langfuse.com) |
 | 5 | Joignabilité | `curl <svc>/api/public/health` depuis le pod EdgeQuake | 200 |
@@ -324,6 +366,16 @@ kubectl exec -n <ns> deploy/edgequake -- \
 ```
 Une liste non vide après une requête RAG prouve la chaîne complète.
 
+**Étape 9 — coûts.** Après `make langfuse-sync-prices`, une génération doit porter un
+coût non nul :
+```bash
+curl -s -u "$LANGFUSE_PUBLIC_KEY:$LANGFUSE_SECRET_KEY" \
+  "http://langfuse-web.<ns>.svc.cluster.local:3000/api/public/observations?limit=5" \
+  | jq '.data[] | {name, model, usage, calculatedTotalCost}'
+```
+`calculatedTotalCost: null` sur une génération avec des tokens ⇒ le modèle manque au
+catalogue Langfuse (§4).
+
 > ⚠️ Après une éventuelle montée en v4, ce contrôle cesse d'être valable : basculer
 > sur la requête ClickHouse `events_core`.
 
@@ -336,25 +388,29 @@ Une liste non vide après une requête RAG prouve la chaîne complète.
 | `HttpTraceClient.ResponseParseError: invalid wire type value: 6` | Langfuse répond en **JSON**, le client Rust attend du **protobuf**. Erreur de lecture de la réponse — la **livraison a réussi** (HTTP 200) | Aucune |
 | `GET /api/public/traces` renvoie 0 **en v4** | API legacy — en v4 les données sont dans `events_core` (en **v3 elle fonctionne**) | Utiliser ClickHouse ou l'UI |
 | `export_active: true` sans trace | N'atteste que de la présence des clés | Dérouler §6 |
+| Coût **$0.00** sur une génération | Modèle absent du catalogue Langfuse — EdgeQuake n'émet jamais le coût (LAW-124-12) | `make langfuse-sync-prices` (§4) |
+| Coût **$0.00** sur `query.embed` | Aucun décompte de tokens remonté par l'API d'embedding | Limite connue (§4.3) |
 
 ---
 
 ## 8. Synthèse pour le client
 
-1. **Cause** : Langfuse 3.1 ne dispose pas de l'endpoint OTLP requis par EdgeQuake
-   (404 vérifié). Aucun réglage Kubernetes ne peut y remédier.
-2. **Correctif** : montée de Langfuse en **3.225+** — même majeure, migration
-   standard, sans changement d'architecture.
+1. **Traçage** : aucune montée de Langfuse n'est requise. EdgeQuake détecte
+   l'absence d'endpoint OTLP (404) et bascule seul sur l'API d'ingestion native,
+   présente depuis Langfuse v2. **Rien à configurer.**
+2. **Coûts** : lancer **une fois** `make langfuse-sync-prices` (ou le script
+   équivalent) sur l'instance Langfuse — sans quoi tout modèle récent affiche $0.00,
+   le catalogue de 3.1 datant de 2024.
 3. **Contrôle préalable indispensable** : vérifier que `base_url` ne pointe pas vers
    `cloud.langfuse.com` (repli silencieux avec risque d'émission de données hors du SI).
 4. **Point de vigilance déploiement** : ordonner web → worker (course aux migrations),
    quoter les valeurs hexadécimales en YAML.
-5. **Repli** : `EDGEQUAKE_LANGFUSE_ENABLED=0` si la montée n'est pas immédiate — le
-   reste de l'observabilité demeure opérationnel.
+5. **Repli** : `EDGEQUAKE_LANGFUSE_ENABLED=0` — le reste de l'observabilité demeure
+   opérationnel.
 
 ---
 
-*Document établi le 2026-08-26 à partir de tests exécutés sur Langfuse 3.1.1, 3.225.5
+*Révision 2.0 du 2026-08-27, à partir de tests exécutés sur Langfuse 3.1.1, 3.225.5
 et 4, avec EdgeQuake v0.26.1. Documents liés :
 [Déploiement technique](01-deploiement-technique.md) ·
 [Intégration IT](02-integration-it.md).*

--- a/docs/documentation_interne/RUNBOOK-LOCAL-LANGFUSE.md
+++ b/docs/documentation_interne/RUNBOOK-LOCAL-LANGFUSE.md
@@ -1,13 +1,15 @@
 # EdgeQuake v0.26.1 — Démarrage local avec Langfuse
 
-> Validé le 2026-08-26 sur cette machine. Chaîne de traçage prouvée de bout en bout.
+> Révision 2.0 — 2026-08-27. Chaîne de traçage **et** suivi des coûts validés de bout
+> en bout sur Langfuse **3.1.1** et **4**.
 
 ## Démarrage
 
 ```bash
-make dev-bg-langfuse      # stack complète + Langfuse (clés locales injectées)
-make status               # état des services
-make stop                 # arrêt
+make dev-bg-langfuse       # stack complète + Langfuse v4 local (clés injectées)
+make langfuse-sync-prices  # tarifs des modèles → sans cela, coûts à $0.00
+make status                # état des services
+make stop                  # arrêt
 ```
 
 | Service | URL | Notes |
@@ -19,6 +21,59 @@ make stop                 # arrêt
 
 Les ports viennent de `scripts/select_edgequake_port.py` (8090/3010), **pas** de
 `EDGEQUAKE_PORT` du `.env`.
+
+## Les deux transports Langfuse
+
+EdgeQuake exporte vers **toutes les versions de Langfuse ≥ 2.x**. Le transport est
+choisi au démarrage :
+
+| Version Langfuse | Endpoint OTLP | Transport retenu |
+|---|---|---|
+| ≥ 3.22x, 4.x | présent | **OTLP/HTTP** |
+| ≤ 3.1 | **404** | **API d'ingestion native** |
+
+```bash
+EDGEQUAKE_LANGFUSE_API=auto        # défaut : sonde puis choisit
+                      =otlp        # force OTLP
+                      =ingestion   # force l'API native
+```
+
+Vérifier le choix effectué :
+```bash
+grep 'Langfuse API auto-detected' /tmp/edgequake-backend.log
+# → Langfuse API auto-detected → Otlp   (ou Ingestion)
+```
+
+> Seul un **404** déclenche le repli. Un 401 (mauvaises clés) ou une panne réseau
+> conserve OTLP : une erreur d'authentification ne doit pas changer silencieusement de
+> transport et masquer le vrai problème.
+
+## Suivi des coûts
+
+Langfuse calcule les coûts depuis **son propre catalogue** ; EdgeQuake n'émet jamais
+d'attribut de coût (`LAW-124-12` — Langfuse reste la source unique de vérité). Le
+catalogue livré avec Langfuse 3.1 datant de 2024, tout modèle récent affiche **$0.00**.
+
+```bash
+make langfuse-sync-prices              # pousse models.toml → Langfuse
+make langfuse-sync-prices DRY_RUN=1    # aperçu sans écrire
+make langfuse-sync-prices FORCE=1      # réécrit les modèles existants
+```
+
+Mesuré après synchronisation (catalogue 88 → 133 modèles) :
+
+| Modèle | Tokens | Coût |
+|---|---|---|
+| `gpt-5.4` | 10 000 / 1 000 | $0.0400 |
+| `claude-sonnet-4-6` | 10 000 / 1 000 | $0.0450 |
+| `gemini-2.5-flash` | 10 000 / 1 000 | $0.0021 |
+| `mistral-small-latest` | 10 000 / 1 000 | $0.0026 |
+
+**À relancer** après tout ajout de modèle dans `models.toml`.
+
+**Limite connue** — sans tokens, pas de coût possible : `query.embed` (l'API
+d'embedding ne remonte pas de décompte) et `generate-answer` via `/query/stream`
+(la branche `llm.stream` ne renseigne pas l'usage, contrairement à `llm.chat`).
 
 ## Points de vigilance découverts
 
@@ -47,12 +102,29 @@ cd edgequake/docker && LANGFUSE_PORT=3310 NEXTAUTH_URL=http://localhost:3310 \
 ```
 Vérifier ensuite : `docker logs edgequake-langfuse-langfuse-worker-1 | grep -c "does not exist"` → **0**.
 
-### 4. Deux faux positifs à ne PAS diagnostiquer comme des pannes
+### 4. `make stop` supprime le conteneur PostgreSQL
+
+Si un **PostgreSQL hôte** occupe déjà le port 5432, le Makefile le détecte au
+redémarrage (« PostgreSQL already reachable ») et l'utilise **à la place** de celui
+d'EdgeQuake — d'où des `permission denied for schema public` au `migrate`.
+
+Les données ne sont pas perdues : elles vivent dans le volume
+`edgequake-dev_postgres-data-pg18`. Correctif — déplacer EdgeQuake sur un port libre :
+```bash
+# .env
+POSTGRES_PORT=5433
+DATABASE_URL=postgresql://edgequake:edgequake_secret@localhost:5433/edgequake?options=-c%20search_path%3Dpublic
+```
+Vérifier : `docker volume ls | grep edgequake` puis
+`psql -h localhost -p 5433 -U edgequake -d edgequake -c 'SELECT count(*) FROM conversations;'`
+
+### 5. Deux faux positifs à ne PAS diagnostiquer comme des pannes
 - **`HttpTraceClient.ResponseParseError: invalid wire type value: 6`** dans les logs
   backend : cosmétique. Langfuse répond en JSON là où le client Rust attend du
   protobuf. La livraison réussit (HTTP 200).
-- **`GET /api/public/traces` renvoie 0** : API *legacy*. Langfuse v4 stocke dans
-  ClickHouse `events_core`. Utiliser l'UI ou :
+- **`GET /api/public/traces` renvoie 0 en v4** : API *legacy*. v4 stocke dans
+  `events_core`, **v3 dans `observations`** (et son API `/traces` fonctionne).
+  Utiliser l'UI ou :
   ```bash
   docker exec edgequake-langfuse-clickhouse-1 clickhouse-client \
     --user clickhouse --password clickhouse \
@@ -72,9 +144,19 @@ Spans attendus après une ingestion + une requête : `ingest.document`,
 `query.fuse`, `query.rerank`, `generate-answer`.
 Les spans LLM portent `type=GENERATION`, le modèle et les tokens.
 
+**Sur Langfuse 3.x** (table `observations`) :
+```bash
+docker exec eq-langfuse3-clickhouse-1 clickhouse-client \
+  --user clickhouse --password clickhouse \
+  -q "SELECT name, type, provided_model_name, toString(usage_details), total_cost \
+      FROM default.observations ORDER BY start_time DESC LIMIT 10 FORMAT PrettyCompact"
+```
+`total_cost` à `NULL` sur une génération avec des tokens ⇒ modèle absent du catalogue
+Langfuse → `make langfuse-sync-prices`.
+
 ## Fournisseur LLM
 
-État au 2026-08-26 : la clé **OpenAI du `.env` est invalide** (401 `invalid_api_key`,
+État constaté le 2026-08-26 (à revérifier) : la clé **OpenAI du `.env` était invalide** (401 `invalid_api_key`,
 vérifié directement auprès d'OpenAI). Le `.env` racine est donc configuré sur
 **Mistral** (clé valide).
 
@@ -94,6 +176,9 @@ des documents, prévoir `POST /api/v1/workspaces/{ws}/rebuild-embeddings`.
 ---
 
 # Annexe — Langfuse en Kubernetes (pods séparés)
+
+> Version complète et à jour : **[04-langfuse-kubernetes.md](04-langfuse-kubernetes.md)**
+> (compatibilité par version, suivi des coûts, manifests, validation en 9 points).
 
 ## Le piège n°1 : repli silencieux vers Langfuse Cloud
 

--- a/edgequake/Cargo.lock
+++ b/edgequake/Cargo.lock
@@ -1993,6 +1993,7 @@ dependencies = [
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry_sdk",
+ "reqwest 0.12.28",
  "rustls",
  "serde_json",
  "tokio",

--- a/edgequake/crates/edgequake-observability/Cargo.toml
+++ b/edgequake/crates/edgequake-observability/Cargo.toml
@@ -17,6 +17,7 @@ otel = [
     "dep:opentelemetry_sdk",
     "dep:opentelemetry-otlp",
     "dep:tracing-opentelemetry",
+    "dep:reqwest",
     "dep:rustls",
 ]
 
@@ -37,6 +38,8 @@ opentelemetry_sdk = { version = "0.32", features = ["rt-tokio", "testing"], opti
 # reqwest-rustls: HTTPS to cloud.langfuse.com / us.cloud… (reqwest 0.13 blocking has no TLS by default).
 opentelemetry-otlp = { version = "0.32", features = ["grpc-tonic", "http-proto", "reqwest-blocking-client", "reqwest-rustls", "trace"], optional = true }
 tracing-opentelemetry = { version = "0.33", optional = true }
+# SPEC-124b: native Langfuse ingestion transport (Langfuse 3.1 exposes no OTLP endpoint).
+reqwest = { version = "0.12", default-features = false, features = ["json", "blocking", "rustls-tls"], optional = true }
 # rustls 0.23 requires an explicit process-default CryptoProvider for HTTPS (reqwest OTLP).
 rustls = { version = "0.23", optional = true, default-features = false, features = ["std", "tls12", "aws-lc-rs"] }
 

--- a/edgequake/crates/edgequake-observability/src/langfuse.rs
+++ b/edgequake/crates/edgequake-observability/src/langfuse.rs
@@ -217,9 +217,90 @@ pub fn langfuse_otlp_headers_from_env() -> Option<HashMap<String, String>> {
     Some(langfuse_otlp_headers(&public, &secret))
 }
 
+/// Which Langfuse transport to use for trace export.
+///
+/// `/api/public/otel/v1/traces` (OTLP) only exists from Langfuse **3.22x**;
+/// on **3.1 it 404s**. `/api/public/ingestion` (native) has shipped since v2.
+/// `Auto` probes once at startup and picks whichever the server actually
+/// serves, so self-hosted fleets pinned to 3.1 need no configuration.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LangfuseApi {
+    /// OTLP/HTTP — Langfuse >= 3.22x and 4.x.
+    Otlp,
+    /// Native ingestion API — every Langfuse >= 2.x, including 3.1.
+    Ingestion,
+    /// Probe the OTLP endpoint at startup, fall back to ingestion on 404.
+    Auto,
+}
+
+impl LangfuseApi {
+    /// Read `EDGEQUAKE_LANGFUSE_API` (`otlp` | `ingestion` | `auto`).
+    /// Defaults to `Auto` — unknown values also fall back to `Auto` rather than
+    /// silently disabling export.
+    pub fn from_env() -> Self {
+        match std::env::var("EDGEQUAKE_LANGFUSE_API")
+            .ok()
+            .map(|v| unquote_env_value(&v).trim().to_ascii_lowercase())
+            .as_deref()
+        {
+            Some("otlp") => Self::Otlp,
+            Some("ingestion") | Some("native") => Self::Ingestion,
+            _ => Self::Auto,
+        }
+    }
+}
+
+/// Resolve [`LangfuseApi::Auto`] by probing the OTLP endpoint.
+///
+/// A **404** means the server predates OTLP support (3.1) → use ingestion.
+/// Anything else (200/401/405/network error) keeps OTLP: an auth or transient
+/// failure must not silently switch transports.
+pub fn probe_langfuse_api(base_url: &str, auth_token: &str) -> LangfuseApi {
+    let url = format!(
+        "{}/api/public/otel/v1/traces",
+        base_url.trim_end_matches('/')
+    );
+    let auth = format!("Basic {auth_token}");
+
+    // The probe runs on a dedicated OS thread: `reqwest::blocking` spins up its
+    // own Tokio runtime, and dropping a runtime from inside an async context
+    // panics ("Cannot drop a runtime in a context where blocking is not
+    // allowed"). Observability init is called from within the server runtime,
+    // so the nested runtime must live on a thread of its own.
+    let handle = std::thread::spawn(move || {
+        let client = reqwest::blocking::Client::builder()
+            .timeout(std::time::Duration::from_secs(5))
+            .build()
+            .ok()?;
+        let status = client
+            .post(&url)
+            .header("Authorization", auth)
+            .header("Content-Type", "application/x-protobuf")
+            .body(Vec::new())
+            .send()
+            .ok()?
+            .status()
+            .as_u16();
+        Some(status)
+    });
+
+    match handle.join() {
+        // 404 = server predates OTLP support (Langfuse 3.1) → native ingestion.
+        // Anything else (200/401/405) or a failed probe keeps OTLP: an auth or
+        // transient error must not silently switch transports.
+        Ok(Some(404)) => LangfuseApi::Ingestion,
+        _ => LangfuseApi::Otlp,
+    }
+}
+
+/// Basic-auth token shared by the OTLP headers and the ingestion exporter.
+pub fn basic_auth_token(public_key: &str, secret_key: &str) -> String {
+    base64_encode(format!("{public_key}:{secret_key}").as_bytes())
+}
+
 /// Pure header builder (testable).
 pub fn langfuse_otlp_headers(public_key: &str, secret_key: &str) -> HashMap<String, String> {
-    let token = base64_encode(format!("{public_key}:{secret_key}").as_bytes());
+    let token = basic_auth_token(public_key, secret_key);
     let mut headers = HashMap::new();
     headers.insert("Authorization".into(), format!("Basic {token}"));
     headers.insert("x-langfuse-ingestion-version".into(), "4".into());

--- a/edgequake/crates/edgequake-observability/src/langfuse_ingestion.rs
+++ b/edgequake/crates/edgequake-observability/src/langfuse_ingestion.rs
@@ -1,0 +1,405 @@
+//! Langfuse **native ingestion** span exporter (`POST /api/public/ingestion`).
+//!
+//! # Why this exists
+//!
+//! EdgeQuake exports traces over OTLP/HTTP to `/api/public/otel/v1/traces`.
+//! That endpoint only exists from Langfuse **3.22x** onward — on **Langfuse 3.1
+//! it returns 404**, so no trace can ever arrive, whatever the network setup.
+//! Self-hosted fleets that cannot upgrade were therefore left without tracing.
+//!
+//! The native ingestion API (`/api/public/ingestion`) has shipped since
+//! Langfuse v2 and is present on 3.1. This exporter maps OpenTelemetry spans
+//! onto that API, so the same instrumentation feeds both transports.
+//!
+//! Selected via [`crate::langfuse::LangfuseApi`]; OTLP remains the default, so
+//! existing deployments are untouched.
+
+use std::collections::HashMap;
+use std::sync::OnceLock;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use opentelemetry::trace::{SpanId, TraceId};
+use opentelemetry::Value;
+use opentelemetry_sdk::error::{OTelSdkError, OTelSdkResult};
+use opentelemetry_sdk::trace::{SpanData, SpanExporter};
+use serde_json::{json, Map as JsonMap, Value as JsonValue};
+
+/// Langfuse observation kinds we emit.
+const TYPE_GENERATION: &str = "generation";
+const TYPE_SPAN: &str = "span";
+
+/// Span exporter that speaks Langfuse's native ingestion API.
+#[derive(Debug)]
+pub struct LangfuseIngestionExporter {
+    endpoint: String,
+    auth_header: String,
+    /// Built lazily on the batch-processor thread.
+    ///
+    /// `BatchSpanProcessor` polls `export()` on a **dedicated thread with no
+    /// Tokio reactor**, so an async client panics with "there is no reactor
+    /// running" — this is why the upstream OTLP exporter ships a blocking
+    /// client. A blocking client cannot be *constructed* inside an async
+    /// context either (it spawns its own runtime), and `new()` runs during
+    /// observability init, which is async. Building it on first export
+    /// satisfies both constraints.
+    client: OnceLock<reqwest::blocking::Client>,
+}
+
+impl LangfuseIngestionExporter {
+    /// Build an exporter for `base_url` (no trailing path) with Basic auth.
+    pub fn new(base_url: &str, public_key: &str, secret_key: &str) -> Self {
+        let token = crate::langfuse::basic_auth_token(public_key, secret_key);
+        Self {
+            endpoint: format!("{}/api/public/ingestion", base_url.trim_end_matches('/')),
+            auth_header: format!("Basic {token}"),
+            client: OnceLock::new(),
+        }
+    }
+
+    /// Endpoint this exporter posts to (diagnostics).
+    pub fn endpoint(&self) -> &str {
+        &self.endpoint
+    }
+}
+
+/// RFC3339 (UTC, millisecond precision) — the format Langfuse expects.
+fn rfc3339(ts: SystemTime) -> String {
+    let d = ts.duration_since(UNIX_EPOCH).unwrap_or_default();
+    let secs = d.as_secs() as i64;
+    let millis = d.subsec_millis();
+    // Civil-from-days (Howard Hinnant's algorithm) — avoids a chrono dependency
+    // in a crate that does not otherwise need one.
+    let days = secs.div_euclid(86_400);
+    let rem = secs.rem_euclid(86_400);
+    let (h, mi, s) = (rem / 3600, (rem % 3600) / 60, rem % 60);
+    let z = days + 719_468;
+    let era = z.div_euclid(146_097);
+    let doe = z.rem_euclid(146_097);
+    let yoe = (doe - doe / 1460 + doe / 36_524 - doe / 146_096) / 365;
+    let y = yoe + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let day = doy - (153 * mp + 2) / 5 + 1;
+    let month = if mp < 10 { mp + 3 } else { mp - 9 };
+    let year = if month <= 2 { y + 1 } else { y };
+    format!("{year:04}-{month:02}-{day:02}T{h:02}:{mi:02}:{s:02}.{millis:03}Z")
+}
+
+fn trace_hex(id: TraceId) -> String {
+    format!("{:032x}", u128::from_be_bytes(id.to_bytes()))
+}
+
+fn span_hex(id: SpanId) -> String {
+    format!("{:016x}", u64::from_be_bytes(id.to_bytes()))
+}
+
+fn value_to_json(v: &Value) -> JsonValue {
+    match v {
+        Value::Bool(b) => json!(b),
+        Value::I64(i) => json!(i),
+        Value::F64(f) => json!(f),
+        Value::String(s) => json!(s.as_str()),
+        other => json!(other.to_string()),
+    }
+}
+
+/// Attributes → (json map, langfuse-specific extractions).
+struct Extracted {
+    attributes: JsonMap<String, JsonValue>,
+    observation_type: Option<String>,
+    model: Option<String>,
+    input: Option<JsonValue>,
+    output: Option<JsonValue>,
+    usage_in: Option<i64>,
+    usage_out: Option<i64>,
+    session_id: Option<String>,
+    user_id: Option<String>,
+    level: Option<String>,
+}
+
+fn extract(span: &SpanData) -> Extracted {
+    let mut e = Extracted {
+        attributes: JsonMap::new(),
+        observation_type: None,
+        model: None,
+        input: None,
+        output: None,
+        usage_in: None,
+        usage_out: None,
+        session_id: None,
+        user_id: None,
+        level: None,
+    };
+    for kv in span.attributes.iter() {
+        let k = kv.key.as_str();
+        let v = &kv.value;
+        match k {
+            "langfuse.observation.type" => e.observation_type = Some(v.to_string()),
+            "gen_ai.request.model" | "gen_ai.response.model" | "langfuse.observation.model.name" => {
+                e.model = Some(v.to_string())
+            }
+            "langfuse.observation.input" | "gen_ai.prompt" | "input.value" => {
+                e.input = Some(value_to_json(v))
+            }
+            "langfuse.observation.output" | "gen_ai.completion" | "output.value" => {
+                e.output = Some(value_to_json(v))
+            }
+            "gen_ai.usage.input_tokens" | "gen_ai.usage.prompt_tokens" => {
+                if let Value::I64(i) = v {
+                    e.usage_in = Some(*i)
+                }
+            }
+            "gen_ai.usage.output_tokens" | "gen_ai.usage.completion_tokens" => {
+                if let Value::I64(i) = v {
+                    e.usage_out = Some(*i)
+                }
+            }
+            "langfuse.session.id" | "session.id" => e.session_id = Some(v.to_string()),
+            "langfuse.user.id" | "user.id" => e.user_id = Some(v.to_string()),
+            "langfuse.observation.level" => e.level = Some(v.to_string()),
+            _ => {
+                e.attributes.insert(k.to_string(), value_to_json(v));
+            }
+        }
+    }
+    e
+}
+
+/// Map a batch of OTel spans onto Langfuse ingestion events.
+///
+/// Root spans (no parent) additionally emit a `trace-create` so the trace shows
+/// a name, session and user in the UI. Every span becomes an observation —
+/// `generation` when it carries model/usage attributes, `span` otherwise.
+/// Span names that describe a request better than the transport root.
+///
+/// The OTel root of an API call is the Axum `HTTP` server span, which makes
+/// every Langfuse trace show up as "HTTP". Prefer a RAG/pipeline span name so
+/// the trace list is readable.
+const PREFERRED_TRACE_NAMES: &[&str] = &[
+    "query_pipeline",
+    "query_execute",
+    "chat_stream",
+    "query_stream",
+    "ingest.document",
+    "task_process",
+];
+
+/// Map a batch of OTel spans onto Langfuse ingestion events.
+///
+/// One `trace-create` per trace id, carrying a readable name plus the
+/// session/user ids found on **any** span of that trace — Langfuse propagates
+/// those onto all spans, but the transport root (`HTTP`) is created before the
+/// baggage exists, so reading only the root loses them. The ingestion API
+/// upserts traces, so later batches enrich the same trace.
+///
+/// Every span becomes an observation — `generation` when it carries model or
+/// usage attributes, `span` otherwise.
+pub fn spans_to_batch(batch: &[SpanData]) -> Vec<JsonValue> {
+    let mut events = Vec::with_capacity(batch.len() * 2);
+
+    // Per-trace aggregation: name candidate, session, user, root timestamp.
+    struct TraceInfo {
+        name: String,
+        name_is_preferred: bool,
+        session_id: Option<String>,
+        user_id: Option<String>,
+        timestamp: String,
+        input: Option<JsonValue>,
+        output: Option<JsonValue>,
+    }
+    let mut traces: HashMap<String, TraceInfo> = HashMap::new();
+
+    for span in batch {
+        let trace_id = trace_hex(span.span_context.trace_id());
+        let is_root = span.parent_span_id == SpanId::INVALID;
+        let e = extract(span);
+        let name = span.name.to_string();
+        let preferred = PREFERRED_TRACE_NAMES.contains(&name.as_str());
+        let start = rfc3339(span.start_time);
+
+        let info = traces.entry(trace_id.clone()).or_insert_with(|| TraceInfo {
+            name: name.clone(),
+            name_is_preferred: preferred,
+            session_id: None,
+            user_id: None,
+            timestamp: start.clone(),
+            input: None,
+            output: None,
+        });
+        // A preferred name always wins; otherwise the root names the trace.
+        if preferred && !info.name_is_preferred {
+            info.name = name.clone();
+            info.name_is_preferred = true;
+        } else if is_root && !info.name_is_preferred {
+            info.name = name.clone();
+            info.timestamp = start.clone();
+        }
+        if info.session_id.is_none() {
+            info.session_id = e.session_id.clone();
+        }
+        if info.user_id.is_none() {
+            info.user_id = e.user_id.clone();
+        }
+        if is_root {
+            if info.input.is_none() {
+                info.input = e.input.clone();
+            }
+            if info.output.is_none() {
+                info.output = e.output.clone();
+            }
+        }
+    }
+
+    for (trace_id, info) in &traces {
+        let mut body = json!({
+            "id": trace_id,
+            "name": info.name,
+            "timestamp": info.timestamp,
+        });
+        if let Some(s) = &info.session_id {
+            body["sessionId"] = json!(s);
+        }
+        if let Some(u) = &info.user_id {
+            body["userId"] = json!(u);
+        }
+        if let Some(i) = &info.input {
+            body["input"] = i.clone();
+        }
+        if let Some(o) = &info.output {
+            body["output"] = o.clone();
+        }
+        events.push(json!({
+            "id": format!("{trace_id}-trace"),
+            "timestamp": info.timestamp,
+            "type": "trace-create",
+            "body": body,
+        }));
+    }
+
+    for span in batch {
+        let trace_id = trace_hex(span.span_context.trace_id());
+        let span_id = span_hex(span.span_context.span_id());
+        let is_root = span.parent_span_id == SpanId::INVALID;
+        let e = extract(span);
+        let start = rfc3339(span.start_time);
+        let end = rfc3339(span.end_time);
+
+        let is_generation = e.observation_type.as_deref() == Some(TYPE_GENERATION)
+            || e.model.is_some()
+            || e.usage_in.is_some()
+            || e.usage_out.is_some();
+        let obs_type = if is_generation {
+            TYPE_GENERATION
+        } else {
+            e.observation_type.as_deref().unwrap_or(TYPE_SPAN)
+        };
+
+        let mut body = json!({
+            "id": span_id,
+            "traceId": trace_id,
+            "name": span.name.to_string(),
+            "startTime": start,
+            "endTime": end,
+        });
+        if !is_root {
+            body["parentObservationId"] = json!(span_hex(span.parent_span_id));
+        }
+        if let Some(m) = &e.model {
+            body["model"] = json!(m);
+        }
+        if let Some(i) = &e.input {
+            body["input"] = i.clone();
+        }
+        if let Some(o) = &e.output {
+            body["output"] = o.clone();
+        }
+        if e.usage_in.is_some() || e.usage_out.is_some() {
+            let i = e.usage_in.unwrap_or(0);
+            let o = e.usage_out.unwrap_or(0);
+            body["usage"] = json!({ "input": i, "output": o, "total": i + o });
+        }
+        let level = match span.status {
+            opentelemetry::trace::Status::Error { .. } => "ERROR",
+            _ => e.level.as_deref().unwrap_or("DEFAULT"),
+        };
+        body["level"] = json!(level);
+        if !e.attributes.is_empty() {
+            body["metadata"] = JsonValue::Object(e.attributes);
+        }
+
+        events.push(json!({
+            "id": format!("{span_id}-obs"),
+            "timestamp": end,
+            "type": format!("{obs_type}-create"),
+            "body": body,
+        }));
+    }
+
+    events
+}
+
+impl SpanExporter for LangfuseIngestionExporter {
+    async fn export(&self, batch: Vec<SpanData>) -> OTelSdkResult {
+        if batch.is_empty() {
+            return Ok(());
+        }
+        let events = spans_to_batch(&batch);
+        if events.is_empty() {
+            return Ok(());
+        }
+
+        let client = self.client.get_or_init(|| {
+            reqwest::blocking::Client::builder()
+                .timeout(Duration::from_secs(10))
+                .build()
+                .unwrap_or_default()
+        });
+
+        let resp = client
+            .post(&self.endpoint)
+            .header("Authorization", &self.auth_header)
+            .header("Content-Type", "application/json")
+            .json(&json!({ "batch": events }))
+            .send()
+            .map_err(|e| OTelSdkError::InternalFailure(format!("langfuse ingestion send: {e}")))?;
+
+        // 207 Multi-Status is the nominal success code for this API.
+        let code = resp.status().as_u16();
+        if resp.status().is_success() || code == 207 {
+            Ok(())
+        } else {
+            let body = resp.text().unwrap_or_default();
+            Err(OTelSdkError::InternalFailure(format!(
+                "langfuse ingestion HTTP {code}: {}",
+                body.chars().take(300).collect::<String>()
+            )))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rfc3339_formats_epoch() {
+        assert_eq!(rfc3339(UNIX_EPOCH), "1970-01-01T00:00:00.000Z");
+    }
+
+    #[test]
+    fn rfc3339_formats_known_instant() {
+        // 2026-08-26T12:00:00Z
+        let ts = UNIX_EPOCH + Duration::from_secs(1_787_745_600);
+        assert!(ts_is_2026(&rfc3339(ts)), "{}", rfc3339(ts));
+    }
+
+    fn ts_is_2026(s: &str) -> bool {
+        s.starts_with("2026-") && s.ends_with('Z') && s.contains('T')
+    }
+
+    #[test]
+    fn endpoint_joins_path_once() {
+        let e = LangfuseIngestionExporter::new("http://lf:3000/", "pk", "sk");
+        assert_eq!(e.endpoint(), "http://lf:3000/api/public/ingestion");
+    }
+}

--- a/edgequake/crates/edgequake-observability/src/lib.rs
+++ b/edgequake/crates/edgequake-observability/src/lib.rs
@@ -10,6 +10,8 @@ pub mod langfuse;
 pub mod langfuse_attrs;
 pub mod langfuse_context;
 pub mod langfuse_meta;
+#[cfg(feature = "otel")]
+pub mod langfuse_ingestion;
 pub mod propagation;
 pub mod rag_span;
 pub mod request_context;

--- a/edgequake/crates/edgequake-observability/src/subscriber.rs
+++ b/edgequake/crates/edgequake-observability/src/subscriber.rs
@@ -271,33 +271,73 @@ fn init_otel_layers(
         }
     }
 
-    // --- Langfuse OTLP/HTTP (SPEC-124; Langfuse does not support gRPC) ---
+    // --- Langfuse (SPEC-124; Langfuse does not support gRPC) ---
+    //
+    // Two transports, because `/api/public/otel/v1/traces` only exists from
+    // Langfuse 3.22x onward — on 3.1 it 404s and no trace can ever arrive.
+    // `EDGEQUAKE_LANGFUSE_API=auto` (default) probes once and falls back to the
+    // native ingestion API, which every Langfuse >= 2.x serves.
     if config.langfuse.enabled {
-        if let Some(headers) = crate::langfuse::langfuse_otlp_headers_from_env() {
-            let endpoint = config.langfuse.otlp_endpoint();
-            let builder = opentelemetry_otlp::SpanExporter::builder()
-                .with_http()
-                .with_endpoint(endpoint)
-                .with_headers(headers);
-            match builder.build() {
-                Ok(exporter) => {
-                    provider_builder = provider_builder.with_batch_exporter(exporter);
-                    any_exporter = true;
-                    eprintln!(
-                        "Langfuse OTLP/HTTP exporter enabled → {}",
-                        config.langfuse.otlp_endpoint()
-                    );
+        let keys = std::env::var("LANGFUSE_PUBLIC_KEY")
+            .ok()
+            .map(|p| crate::langfuse::unquote_env_value(&p))
+            .zip(
+                std::env::var("LANGFUSE_SECRET_KEY")
+                    .ok()
+                    .map(|s| crate::langfuse::unquote_env_value(&s)),
+            )
+            .filter(|(p, s)| !p.is_empty() && !s.is_empty());
+
+        match keys {
+            Some((public_key, secret_key)) => {
+                let mut api = crate::langfuse::LangfuseApi::from_env();
+                if api == crate::langfuse::LangfuseApi::Auto {
+                    let token = crate::langfuse::basic_auth_token(&public_key, &secret_key);
+                    api = crate::langfuse::probe_langfuse_api(&config.langfuse.base_url, &token);
+                    eprintln!("Langfuse API auto-detected → {api:?}");
                 }
-                Err(e) => {
-                    eprintln!(
-                        "Langfuse OTLP/HTTP exporter build failed: {e}; continuing without Langfuse"
-                    );
+
+                match api {
+                    crate::langfuse::LangfuseApi::Ingestion => {
+                        let exporter = crate::langfuse_ingestion::LangfuseIngestionExporter::new(
+                            &config.langfuse.base_url,
+                            &public_key,
+                            &secret_key,
+                        );
+                        eprintln!("Langfuse native ingestion exporter enabled → {}", exporter.endpoint());
+                        provider_builder = provider_builder.with_batch_exporter(exporter);
+                        any_exporter = true;
+                    }
+                    _ => {
+                        let headers =
+                            crate::langfuse::langfuse_otlp_headers(&public_key, &secret_key);
+                        let builder = opentelemetry_otlp::SpanExporter::builder()
+                            .with_http()
+                            .with_endpoint(config.langfuse.otlp_endpoint())
+                            .with_headers(headers);
+                        match builder.build() {
+                            Ok(exporter) => {
+                                provider_builder = provider_builder.with_batch_exporter(exporter);
+                                any_exporter = true;
+                                eprintln!(
+                                    "Langfuse OTLP/HTTP exporter enabled → {}",
+                                    config.langfuse.otlp_endpoint()
+                                );
+                            }
+                            Err(e) => {
+                                eprintln!(
+                                    "Langfuse OTLP/HTTP exporter build failed: {e}; continuing without Langfuse"
+                                );
+                            }
+                        }
+                    }
                 }
             }
-        } else {
-            eprintln!(
-                "WARNING: Langfuse enabled but keys missing at exporter build — skipping HTTP OTLP"
-            );
+            None => {
+                eprintln!(
+                    "WARNING: Langfuse enabled but keys missing at exporter build — skipping export"
+                );
+            }
         }
     }
 

--- a/scripts/langfuse_sync_model_prices.py
+++ b/scripts/langfuse_sync_model_prices.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""Sync EdgeQuake model prices into a Langfuse instance.
+
+WHY
+---
+Langfuse computes observation cost from **its own** model catalogue, and
+EdgeQuake deliberately never emits cost attributes (LAW-124-12: Langfuse stays
+the single source of truth for cost). A self-hosted Langfuse therefore only
+prices the models its bundled catalogue knows — Langfuse 3.1 ships a 2024 list
+with `gpt-4o` but no `gpt-5`, `gemini-1.5` but no `gemini-2.5`, `claude-3.5`
+but no `claude-4.x`, and no Mistral at all. Every newer model then costs $0.00.
+
+This script pushes EdgeQuake's own `models.toml` pricing into Langfuse via
+`POST /api/public/models`, so cost works for every provider EdgeQuake supports
+without touching the export path.
+
+Prices: `models.toml` is per **1k tokens**; Langfuse expects per **token**.
+
+Usage
+-----
+    python3 scripts/langfuse_sync_model_prices.py \
+        --base-url http://localhost:3320 \
+        --public-key pk-lf-... --secret-key sk-lf-...
+
+Credentials default to LANGFUSE_BASE_URL / LANGFUSE_PUBLIC_KEY /
+LANGFUSE_SECRET_KEY from the environment. `--dry-run` prints without writing.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.request
+
+try:
+    import tomllib  # Python >= 3.11
+except ModuleNotFoundError:  # pragma: no cover - older interpreters
+    import tomli as tomllib  # type: ignore
+
+DEFAULT_TOML = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    "edgequake",
+    "models.toml",
+)
+
+
+def api(base_url: str, path: str) -> str:
+    return f"{base_url.rstrip('/')}{path}"
+
+
+def request(url: str, token: str, method: str = "GET", payload: dict | None = None):
+    data = json.dumps(payload).encode() if payload is not None else None
+    req = urllib.request.Request(url, data=data, method=method)
+    req.add_header("Authorization", f"Basic {token}")
+    req.add_header("Content-Type", "application/json")
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        body = resp.read().decode()
+        return resp.status, (json.loads(body) if body.strip() else {})
+
+
+def existing_model_names(base_url: str, token: str) -> set[str]:
+    """Names already priced in Langfuse (paginated)."""
+    names: set[str] = set()
+    page = 1
+    while True:
+        try:
+            _, data = request(api(base_url, f"/api/public/models?page={page}&limit=100"), token)
+        except urllib.error.HTTPError:
+            break
+        items = data.get("data") or []
+        if not items:
+            break
+        names.update(m.get("modelName", "") for m in items)
+        if len(items) < 100:
+            break
+        page += 1
+    return names
+
+
+def collect_prices(toml_path: str) -> list[dict]:
+    """Model → per-token prices, skipping free (local) models."""
+    with open(toml_path, "rb") as fh:
+        doc = tomllib.load(fh)
+
+    out: list[dict] = []
+    seen: set[str] = set()
+    for provider in doc.get("providers", []):
+        for model in provider.get("models", []):
+            name = model.get("name")
+            cost = model.get("cost") or {}
+            if not name or name in seen:
+                continue
+
+            in_1k = float(cost.get("input_per_1k") or 0.0)
+            out_1k = float(cost.get("output_per_1k") or 0.0)
+            emb_1k = float(cost.get("embedding_per_1k") or 0.0)
+
+            # Embedding models price the input side only.
+            if model.get("model_type") == "embedding" or (emb_1k and not in_1k):
+                in_1k, out_1k = emb_1k, 0.0
+
+            # Local runtimes (ollama, lmstudio, …) are free — nothing to price.
+            if in_1k <= 0 and out_1k <= 0:
+                continue
+
+            seen.add(name)
+            out.append(
+                {
+                    "modelName": name,
+                    "matchPattern": f"(?i)^({re.escape(name)})$",
+                    "unit": "TOKENS",
+                    "inputPrice": in_1k / 1000.0,
+                    "outputPrice": out_1k / 1000.0,
+                }
+            )
+    return out
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--models-toml", default=DEFAULT_TOML)
+    ap.add_argument("--base-url", default=os.environ.get("LANGFUSE_BASE_URL", ""))
+    ap.add_argument("--public-key", default=os.environ.get("LANGFUSE_PUBLIC_KEY", ""))
+    ap.add_argument("--secret-key", default=os.environ.get("LANGFUSE_SECRET_KEY", ""))
+    ap.add_argument("--dry-run", action="store_true")
+    ap.add_argument("--force", action="store_true", help="push even if the name already exists")
+    args = ap.parse_args()
+
+    missing = [n for n, v in (("--base-url", args.base_url), ("--public-key", args.public_key), ("--secret-key", args.secret_key)) if not v]
+    if missing:
+        print(f"missing: {', '.join(missing)} (or set LANGFUSE_* env vars)", file=sys.stderr)
+        return 2
+
+    models = collect_prices(args.models_toml)
+    print(f"{len(models)} priced models in {os.path.relpath(args.models_toml)}")
+
+    if args.dry_run:
+        for m in models:
+            print(f"  {m['modelName']:38s} in={m['inputPrice']:.10f} out={m['outputPrice']:.10f}")
+        return 0
+
+    token = base64.b64encode(f"{args.public_key}:{args.secret_key}".encode()).decode()
+    known = set() if args.force else existing_model_names(args.base_url, token)
+    if known:
+        print(f"{len(known)} already in the Langfuse catalogue — skipping those (use --force to overwrite)")
+
+    created = skipped = failed = 0
+    for m in models:
+        if m["modelName"] in known:
+            skipped += 1
+            continue
+        try:
+            status, _ = request(api(args.base_url, "/api/public/models"), token, "POST", m)
+            if 200 <= status < 300:
+                created += 1
+            else:
+                failed += 1
+                print(f"  ! {m['modelName']}: HTTP {status}", file=sys.stderr)
+        except urllib.error.HTTPError as exc:
+            failed += 1
+            print(f"  ! {m['modelName']}: HTTP {exc.code} {exc.read()[:120].decode(errors='replace')}", file=sys.stderr)
+        except Exception as exc:  # noqa: BLE001 - report and continue
+            failed += 1
+            print(f"  ! {m['modelName']}: {exc}", file=sys.stderr)
+
+    print(f"created={created} skipped={skipped} failed={failed}")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION

**3. Langfuse : support de toutes les versions ≥ 2.x**
L'endpoint OTLP `/api/public/otel/v1/traces` n'existe qu'à partir de Langfuse
**3.22x** — sur **3.1 il renvoie 404**, donc aucune trace ne pouvait arriver, quelle
que soit la configuration réseau. Ajout d'un exportateur `SpanExporter` natif
(`langfuse_ingestion.rs`) parlant `/api/public/ingestion`, présent depuis Langfuse v2.
Le transport est choisi au démarrage via `EDGEQUAKE_LANGFUSE_API=auto|otlp|ingestion`
(défaut `auto`, qui sonde et bascule sur un 404). **Le chemin OTLP est inchangé.**

**4. Coûts à $0.00 pour tout modèle récent**
Langfuse calcule les coûts depuis **son propre catalogue** et EdgeQuake n'émet jamais
d'attribut de coût (`LAW-124-12` — Langfuse reste la source unique de vérité). Le
catalogue livré avec 3.1 date de 2024 : `gpt-4o` mais pas `gpt-5`, `gemini-1.5` mais
pas `2.5`, `claude-3.5` mais pas `4.x`, aucun Mistral. Ajout de
`scripts/langfuse_sync_model_prices.py` + cible `make langfuse-sync-prices` qui pousse
les tarifs de `models.toml` — **sans contourner LAW-124-12**.

Fixes # (aucune issue ouverte — bugs remontés en usage direct)

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Other (describe below)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
