### PR TITLE
feat(workspace-copy): add same-model workspace-copy endpoint (EN-3677)

### DIFF
--- a/edgequake/crates/edgequake-api/src/handlers/workspaces/mod.rs
+++ b/edgequake/crates/edgequake-api/src/handlers/workspaces/mod.rs
@@ -52,6 +52,7 @@ mod bulk_ops;
 mod helpers;
 mod stats;
 mod tenants;
+mod workspace_copy;
 mod workspace_crud;
 
 // Re-export all public items (includes utoipa __path_* structs for OpenAPI)
@@ -59,6 +60,7 @@ pub use bulk_ops::*;
 pub use helpers::invalidate_workspace_stats_cache;
 pub use stats::*;
 pub use tenants::*;
+pub use workspace_copy::*;
 pub use workspace_crud::*;
 
 // Re-export DTOs from workspaces_types module

--- a/edgequake/crates/edgequake-api/src/handlers/workspaces/workspace_copy.rs
+++ b/edgequake/crates/edgequake-api/src/handlers/workspaces/workspace_copy.rs
@@ -1,0 +1,212 @@
+//! HTTP handlers for workspace copy (EN-3677 Phase 1).
+//!
+//! Two endpoints:
+//!   * `POST /api/v1/workspaces/{source_workspace_id}/copy` — start / retrieve
+//!     an idempotent copy job.
+//!   * `GET  /api/v1/workspace-copy-jobs/{job_id}` — poll job status.
+//!
+//! The `DELETE /api/v1/workspaces/{workspace_id}` route already exists in
+//! `workspace_crud.rs` and satisfies the cleanup contract that
+//! rag-service (on copy failure) and doc-store (MILVUS_DROP step) rely on.
+//! No new delete handler is added here.
+
+use axum::{
+    extract::{Path, State},
+    http::StatusCode,
+    Json,
+};
+use uuid::Uuid;
+
+use super::helpers::verify_workspace_tenant_access;
+use crate::error::ApiError;
+use crate::handlers::workspaces_types::{
+    CopyMode, CopyStatus, CopyWorkspaceRequest, CopyWorkspaceResponse, CopyWorkspaceStatus,
+};
+use crate::middleware::TenantContext;
+use crate::services::workspace_copy::{
+    execute_copy_plan, CopyJobStore, CopyPlan, GetOrCreateOutcome, NewCopyJob,
+};
+use crate::state::AppState;
+
+/// Copy a workspace (same-model, same-tenant).
+///
+/// # Semantics
+///
+/// - Rejects `dest_embedding_model = Some(_)` with 400 `NOT_IMPLEMENTED_V1`.
+/// - Idempotent on `request_id` — a repeat call returns the existing job's
+///   state (200 sync / 202 async), never 409.
+/// - `async_mode = false` waits for the copy to finish then returns 200.
+/// - `async_mode = true` returns 202 with `job_id`; poll the status route.
+///
+/// # Guards
+///
+/// - `verify_workspace_tenant_access` — source workspace must belong to the
+///   caller's `X-Tenant-ID`.
+/// - `pg_try_advisory_xact_lock` on both workspaces + ingest-in-flight
+///   scan of the `tasks` table are executed inside the copy transaction
+///   (see `services::workspace_copy::lock`).
+///
+/// POST /api/v1/workspaces/{source_workspace_id}/copy
+#[utoipa::path(
+    post,
+    path = "/api/v1/workspaces/{source_workspace_id}/copy",
+    params(
+        ("source_workspace_id" = Uuid, Path, description = "Source workspace ID"),
+    ),
+    request_body = CopyWorkspaceRequest,
+    responses(
+        (status = 200, description = "Copy completed (sync mode)", body = CopyWorkspaceResponse),
+        (status = 202, description = "Copy accepted (async mode)", body = CopyWorkspaceResponse),
+        (status = 400, description = "Invalid request (e.g. NOT_IMPLEMENTED_V1)"),
+        (status = 404, description = "Source workspace not found"),
+        (status = 409, description = "Copy blocked by lock or in-flight ingestion"),
+    ),
+    tags = ["workspaces"]
+)]
+pub async fn copy_workspace(
+    State(state): State<AppState>,
+    Path(source_workspace_id): Path<Uuid>,
+    tenant_ctx: TenantContext,
+    Json(request): Json<CopyWorkspaceRequest>,
+) -> Result<(StatusCode, Json<CopyWorkspaceResponse>), ApiError> {
+    // ── v1 guard: reject cross-model requests before doing anything else ──
+    if request.dest_embedding_model.is_some()
+        || request.dest_embedding_provider.is_some()
+        || request.dest_embedding_dimension.is_some()
+    {
+        return Err(ApiError::BadRequest(
+            "NOT_IMPLEMENTED_V1: cross-model re-embed is deferred to v2; \
+             omit dest_embedding_* fields for same-model copy"
+                .to_string(),
+        ));
+    }
+
+    // ── tenant isolation on the source workspace ──
+    let source = verify_workspace_tenant_access(&state, source_workspace_id, &tenant_ctx).await?;
+
+    // Provisional destination workspace id — the real create step lives in
+    // the copy service (Phase 2 wiring); the handler generates the id now
+    // so the response and job record can share it.
+    let dest_workspace_id = Uuid::new_v4();
+
+    let store = copy_job_store(&state);
+
+    let outcome = store
+        .get_or_create(NewCopyJob {
+            request_id: request.request_id.clone(),
+            tenant_id: Some(source.tenant_id),
+            source_workspace_id,
+            dest_workspace_id,
+            dest_slug: request.dest_slug.clone(),
+            mode: CopyMode::SameModel,
+        })
+        .await;
+
+    let (record, is_new) = match outcome {
+        GetOrCreateOutcome::Existing(rec) => (rec, false),
+        GetOrCreateOutcome::Created(rec) => (rec, true),
+    };
+
+    let job_id = record.job_id;
+
+    if is_new {
+        let plan = CopyPlan {
+            job_id,
+            source_workspace_id,
+            dest_workspace_id: record.dest_workspace_id,
+            tenant_namespace: source.tenant_id.simple().to_string(),
+            mode: CopyMode::SameModel,
+        };
+
+        if request.async_mode {
+            let store_clone = store.clone();
+            tokio::spawn(async move {
+                if let Err(e) = execute_copy_plan(&store_clone, plan).await {
+                    store_clone
+                        .mark_failed(job_id, "COPY_FAILED", format!("{e}"))
+                        .await;
+                }
+            });
+        } else if let Err(e) = execute_copy_plan(&store, plan).await {
+            store.mark_failed(job_id, "COPY_FAILED", format!("{e}")).await;
+            return Err(ApiError::Internal(format!(
+                "workspace copy failed: {e}"
+            )));
+        }
+    }
+
+    // Re-read after any state mutations so the response reflects fresh
+    // counters (sync path) or the initial pending state (async path).
+    let latest = store.get(job_id).await.unwrap_or(record);
+
+    let response = CopyWorkspaceResponse {
+        source_workspace_id: latest.source_workspace_id,
+        dest_workspace_id: latest.dest_workspace_id,
+        dest_slug: latest.dest_slug.clone(),
+        mode: latest.mode,
+        status: latest.status,
+        job_id: if request.async_mode {
+            Some(latest.job_id)
+        } else {
+            None
+        },
+        chunks_copied: latest.chunks_copied,
+        entities_copied: latest.entities_copied,
+        relationships_copied: latest.relationships_copied,
+        documents_copied: latest.documents_copied,
+        vectors_copied: latest.vectors_copied,
+        elapsed_ms: latest.elapsed_ms,
+    };
+
+    let status_code = if request.async_mode && latest.status != CopyStatus::Completed {
+        StatusCode::ACCEPTED
+    } else {
+        StatusCode::OK
+    };
+
+    Ok((status_code, Json(response)))
+}
+
+/// Poll the status of a workspace copy job.
+///
+/// GET /api/v1/workspace-copy-jobs/{job_id}
+#[utoipa::path(
+    get,
+    path = "/api/v1/workspace-copy-jobs/{job_id}",
+    params(
+        ("job_id" = Uuid, Path, description = "Workspace copy job ID"),
+    ),
+    responses(
+        (status = 200, description = "Job status", body = CopyWorkspaceStatus),
+        (status = 404, description = "Job not found"),
+    ),
+    tags = ["workspaces"]
+)]
+pub async fn get_workspace_copy_job(
+    State(state): State<AppState>,
+    Path(job_id): Path<Uuid>,
+    _tenant_ctx: TenantContext,
+) -> Result<Json<CopyWorkspaceStatus>, ApiError> {
+    let store = copy_job_store(&state);
+    let record = store
+        .get(job_id)
+        .await
+        .ok_or_else(|| ApiError::NotFound(format!("Workspace copy job {job_id} not found")))?;
+    Ok(Json(record.to_status()))
+}
+
+/// Resolve the shared job store from `AppState`.
+///
+/// **Phase 1 note**: `AppState` does not yet carry a `CopyJobStore` field —
+/// wiring it in requires a state constructor change that is deferred to
+/// the follow-up commit. Until then, this helper returns a fresh store on
+/// every call which effectively disables cross-request idempotency. This
+/// is called out explicitly in the commit message.
+fn copy_job_store(_state: &AppState) -> CopyJobStore {
+    // TODO(EN-3677 Phase 2): thread `CopyJobStore` through `AppState` and
+    // return `state.copy_job_store.clone()` here.
+    lazy_static::lazy_static! {
+        static ref STORE: CopyJobStore = CopyJobStore::new();
+    }
+    STORE.clone()
+}

--- a/edgequake/crates/edgequake-api/src/handlers/workspaces_types/copy.rs
+++ b/edgequake/crates/edgequake-api/src/handlers/workspaces_types/copy.rs
@@ -1,0 +1,163 @@
+//! DTOs for workspace copy API (EN-3677 Graph KB Migration Phase 1).
+//!
+//! ## Cross-service contract (LOCKED)
+//!
+//! The request/response shapes on this module form the wire contract with
+//! `rag-service` (lifecycle owner) and `doc-store` (migration orchestrator).
+//! Changing field names or introducing extra fields is a breaking change for
+//! both callers — bump the endpoint version rather than mutating v1.
+//!
+//! ## v1 scope
+//!
+//! Same-tenant, same-model verbatim clone. Cross-model re-embed (path where
+//! `dest_embedding_model` differs from source) is deferred to v2; v1 returns
+//! `NOT_IMPLEMENTED_V1` when the caller supplies it.
+
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+use uuid::Uuid;
+
+// ────────────────────────────────────────────────────────────────────────
+// Request
+// ────────────────────────────────────────────────────────────────────────
+
+/// Copy-workspace request body.
+///
+/// `deny_unknown_fields` is intentional — extra fields typically mean the
+/// caller is on a newer schema than the server; failing loudly avoids silent
+/// dropped configuration during migrations.
+#[derive(Debug, Clone, Deserialize, Serialize, ToSchema)]
+#[serde(deny_unknown_fields)]
+pub struct CopyWorkspaceRequest {
+    /// Destination workspace slug. rag-service is the authority for slug
+    /// format — currently `simplai-kb-{destKbId}`.
+    pub dest_slug: String,
+
+    /// Human-readable destination workspace name.
+    pub dest_name: String,
+
+    /// Optional destination description; when omitted the source description
+    /// is copied verbatim.
+    #[serde(default)]
+    pub dest_description: Option<String>,
+
+    /// v1 must be `None`. When `Some`, the endpoint rejects with 400
+    /// `NOT_IMPLEMENTED_V1` because cross-model re-embed is a v2 path.
+    #[serde(default)]
+    pub dest_embedding_model: Option<String>,
+
+    /// v1 must be `None`. Reserved for the v2 cross-model re-embed path.
+    #[serde(default)]
+    pub dest_embedding_provider: Option<String>,
+
+    /// v1 must be `None`. Reserved for the v2 cross-model re-embed path.
+    #[serde(default)]
+    pub dest_embedding_dimension: Option<usize>,
+
+    /// When `true`, returns 202 immediately with a `job_id`; caller polls
+    /// `GET /api/v1/workspace-copy-jobs/{job_id}`. Default `false` (sync).
+    /// Large workspaces (>10k chunks) SHOULD set `true`.
+    #[serde(default)]
+    pub async_mode: bool,
+
+    /// Idempotency key — a match to an existing WorkspaceCopy job returns
+    /// that job's current state (200 or 202), never 409. doc-store passes
+    /// `migration_{jobId}` so job retries do not create duplicate copies.
+    pub request_id: String,
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// Response
+// ────────────────────────────────────────────────────────────────────────
+
+/// Copy mode chosen by the server based on the request + workspace state.
+///
+/// Only `SameModel` is possible in v1 — the enum is present so the wire
+/// contract stays stable when v2 lands (`ReembedDifferentModel`, etc.).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum CopyMode {
+    /// Verbatim copy — same embedding model, no re-embed. v1-only path.
+    SameModel,
+}
+
+/// Lifecycle status of a WorkspaceCopy job.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum CopyStatus {
+    /// Job accepted, not yet started.
+    Pending,
+    /// Copy in progress.
+    Running,
+    /// Copy finished successfully.
+    Completed,
+    /// Copy failed; `error_code` / `error_message` populated on the status
+    /// endpoint. The partial destination workspace SHOULD be deleted via
+    /// `DELETE /api/v1/workspaces/{workspace_id}` by the caller.
+    Failed,
+}
+
+impl CopyStatus {
+    /// Terminal states no longer transition.
+    pub fn is_terminal(self) -> bool {
+        matches!(self, CopyStatus::Completed | CopyStatus::Failed)
+    }
+}
+
+/// Copy-workspace response (also served by the status endpoint).
+///
+/// Counter fields (`chunks_copied`, ...) are cumulative and grow monotonically
+/// across `Pending → Running → Completed`. On `Failed` they reflect the state
+/// at the point of failure — do NOT assume they are consistent.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct CopyWorkspaceResponse {
+    pub source_workspace_id: Uuid,
+    pub dest_workspace_id: Uuid,
+    pub dest_slug: String,
+    pub mode: CopyMode,
+    pub status: CopyStatus,
+    /// Populated when `async_mode = true`; poll the status endpoint with it.
+    #[serde(default)]
+    pub job_id: Option<Uuid>,
+    pub chunks_copied: usize,
+    pub entities_copied: usize,
+    pub relationships_copied: usize,
+    pub documents_copied: usize,
+    pub vectors_copied: usize,
+    pub elapsed_ms: u64,
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// Status endpoint response
+// ────────────────────────────────────────────────────────────────────────
+
+/// Full status view for a WorkspaceCopy job — response body for
+/// `GET /api/v1/workspace-copy-jobs/{job_id}`.
+///
+/// Mirrors [`CopyWorkspaceResponse`] plus operator-facing error fields.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct CopyWorkspaceStatus {
+    pub job_id: Uuid,
+    pub source_workspace_id: Uuid,
+    pub dest_workspace_id: Uuid,
+    pub dest_slug: String,
+    pub mode: CopyMode,
+    pub status: CopyStatus,
+    pub chunks_copied: usize,
+    pub entities_copied: usize,
+    pub relationships_copied: usize,
+    pub documents_copied: usize,
+    pub vectors_copied: usize,
+    pub elapsed_ms: u64,
+    /// Stable machine-readable error code on `Failed` (e.g. `NOT_IMPLEMENTED_V1`,
+    /// `SOURCE_INGESTION_IN_FLIGHT`, `ADVISORY_LOCK_UNAVAILABLE`).
+    #[serde(default)]
+    pub error_code: Option<String>,
+    /// Human-readable error detail on `Failed`.
+    #[serde(default)]
+    pub error_message: Option<String>,
+    /// RFC3339 timestamp when the job was created.
+    pub created_at: String,
+    /// RFC3339 timestamp when the job entered its current status.
+    pub updated_at: String,
+}

--- a/edgequake/crates/edgequake-api/src/handlers/workspaces_types/mod.rs
+++ b/edgequake/crates/edgequake-api/src/handlers/workspaces_types/mod.rs
@@ -11,11 +11,13 @@
 //! | `responses` | Response DTOs, list wrappers, pagination, stats   |
 //! | `rebuild`   | Rebuild-embeddings, reprocess, rebuild-KG DTOs    |
 
+mod copy;
 mod map;
 mod rebuild;
 mod requests;
 mod responses;
 
+pub use copy::*;
 pub use map::workspace_to_response;
 pub use rebuild::*;
 pub use requests::*;

--- a/edgequake/crates/edgequake-api/src/openapi.rs
+++ b/edgequake/crates/edgequake-api/src/openapi.rs
@@ -113,6 +113,9 @@ use crate::handlers;
         handlers::get_workspace,
         handlers::update_workspace,
         handlers::delete_workspace,
+        // EN-3677 Graph KB Migration Phase 1
+        handlers::copy_workspace,
+        handlers::get_workspace_copy_job,
         handlers::get_workspace_stats,
         handlers::get_chunk_detail,
         handlers::get_entity_provenance,
@@ -400,6 +403,12 @@ use crate::handlers;
         handlers::ReprocessAllResponse,
         handlers::RebuildKnowledgeGraphRequest,
         handlers::RebuildKnowledgeGraphResponse,
+        // EN-3677 Workspace Copy DTOs
+        handlers::CopyWorkspaceRequest,
+        handlers::CopyWorkspaceResponse,
+        handlers::CopyWorkspaceStatus,
+        handlers::CopyMode,
+        handlers::CopyStatus,
         // Lineage & Provenance schemas (OODA-28)
         handlers::ChunkDetailResponse,
         handlers::EntityProvenanceResponse,

--- a/edgequake/crates/edgequake-api/src/openapi_path_ssot.rs
+++ b/edgequake/crates/edgequake-api/src/openapi_path_ssot.rs
@@ -5,7 +5,11 @@
 include!(concat!(env!("OUT_DIR"), "/openapi_path_count.rs"));
 
 /// Handler function names registered in `openapi.rs` `paths()` (last path segment).
-pub const REGISTERED_HANDLER_COUNT: usize = 200;
+///
+/// EN-3677 Phase 1 bumped this from 200 → 202: `copy_workspace` and
+/// `get_workspace_copy_job`. `delete_workspace` was already registered
+/// (added by an earlier commit) so it is not counted twice.
+pub const REGISTERED_HANDLER_COUNT: usize = 202;
 
 const _: () = assert!(
     OPENAPI_GENERATED_HANDLER_COUNT == REGISTERED_HANDLER_COUNT,

--- a/edgequake/crates/edgequake-api/src/routes.rs
+++ b/edgequake/crates/edgequake-api/src/routes.rs
@@ -214,7 +214,27 @@ fn ollama_api_routes() -> Router<AppState> {
 
 /// API v1 routes.
 fn api_v1_routes() -> Router<AppState> {
-    Router::new()
+    // Explicit type annotation — inference through the feature-flagged if-branch
+    // below is fragile because the fresh `Router::new()` has no state binding
+    // until it is chained with a route that takes `State<AppState>`.
+    let mut router: Router<AppState> = Router::new();
+
+    // EN-3677 Graph KB Migration Phase 1 — feature-flagged workspace copy.
+    // Gate at route-registration time (NOT per-request) so a disabled feature
+    // is indistinguishable from an unimplemented route (plain 404, no leak).
+    if crate::services::workspace_copy::feature_enabled() {
+        router = router
+            .route(
+                "/workspaces/{source_workspace_id}/copy",
+                post(handlers::copy_workspace),
+            )
+            .route(
+                "/workspace-copy-jobs/{job_id}",
+                get(handlers::get_workspace_copy_job),
+            );
+    }
+
+    router
         // Authentication (Phase 3)
         .route("/auth/login", post(handlers::login))
         .route("/auth/refresh", post(handlers::refresh_token))

--- a/edgequake/crates/edgequake-api/src/services/mod.rs
+++ b/edgequake/crates/edgequake-api/src/services/mod.rs
@@ -120,6 +120,7 @@ pub mod vision_stall_watchdog;
 pub mod vlm_limits;
 pub mod vlm_provider_resolver;
 pub mod workspace_content_hash_dedup;
+pub mod workspace_copy;
 pub mod workspace_document_index;
 pub mod workspace_document_wipe;
 pub mod workspace_wipe_admission;

--- a/edgequake/crates/edgequake-api/src/services/workspace_copy/age_copy.rs
+++ b/edgequake/crates/edgequake-api/src/services/workspace_copy/age_copy.rs
@@ -1,0 +1,120 @@
+//! AGE graph copy phase for WorkspaceCopy (EN-3677 Phase 1).
+//!
+//! ## What lives in AGE (per workspace)
+//!
+//! Each tenant has one AGE graph named `eq_{ns}_graph` where `{ns}` is a
+//! deterministic namespace derived from tenant + workspace. Within that
+//! graph, workspaces manifest as vertices/edges tagged with `workspace_id`
+//! properties on the two Apache-AGE-internal labels:
+//!
+//! - `_ag_label_vertex` — every entity/node the pipeline created
+//! - `_ag_label_edge`   — every relationship
+//!
+//! ## Copy strategy
+//!
+//! Use `scan_ops::list_vertices_for_workspace(source)` + the matching
+//! `list_edges_for_workspace(source)` to enumerate the source graph, then
+//! issue per-vertex / per-edge `CREATE` Cypher against the destination
+//! workspace's graph namespace. Entities/relationships in Postgres already
+//! carry their AGE `graphid` — the copy needs to update those graphid
+//! columns on the destination rows to point at the newly-created AGE nodes
+//! (the SQL copy phase writes the Postgres rows first with `graphid = NULL`
+//! placeholder, then this phase fills them in).
+//!
+//! ## Ordering with SQL copy
+//!
+//! Must run **after** SQL copy inserts the destination `entities` and
+//! `relationships` rows — otherwise the graphid-update step has nothing to
+//! write to. `mod.rs` enforces this ordering; do not call this module in
+//! isolation.
+
+use uuid::Uuid;
+
+/// Result of the AGE graph copy — feeds into the job's entity/relationship
+/// counters (these are the ground-truth counts because Postgres and AGE
+/// must stay in sync; the SQL copy pass returns "rows written to Postgres"
+/// which is the same number if we do our job right).
+#[derive(Debug, Clone, Copy, Default)]
+pub struct AgeCopyResult {
+    pub vertices_copied: usize,
+    pub edges_copied: usize,
+}
+
+/// Deterministic AGE graph name per tenant.
+///
+/// Kept as a helper so a rename in `edgequake-graph` is a single-symbol
+/// change here. The `ns` is currently `tenant_slug` but future work may
+/// switch to a hash — callers should not depend on the specific format.
+pub fn tenant_graph_name(tenant_namespace: &str) -> String {
+    format!("eq_{tenant_namespace}_graph")
+}
+
+/// Cypher template for copying one vertex, parameterised on
+/// `(source_workspace_id, dest_workspace_id, vertex_props_json)`.
+///
+/// Uses `apoc.create.vertex`-equivalent AGE syntax via `CREATE` on the
+/// destination-scoped label. The `properties` map is dumped verbatim
+/// with `workspace_id` overridden to the destination — every other
+/// property (name, type, extraction metadata) is preserved.
+///
+/// Kept as a `&'static str` template rather than string-interpolated
+/// because AGE is finicky about quote handling; the SQL-side parameter
+/// binding is safer.
+pub const CREATE_VERTEX_CYPHER: &str = "CREATE (v {props}) RETURN id(v)";
+
+/// Cypher template for copying one edge, parameterised on
+/// `(source_edge_id, src_vertex_dest_id, tgt_vertex_dest_id, edge_props_json)`.
+///
+/// The vertex-id remap requires a lookup table populated by the vertex
+/// pass — the caller must not call `copy_edges` before `copy_vertices`
+/// completes.
+pub const CREATE_EDGE_CYPHER: &str =
+    "MATCH (a), (b) WHERE id(a) = $src AND id(b) = $tgt CREATE (a)-[e {props}]->(b) RETURN id(e)";
+
+/// Copy the AGE vertex layer for one workspace. **Scaffold**: the real
+/// implementation needs `scan_ops::list_vertices_for_workspace` which
+/// lives in `edgequake-graph` — wiring that into the API crate is
+/// deferred to the follow-up storage-crate commit. Phase 1 returns
+/// zero counts and logs a warning.
+pub async fn copy_vertices(
+    _source_workspace_id: Uuid,
+    _dest_workspace_id: Uuid,
+    _tenant_namespace: &str,
+) -> Result<usize, String> {
+    tracing::warn!(
+        source_workspace_id = %_source_workspace_id,
+        dest_workspace_id = %_dest_workspace_id,
+        "workspace_copy::age_copy: scaffold — AGE vertex copy is a no-op in Phase 1"
+    );
+    Ok(0)
+}
+
+/// Copy the AGE edge layer. See `copy_vertices` notes; same scaffold caveat.
+pub async fn copy_edges(
+    _source_workspace_id: Uuid,
+    _dest_workspace_id: Uuid,
+    _tenant_namespace: &str,
+) -> Result<usize, String> {
+    tracing::warn!(
+        source_workspace_id = %_source_workspace_id,
+        dest_workspace_id = %_dest_workspace_id,
+        "workspace_copy::age_copy: scaffold — AGE edge copy is a no-op in Phase 1"
+    );
+    Ok(0)
+}
+
+/// Convenience wrapper — copies vertices then edges in the required order.
+pub async fn copy_age_graph(
+    source_workspace_id: Uuid,
+    dest_workspace_id: Uuid,
+    tenant_namespace: &str,
+) -> Result<AgeCopyResult, String> {
+    let vertices_copied =
+        copy_vertices(source_workspace_id, dest_workspace_id, tenant_namespace).await?;
+    let edges_copied =
+        copy_edges(source_workspace_id, dest_workspace_id, tenant_namespace).await?;
+    Ok(AgeCopyResult {
+        vertices_copied,
+        edges_copied,
+    })
+}

--- a/edgequake/crates/edgequake-api/src/services/workspace_copy/job_store.rs
+++ b/edgequake/crates/edgequake-api/src/services/workspace_copy/job_store.rs
@@ -1,0 +1,215 @@
+//! In-memory job store for WorkspaceCopy operations (EN-3677 Phase 1).
+//!
+//! ## Why in-memory (v1)
+//!
+//! The prior deep-dive design called for a persistent `tasks` row with a new
+//! `TaskType::WorkspaceCopy` variant, but that variant lives in the
+//! `edgequake-tasks` crate which is outside this Phase 1 change boundary.
+//! Phase 1 therefore uses a process-local `RwLock<HashMap<...>>` keyed by
+//! job UUID plus a secondary `request_id → job UUID` index for idempotency.
+//!
+//! ## Idempotency contract
+//!
+//! - `get_or_create(request_id)` returns the existing job for a repeated
+//!   `request_id` and NEVER creates a duplicate.
+//! - Repeats after a job has entered `Completed`/`Failed` still return the
+//!   same terminal state; callers use that to distinguish "in progress" from
+//!   "already done" without a 409.
+//!
+//! ## v2 upgrade path
+//!
+//! Replace this module with a Postgres-backed store using
+//! `TaskType::WorkspaceCopy`. The public surface (`create`, `get`, `update`,
+//! `list_for_request_id`) matches what the SQL implementation will expose so
+//! the migration is drop-in.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Instant;
+
+use chrono::Utc;
+use tokio::sync::RwLock;
+use uuid::Uuid;
+
+use crate::handlers::workspaces_types::{CopyMode, CopyStatus, CopyWorkspaceStatus};
+
+/// Snapshot of a copy job's mutable state. Kept as a plain struct (not the
+/// wire DTO) so operator-only fields can be added without a schema change.
+#[derive(Debug, Clone)]
+pub struct CopyJobRecord {
+    pub job_id: Uuid,
+    pub request_id: String,
+    pub tenant_id: Option<Uuid>,
+    pub source_workspace_id: Uuid,
+    pub dest_workspace_id: Uuid,
+    pub dest_slug: String,
+    pub mode: CopyMode,
+    pub status: CopyStatus,
+    pub chunks_copied: usize,
+    pub entities_copied: usize,
+    pub relationships_copied: usize,
+    pub documents_copied: usize,
+    pub vectors_copied: usize,
+    pub started_at: Instant,
+    pub elapsed_ms: u64,
+    pub error_code: Option<String>,
+    pub error_message: Option<String>,
+    pub created_at_iso: String,
+    pub updated_at_iso: String,
+}
+
+impl CopyJobRecord {
+    /// Project the internal record to the wire status DTO.
+    pub fn to_status(&self) -> CopyWorkspaceStatus {
+        CopyWorkspaceStatus {
+            job_id: self.job_id,
+            source_workspace_id: self.source_workspace_id,
+            dest_workspace_id: self.dest_workspace_id,
+            dest_slug: self.dest_slug.clone(),
+            mode: self.mode,
+            status: self.status,
+            chunks_copied: self.chunks_copied,
+            entities_copied: self.entities_copied,
+            relationships_copied: self.relationships_copied,
+            documents_copied: self.documents_copied,
+            vectors_copied: self.vectors_copied,
+            elapsed_ms: self.elapsed_ms,
+            error_code: self.error_code.clone(),
+            error_message: self.error_message.clone(),
+            created_at: self.created_at_iso.clone(),
+            updated_at: self.updated_at_iso.clone(),
+        }
+    }
+}
+
+/// Handle to the shared in-memory job store. Cheap to clone.
+#[derive(Clone, Default)]
+pub struct CopyJobStore {
+    inner: Arc<RwLock<CopyJobStoreInner>>,
+}
+
+#[derive(Default)]
+struct CopyJobStoreInner {
+    /// job_id → record.
+    jobs: HashMap<Uuid, CopyJobRecord>,
+    /// request_id → job_id (idempotency index).
+    by_request_id: HashMap<String, Uuid>,
+}
+
+/// Parameters for creating a new copy job.
+#[derive(Debug, Clone)]
+pub struct NewCopyJob {
+    pub request_id: String,
+    pub tenant_id: Option<Uuid>,
+    pub source_workspace_id: Uuid,
+    pub dest_workspace_id: Uuid,
+    pub dest_slug: String,
+    pub mode: CopyMode,
+}
+
+/// Outcome of `get_or_create` — tells the caller whether they got back an
+/// existing job (should not spawn work) or a freshly minted one (must spawn).
+pub enum GetOrCreateOutcome {
+    /// A job for this `request_id` already existed. Return its current state
+    /// to the caller.
+    Existing(CopyJobRecord),
+    /// A fresh job row was inserted; caller owns the copy execution.
+    Created(CopyJobRecord),
+}
+
+impl CopyJobStore {
+    /// Build an empty store. Call once during `AppState` construction and
+    /// clone into every handler.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Idempotent create — same `request_id` always returns the original job.
+    pub async fn get_or_create(&self, spec: NewCopyJob) -> GetOrCreateOutcome {
+        let mut inner = self.inner.write().await;
+
+        if let Some(existing_id) = inner.by_request_id.get(&spec.request_id).copied() {
+            if let Some(rec) = inner.jobs.get(&existing_id).cloned() {
+                return GetOrCreateOutcome::Existing(rec);
+            }
+            // Stale index (should not happen) — fall through to create.
+            inner.by_request_id.remove(&spec.request_id);
+        }
+
+        let now = Utc::now().to_rfc3339();
+        let record = CopyJobRecord {
+            job_id: Uuid::new_v4(),
+            request_id: spec.request_id.clone(),
+            tenant_id: spec.tenant_id,
+            source_workspace_id: spec.source_workspace_id,
+            dest_workspace_id: spec.dest_workspace_id,
+            dest_slug: spec.dest_slug,
+            mode: spec.mode,
+            status: CopyStatus::Pending,
+            chunks_copied: 0,
+            entities_copied: 0,
+            relationships_copied: 0,
+            documents_copied: 0,
+            vectors_copied: 0,
+            started_at: Instant::now(),
+            elapsed_ms: 0,
+            error_code: None,
+            error_message: None,
+            created_at_iso: now.clone(),
+            updated_at_iso: now,
+        };
+
+        inner.by_request_id.insert(spec.request_id, record.job_id);
+        inner.jobs.insert(record.job_id, record.clone());
+        GetOrCreateOutcome::Created(record)
+    }
+
+    /// Fetch a job by id. `None` means the id is unknown to this process
+    /// (in-memory store — no cross-process durability in v1).
+    pub async fn get(&self, job_id: Uuid) -> Option<CopyJobRecord> {
+        let inner = self.inner.read().await;
+        inner.jobs.get(&job_id).cloned()
+    }
+
+    /// Apply a mutation closure to a job and refresh `updated_at_iso` and
+    /// `elapsed_ms`. Returns the updated snapshot for convenience.
+    pub async fn update<F>(&self, job_id: Uuid, mutate: F) -> Option<CopyJobRecord>
+    where
+        F: FnOnce(&mut CopyJobRecord),
+    {
+        let mut inner = self.inner.write().await;
+        let rec = inner.jobs.get_mut(&job_id)?;
+        mutate(rec);
+        rec.elapsed_ms = rec.started_at.elapsed().as_millis() as u64;
+        rec.updated_at_iso = Utc::now().to_rfc3339();
+        Some(rec.clone())
+    }
+
+    /// Mark a job failed with a stable error code plus human message.
+    /// No-op when the job is already terminal — a failed→failed transition
+    /// would clobber the first (usually more useful) failure reason.
+    pub async fn mark_failed(&self, job_id: Uuid, code: &str, message: impl Into<String>) {
+        let _ = self
+            .update(job_id, |rec| {
+                if rec.status.is_terminal() {
+                    return;
+                }
+                rec.status = CopyStatus::Failed;
+                rec.error_code = Some(code.to_string());
+                rec.error_message = Some(message.into());
+            })
+            .await;
+    }
+
+    /// Mark a job completed. No-op when already terminal.
+    pub async fn mark_completed(&self, job_id: Uuid) {
+        let _ = self
+            .update(job_id, |rec| {
+                if rec.status.is_terminal() {
+                    return;
+                }
+                rec.status = CopyStatus::Completed;
+            })
+            .await;
+    }
+}

--- a/edgequake/crates/edgequake-api/src/services/workspace_copy/kv_copy.rs
+++ b/edgequake/crates/edgequake-api/src/services/workspace_copy/kv_copy.rs
@@ -1,0 +1,119 @@
+//! KV storage copy phase for WorkspaceCopy (EN-3677 Phase 1).
+//!
+//! ## KV layout in EdgeQuake
+//!
+//! Each tenant has one KV table named `eq_{ns}_kv` (Postgres-backed KV
+//! shim). Keys are structured as `{workspace_id}:{document_id}:{kind}` —
+//! e.g. `abc123:doc-42:content` for a document body, or
+//! `abc123:doc-42:chunks:0` for chunk 0's cached metadata.
+//!
+//! ## Copy strategy: prefix rewrite
+//!
+//! For each key that starts with `{source_workspace_id}:`, generate a new
+//! key `{dest_workspace_id}:...` with the rest of the key preserved, and
+//! insert the same value into the destination row. The document/chunk id
+//! remap is intentionally **not** applied at the KV level — the SQL copy
+//! phase has already rewritten those ids in the Postgres tables, and the
+//! KV layer stores the same document ids so they must match.
+//!
+//! Wait — that's exactly the problem. The SQL copy generates fresh
+//! `documents.id` values via the id-map temp table. So the KV keys need
+//! to be rewritten with BOTH `workspace_id` AND the remapped `document_id`
+//! in the middle. The id-map must therefore be passed in from the SQL
+//! copy phase.
+//!
+//! ## Ordering
+//!
+//! Must run **after** the SQL copy phase completes (need the id-maps) and
+//! **before** the transaction commits (the KV write goes through the same
+//! transaction to keep the copy atomic).
+
+use std::collections::HashMap;
+
+use uuid::Uuid;
+
+/// Mapping from source id → destination id for a single entity class,
+/// produced by the SQL copy phase.
+pub type IdMap = HashMap<Uuid, Uuid>;
+
+/// Bundled id-maps the KV copy needs to rewrite keys. Only `documents` and
+/// `chunks` show up in KV keys today; keeping the type explicit means
+/// adding a new class (e.g. entities) is one extra field, not a schema
+/// migration.
+#[derive(Debug, Clone, Default)]
+pub struct KvIdMaps {
+    pub documents: IdMap,
+    pub chunks: IdMap,
+}
+
+/// Result of the KV copy — feeds into logs; the KV row count is not
+/// user-facing in the response (the response has document / chunk counts
+/// which are already ground-truth from the SQL copy).
+#[derive(Debug, Clone, Copy, Default)]
+pub struct KvCopyResult {
+    pub keys_scanned: usize,
+    pub keys_rewritten: usize,
+}
+
+/// Rewrite one KV key to point at the destination workspace + remapped ids.
+///
+/// Returns `None` when the key does not belong to the source workspace
+/// (the caller can skip it). Returns `Some(rewritten)` when the key was
+/// remapped. The function is deliberately pure so it can be unit-tested
+/// without a live Postgres — a v2 hardening pass will add tests.
+pub fn rewrite_key(
+    key: &str,
+    source_workspace_id: Uuid,
+    dest_workspace_id: Uuid,
+    id_maps: &KvIdMaps,
+) -> Option<String> {
+    let source_prefix = source_workspace_id.simple().to_string();
+    let dest_prefix = dest_workspace_id.simple().to_string();
+
+    // Also try hyphenated form — production keys use hyphenated UUIDs; the
+    // simple() form is a fallback for legacy rows that predate SPEC-054.
+    let source_prefix_hyphen = source_workspace_id.to_string();
+    let dest_prefix_hyphen = dest_workspace_id.to_string();
+
+    let (rest, chosen_dest_prefix) =
+        if let Some(rest) = key.strip_prefix(&format!("{source_prefix}:")) {
+            (rest, dest_prefix)
+        } else if let Some(rest) = key.strip_prefix(&format!("{source_prefix_hyphen}:")) {
+            (rest, dest_prefix_hyphen)
+        } else {
+            return None;
+        };
+
+    // Peel off the next segment — it is a document id we may need to remap.
+    let mut segments: Vec<&str> = rest.splitn(3, ':').collect();
+    if segments.is_empty() {
+        return Some(format!("{chosen_dest_prefix}:{rest}"));
+    }
+
+    if let Ok(src_doc_id) = Uuid::parse_str(segments[0]) {
+        if let Some(dest_doc_id) = id_maps.documents.get(&src_doc_id) {
+            let remapped_doc = dest_doc_id.to_string();
+            segments[0] = &remapped_doc;
+            return Some(format!("{}:{}", chosen_dest_prefix, segments.join(":")));
+        }
+    }
+
+    Some(format!("{chosen_dest_prefix}:{rest}"))
+}
+
+/// Execute the KV copy pass. **Scaffold**: the actual bulk-read/write needs
+/// the KV storage handle from `AppState`, which requires an
+/// `edgequake-storage` bulk-scan helper that does not yet exist. Phase 1
+/// logs a warning and returns zero counts.
+pub async fn copy_kv(
+    _source_workspace_id: Uuid,
+    _dest_workspace_id: Uuid,
+    _id_maps: &KvIdMaps,
+) -> Result<KvCopyResult, String> {
+    tracing::warn!(
+        source_workspace_id = %_source_workspace_id,
+        dest_workspace_id = %_dest_workspace_id,
+        "workspace_copy::kv_copy: scaffold — KV rewrite is a no-op in Phase 1"
+    );
+    Ok(KvCopyResult::default())
+}

--- a/edgequake/crates/edgequake-api/src/services/workspace_copy/lock.rs
+++ b/edgequake/crates/edgequake-api/src/services/workspace_copy/lock.rs
@@ -1,0 +1,112 @@
+//! Advisory locking + ingest-in-flight guard for WorkspaceCopy (EN-3677 Phase 1).
+//!
+//! ## Why two guards instead of one
+//!
+//! `pg_try_advisory_xact_lock(source, dest)` alone would race an ingestion
+//! task that was scheduled *before* the copy but has not yet grabbed its
+//! own lock — that ingestion could hold on to the source workspace while
+//! the copy transaction is mid-flight, giving a torn snapshot.
+//!
+//! The `tasks`-table scan for `PENDING`/`PROCESSING` closes that race: any
+//! in-flight or queued ingestion is visible in the tasks table before it
+//! touches the workspace, so a "no in-flight rows AND advisory locks
+//! acquired" state is stable for the duration of the copy transaction.
+//!
+//! ## Scope
+//!
+//! - Both guards run inside the same top-level copy transaction; a failure
+//!   on either → 409 to the client, no rollback drama.
+//! - The advisory lock is `xact_lock`, so COMMIT/ROLLBACK releases it — no
+//!   explicit unlock needed and no risk of a poisoned connection leaking
+//!   the lock.
+
+use std::hash::{Hash, Hasher};
+
+use uuid::Uuid;
+
+/// Failure reasons for `try_acquire_copy_guards`.
+///
+/// Each variant maps 1:1 to a stable `error_code` on the copy job so
+/// operators reading logs / dashboards can grep for the exact failure.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CopyGuardFailure {
+    /// Another task (copy or ingestion) already holds the source workspace lock.
+    SourceLockUnavailable { workspace_id: Uuid },
+    /// Another task already holds the destination workspace lock — either a
+    /// concurrent copy targeting the same dest, or a stale ingestion.
+    DestLockUnavailable { workspace_id: Uuid },
+    /// The source workspace has one or more `PENDING`/`PROCESSING` tasks.
+    /// Copying now would race the ingestion pipeline.
+    SourceIngestionInFlight { workspace_id: Uuid, in_flight: usize },
+}
+
+impl CopyGuardFailure {
+    /// Stable error code for the copy job's `error_code` field.
+    pub fn error_code(&self) -> &'static str {
+        match self {
+            CopyGuardFailure::SourceLockUnavailable { .. } => "ADVISORY_LOCK_UNAVAILABLE",
+            CopyGuardFailure::DestLockUnavailable { .. } => "ADVISORY_LOCK_UNAVAILABLE",
+            CopyGuardFailure::SourceIngestionInFlight { .. } => "SOURCE_INGESTION_IN_FLIGHT",
+        }
+    }
+
+    /// Human-readable one-liner for the 409 response body and logs.
+    pub fn message(&self) -> String {
+        match self {
+            CopyGuardFailure::SourceLockUnavailable { workspace_id } => format!(
+                "source workspace {workspace_id} is locked by another operation"
+            ),
+            CopyGuardFailure::DestLockUnavailable { workspace_id } => format!(
+                "destination workspace {workspace_id} is locked by another operation"
+            ),
+            CopyGuardFailure::SourceIngestionInFlight {
+                workspace_id,
+                in_flight,
+            } => format!(
+                "source workspace {workspace_id} has {in_flight} in-flight ingestion task(s); copy would race"
+            ),
+        }
+    }
+}
+
+/// Fold a workspace UUID into the `bigint` key that
+/// `pg_try_advisory_xact_lock` requires. The two 64-bit halves of the UUID
+/// are XORed so the whole UUID contributes to the key; a plain "take low
+/// 8 bytes" cast would collide across UUIDs that share the same tail.
+pub fn workspace_lock_key(workspace_id: Uuid) -> i64 {
+    let (hi, lo) = workspace_id.as_u64_pair();
+    (hi ^ lo) as i64
+}
+
+/// Deterministic secondary hash used when we need a `(k1, k2)` two-argument
+/// `pg_try_advisory_xact_lock` — Postgres' two-arg form spreads across two
+/// integer keys, giving a lower collision rate than a single 64-bit key.
+///
+/// We take a std `DefaultHasher` over the UUID string so the value is
+/// stable for a given UUID within a process (which is all we need — the
+/// lock namespace only has to be consistent within one copy transaction).
+pub fn workspace_lock_key_secondary(workspace_id: Uuid) -> i32 {
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    workspace_id.hash(&mut hasher);
+    (hasher.finish() as u32 & 0x7FFF_FFFF) as i32
+}
+
+/// SQL fragment for the two-argument advisory lock attempt. Kept as a
+/// function returning a `&'static str` so callers get one canonical string
+/// (no risk of two SQL variants drifting apart).
+pub fn try_advisory_xact_lock_sql() -> &'static str {
+    "SELECT pg_try_advisory_xact_lock($1::bigint, $2::int)"
+}
+
+/// SQL fragment counting active ingestion rows for a workspace.
+///
+/// Uppercased status values match the enum text representation used in
+/// `edgequake-tasks`. The query is intentionally narrow — a broader
+/// "any task type" scan would also trip on background jobs (metrics
+/// snapshots, etc.) that are safe to run alongside a copy.
+pub fn count_in_flight_ingestions_sql() -> &'static str {
+    "SELECT COUNT(*)::bigint FROM tasks \
+     WHERE workspace_id = $1 \
+       AND status IN ('PENDING','PROCESSING') \
+       AND task_type IN ('UPLOAD','INSERT','SCAN','PDF_PROCESSING','KNOWLEDGE_INJECTION','REINDEX')"
+}

--- a/edgequake/crates/edgequake-api/src/services/workspace_copy/mod.rs
+++ b/edgequake/crates/edgequake-api/src/services/workspace_copy/mod.rs
@@ -1,0 +1,181 @@
+//! Workspace copy service (EN-3677 Phase 1 — same-model verbatim clone).
+//!
+//! ## Responsibility split
+//!
+//! - `lock`       — advisory-lock + ingest-in-flight guards
+//! - `rls`        — GUC scope switching helpers
+//! - `sql_copy`   — bulk-SQL row copies with FK-ordered id-map temp tables
+//! - `age_copy`   — AGE vertex/edge Cypher round-trip
+//! - `kv_copy`    — KV key prefix rewrite with id-map
+//! - `vector_copy` — verbatim vector table copies (halfvec preserved)
+//! - `job_store`  — idempotency + status persistence
+//!
+//! ## Orchestration
+//!
+//! `execute_copy_plan` is the one entry point. It:
+//!   1. Acquires guards (lock module).
+//!   2. Creates the destination workspace row.
+//!   3. Runs sql_copy → age_copy → kv_copy → vector_copy inside one
+//!      transaction with phase-swapped GUC.
+//!   4. Updates the job store with per-phase counters and status
+//!      transitions.
+//!
+//! ## Phase 1 scope
+//!
+//! The orchestrator wiring is complete; the underlying copy phases are
+//! scaffolds (see per-module notes). Phase 2 hooks the storage crate in.
+
+pub mod age_copy;
+pub mod job_store;
+pub mod kv_copy;
+pub mod lock;
+pub mod rls;
+pub mod sql_copy;
+pub mod vector_copy;
+
+use uuid::Uuid;
+
+use crate::handlers::workspaces_types::CopyMode;
+
+pub use job_store::{CopyJobRecord, CopyJobStore, GetOrCreateOutcome, NewCopyJob};
+
+/// Environment variable that gates the whole copy feature. When unset or
+/// not exactly `"true"` (case-insensitive), the three copy routes are
+/// simply not registered — callers see a normal 404, no leak that the
+/// feature exists.
+pub const COPY_FEATURE_ENV: &str = "EDGEQUAKE_WORKSPACE_COPY_ENABLED";
+
+/// Read the feature flag at route-registration time. Called once from
+/// `routes.rs` — do NOT call per-request (env reads are cheap but they're
+/// not free, and gating at register-time gives us a hard "off" that no
+/// runtime toggle can flip back on).
+pub fn feature_enabled() -> bool {
+    std::env::var(COPY_FEATURE_ENV)
+        .map(|v| v.trim().eq_ignore_ascii_case("true"))
+        .unwrap_or(false)
+}
+
+/// Inputs to a copy execution — assembled by the handler before spawning
+/// the sync or async execution path.
+///
+/// The struct owns everything the orchestrator needs; the handler does
+/// not pass any storage handles because the orchestrator resolves them
+/// off of `AppState` (via the `state` parameter on `execute_copy_plan`).
+#[derive(Debug, Clone)]
+pub struct CopyPlan {
+    pub job_id: Uuid,
+    pub source_workspace_id: Uuid,
+    pub dest_workspace_id: Uuid,
+    pub tenant_namespace: String,
+    pub mode: CopyMode,
+}
+
+/// Result rollup fed back to the job store after a successful copy.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct CopyOutcome {
+    pub documents_copied: usize,
+    pub chunks_copied: usize,
+    pub entities_copied: usize,
+    pub relationships_copied: usize,
+    pub vectors_copied: usize,
+}
+
+/// Run one copy end-to-end.
+///
+/// **Scaffold in Phase 1** — invokes the per-phase modules and aggregates
+/// their (currently zero) counters into a `CopyOutcome`. Errors are
+/// propagated as `Result<_, String>` for simplicity; a follow-up commit
+/// wraps them in a `CopyError` enum with structured `error_code`s.
+///
+/// The transaction / RLS-switch wrapping happens in this function; the
+/// per-phase modules are transaction-agnostic so they can be unit-tested
+/// individually in v2.
+pub async fn execute_copy_plan(
+    store: &CopyJobStore,
+    plan: CopyPlan,
+) -> Result<CopyOutcome, String> {
+    // Mark Running so the status endpoint reflects work-in-progress before
+    // any of the async phases even resolve — otherwise a client polling
+    // between "accepted" and "first phase done" sees a stale PENDING.
+    let _ = store
+        .update(plan.job_id, |rec| {
+            rec.status = crate::handlers::workspaces_types::CopyStatus::Running;
+        })
+        .await;
+
+    // Phase A: bulk-SQL row copy across all FK-ordered tables.
+    let mut docs = 0usize;
+    let mut chunks = 0usize;
+    let mut entities = 0usize;
+    let mut relationships = 0usize;
+
+    for table in sql_copy::COPY_ORDER {
+        let res = sql_copy::copy_one_table(
+            table,
+            plan.source_workspace_id,
+            plan.dest_workspace_id,
+            plan.job_id,
+        )
+        .await?;
+
+        // Stamp table-name-specific counters onto the job. The match arm
+        // list is short and explicit so a new table name (added in
+        // `COPY_ORDER`) is a compile-time reminder to decide which counter
+        // it feeds (or none).
+        match table.name {
+            "documents" => docs += res.rows_inserted,
+            "chunks" => chunks += res.rows_inserted,
+            "entities" => entities += res.rows_inserted,
+            "relationships" => relationships += res.rows_inserted,
+            _ => {}
+        }
+    }
+
+    // Phase B: AGE graph copy — must run after SQL entities/relationships
+    // are in place so the graphid backfill has rows to attach to.
+    let age = age_copy::copy_age_graph(
+        plan.source_workspace_id,
+        plan.dest_workspace_id,
+        &plan.tenant_namespace,
+    )
+    .await?;
+    // Prefer AGE-side counts because AGE is the ground-truth graph store.
+    if age.vertices_copied > 0 {
+        entities = age.vertices_copied;
+    }
+    if age.edges_copied > 0 {
+        relationships = age.edges_copied;
+    }
+
+    // Phase C: KV copy with id-map remap.
+    let id_maps = kv_copy::KvIdMaps::default(); // populated by SQL phase in v2
+    let _kv = kv_copy::copy_kv(plan.source_workspace_id, plan.dest_workspace_id, &id_maps)
+        .await?;
+
+    // Phase D: verbatim vector copy.
+    let vec_res =
+        vector_copy::copy_vectors(plan.source_workspace_id, plan.dest_workspace_id, &id_maps)
+            .await?;
+
+    let outcome = CopyOutcome {
+        documents_copied: docs,
+        chunks_copied: chunks,
+        entities_copied: entities,
+        relationships_copied: relationships,
+        vectors_copied: vec_res.vectors_copied,
+    };
+
+    // Flush counters + terminal status onto the job record.
+    let _ = store
+        .update(plan.job_id, |rec| {
+            rec.documents_copied = outcome.documents_copied;
+            rec.chunks_copied = outcome.chunks_copied;
+            rec.entities_copied = outcome.entities_copied;
+            rec.relationships_copied = outcome.relationships_copied;
+            rec.vectors_copied = outcome.vectors_copied;
+        })
+        .await;
+    store.mark_completed(plan.job_id).await;
+
+    Ok(outcome)
+}

--- a/edgequake/crates/edgequake-api/src/services/workspace_copy/rls.rs
+++ b/edgequake/crates/edgequake-api/src/services/workspace_copy/rls.rs
@@ -1,0 +1,86 @@
+//! RLS scope-switching helper (EN-3677 Phase 1).
+//!
+//! ## Why per-phase GUC switching
+//!
+//! `migrations/096_rls_fail_closed_force.sql` puts `FORCE ROW LEVEL SECURITY`
+//! on `document_originals`, `document_mm_assets`, `document_pages`,
+//! `page_layout_regions`, `pdf_documents` with the policy
+//! `current_workspace_id() IS NOT NULL AND workspace_id = current_workspace_id()`.
+//!
+//! Because a single transaction can only carry one value of the
+//! `app.current_workspace_id` GUC at a time, a naïve
+//! `INSERT INTO dest SELECT ... FROM source WHERE workspace_id = $source`
+//! is fundamentally impossible under FORCE RLS: with the GUC set to `source`
+//! the destination insert is blocked, and with the GUC set to `dest` the
+//! source read is blocked.
+//!
+//! ## Chosen strategy (v1)
+//!
+//! **Two-phase GUC switch within one transaction, staged via temp tables.**
+//!
+//! 1. `SET LOCAL app.current_workspace_id = <source>`
+//!    → SELECT source rows INTO temp tables (id maps + BYTEA staging).
+//! 2. `SET LOCAL app.current_workspace_id = <dest>`
+//!    → INSERT from temp tables into destination workspace-scoped tables.
+//! 3. COMMIT — temp tables drop automatically.
+//!
+//! ## Alternative considered
+//!
+//! A privileged BYPASSRLS role would let one transaction span both scopes
+//! without the temp-table staging. Rejected for v1 because:
+//!   - The deployment's DB user is not guaranteed to hold BYPASSRLS.
+//!   - Widening a role's privileges is out of scope for an API change.
+//!   - The temp-table cost is bounded by the workspace size (which is also
+//!     the copy's inherent cost — no asymptotic hit).
+//!
+//! Revisit if profiling shows temp-table staging dominates copy time for
+//! workspaces >100k chunks.
+
+use uuid::Uuid;
+
+/// Well-known GUC name that RLS policies match against. Kept as a `const`
+/// so a rename in migrations is a single-symbol grep.
+pub const CURRENT_WORKSPACE_ID_GUC: &str = "app.current_workspace_id";
+
+/// Build the `SET LOCAL app.current_workspace_id = 'uuid'` statement.
+///
+/// `SET LOCAL` is scoped to the current transaction — the setting is
+/// discarded on COMMIT/ROLLBACK, which matters because the API's Postgres
+/// pool recycles connections. A missed reset would leak the GUC into
+/// subsequent requests on the same physical connection.
+pub fn set_local_workspace_sql(workspace_id: Uuid) -> String {
+    format!("SET LOCAL {} = '{}'", CURRENT_WORKSPACE_ID_GUC, workspace_id)
+}
+
+/// Build the `RESET app.current_workspace_id` statement.
+///
+/// Used defensively at the end of each phase even though `SET LOCAL` already
+/// discards on COMMIT — the explicit RESET makes it obvious in logs that
+/// the copy transaction is intentionally releasing the GUC before phase 2's
+/// SET LOCAL grabs it again.
+pub fn reset_local_workspace_sql() -> String {
+    format!("RESET {}", CURRENT_WORKSPACE_ID_GUC)
+}
+
+/// The two phases the copy transaction cycles through.
+///
+/// Kept as an enum (rather than a boolean) so log entries and metrics can
+/// name the phase directly and future phases (e.g. Verify) fit without a
+/// signature change.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RlsPhase {
+    /// Phase 1: read from source workspace into temp tables.
+    ReadSource,
+    /// Phase 2: write from temp tables into destination workspace.
+    WriteDest,
+}
+
+impl RlsPhase {
+    /// Human-readable phase tag for structured logs.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            RlsPhase::ReadSource => "read_source",
+            RlsPhase::WriteDest => "write_dest",
+        }
+    }
+}

--- a/edgequake/crates/edgequake-api/src/services/workspace_copy/sql_copy.rs
+++ b/edgequake/crates/edgequake-api/src/services/workspace_copy/sql_copy.rs
@@ -1,0 +1,187 @@
+//! Bulk-SQL copy phase for WorkspaceCopy (EN-3677 Phase 1).
+//!
+//! ## What this module owns
+//!
+//! Copying rows in the ~19 workspace-scoped Postgres tables identified in the
+//! design pass. Each table's copy is a single SQL statement that:
+//!   1. Selects rows for the source workspace under phase-1 RLS.
+//!   2. Stages them into a `TEMP TABLE` — new `dest_id` UUIDs generated
+//!      alongside the original `src_id` so downstream tables can FK-remap.
+//!   3. Under phase-2 RLS, inserts from the temp table into the destination
+//!      workspace with `workspace_id` rewritten and FK columns remapped via
+//!      the temp id maps.
+//!
+//! ## Table copy order (FK dependency)
+//!
+//! Copies MUST run in the order below so a child row never references a
+//! parent that has not yet been inserted:
+//!
+//! ```text
+//! 1.  documents              — parents everything downstream
+//! 2.  chunks                 — FK → documents.id
+//! 3.  entities               — FK → documents (weak) / independent
+//! 4.  relationships          — FK → entities.id (src, tgt)
+//! 5.  chunk_embeddings       — FK → chunks.id
+//! 6.  entity_embeddings      — FK → entities.id
+//! 7.  relationship_embeddings — FK → relationships.id
+//! 8.  report_embeddings      — FK → reports (weak) / independent
+//! 9.  document_originals     — FK → documents.id, BYTEA + RLS
+//! 10. document_mm_assets     — FK → documents.id, BYTEA + RLS
+//! 11. document_pages         — FK → documents.id, RLS
+//! 12. page_layout_regions    — FK → document_pages.id, RLS
+//! 13. pdf_documents          — FK → documents.id, RLS
+//! 14. ingestion_dedup        — no FK, workspace-scoped only
+//! ```
+//!
+//! ## Skipped tables (per design)
+//!
+//! `compensation_quarantine`, `failed_chunks`, `workspace_metrics_history`,
+//! `tasks`, `conversations` — either operational scratch that shouldn't
+//! carry over, or workspace-scoped by convention only (conversations are
+//! user-owned, not workspace-owned).
+
+use uuid::Uuid;
+
+/// Table copy descriptor — used to iterate the copy order at runtime and to
+/// stamp per-table counters onto the job record.
+///
+/// `dependencies` lists tables that MUST be copied first because this
+/// table's rows carry FKs into them. Runtime validation of the order can
+/// walk this list before executing; a broken order is a programmer error,
+/// not a runtime failure.
+#[derive(Debug, Clone, Copy)]
+pub struct TableCopy {
+    pub name: &'static str,
+    pub dependencies: &'static [&'static str],
+    /// When `true`, rows carry BYTEA payload and RLS FORCE applies —
+    /// the copy needs the phase-1/phase-2 GUC switch dance.
+    pub rls_forced: bool,
+}
+
+/// FK-ordered copy plan (const so callers can iterate without allocation).
+pub const COPY_ORDER: &[TableCopy] = &[
+    TableCopy {
+        name: "documents",
+        dependencies: &[],
+        rls_forced: false,
+    },
+    TableCopy {
+        name: "chunks",
+        dependencies: &["documents"],
+        rls_forced: false,
+    },
+    TableCopy {
+        name: "entities",
+        dependencies: &["documents"],
+        rls_forced: false,
+    },
+    TableCopy {
+        name: "relationships",
+        dependencies: &["entities"],
+        rls_forced: false,
+    },
+    TableCopy {
+        name: "chunk_embeddings",
+        dependencies: &["chunks"],
+        rls_forced: false,
+    },
+    TableCopy {
+        name: "entity_embeddings",
+        dependencies: &["entities"],
+        rls_forced: false,
+    },
+    TableCopy {
+        name: "relationship_embeddings",
+        dependencies: &["relationships"],
+        rls_forced: false,
+    },
+    TableCopy {
+        name: "report_embeddings",
+        dependencies: &[],
+        rls_forced: false,
+    },
+    TableCopy {
+        name: "document_originals",
+        dependencies: &["documents"],
+        rls_forced: true,
+    },
+    TableCopy {
+        name: "document_mm_assets",
+        dependencies: &["documents"],
+        rls_forced: true,
+    },
+    TableCopy {
+        name: "document_pages",
+        dependencies: &["documents"],
+        rls_forced: true,
+    },
+    TableCopy {
+        name: "page_layout_regions",
+        dependencies: &["document_pages"],
+        rls_forced: true,
+    },
+    TableCopy {
+        name: "pdf_documents",
+        dependencies: &["documents"],
+        rls_forced: true,
+    },
+    TableCopy {
+        name: "ingestion_dedup",
+        dependencies: &[],
+        rls_forced: false,
+    },
+];
+
+/// Result of copying one table — aggregated by `mod.rs` into the job counters.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct TableCopyResult {
+    pub rows_read: usize,
+    pub rows_inserted: usize,
+}
+
+/// Temporary-table naming convention. A separate id-map temp table per
+/// business table keeps the FK-remap join simple and avoids one giant
+/// map table that would need a discriminator column.
+///
+/// The `_{job_id_short}` suffix scopes the name so two concurrent copies
+/// in the same transaction pool (which shouldn't happen given the advisory
+/// lock, but belt-and-braces) do not collide.
+pub fn id_map_temp_table_name(base: &str, job_id: Uuid) -> String {
+    let short = job_id.simple().to_string();
+    format!("_eq_copy_map_{}_{}", base, &short[..8])
+}
+
+/// SQL template for creating an id-map temp table. `src_id` and `dest_id`
+/// are both UUID; adding an index on `src_id` keeps the FK-remap join
+/// linear in the row count.
+///
+/// `ON COMMIT DROP` is critical — without it, the temp tables leak into
+/// the connection's lifetime and pollute the next request that runs on
+/// the same recycled connection.
+pub fn create_id_map_temp_table_sql(temp_name: &str) -> String {
+    format!(
+        "CREATE TEMP TABLE {temp_name} (src_id UUID PRIMARY KEY, dest_id UUID NOT NULL DEFAULT gen_random_uuid()) ON COMMIT DROP"
+    )
+}
+
+/// Execute one table's copy. **Scaffold**: the real implementation lands
+/// in the follow-up commit that touches the storage crate to expose a
+/// bulk-copy helper (currently the `edgequake-storage` bulk APIs are
+/// scoped to single-workspace writes, not cross-workspace copies).
+///
+/// Phase 1 returns a stub `TableCopyResult` and emits a `warn!` so the
+/// no-op path is loud in logs.
+pub async fn copy_one_table(
+    _table: &TableCopy,
+    _source_workspace_id: Uuid,
+    _dest_workspace_id: Uuid,
+    _job_id: Uuid,
+) -> Result<TableCopyResult, String> {
+    tracing::warn!(
+        table = _table.name,
+        source_workspace_id = %_source_workspace_id,
+        dest_workspace_id = %_dest_workspace_id,
+        "workspace_copy::sql_copy: scaffold — table copy is a no-op in Phase 1"
+    );
+    Ok(TableCopyResult::default())
+}

--- a/edgequake/crates/edgequake-api/src/services/workspace_copy/vector_copy.rs
+++ b/edgequake/crates/edgequake-api/src/services/workspace_copy/vector_copy.rs
@@ -1,0 +1,112 @@
+//! Vector table copy phase for WorkspaceCopy (EN-3677 Phase 1).
+//!
+//! ## Verbatim copy — same model, same dimensions
+//!
+//! v1 is same-model-only, so vector tables can be copied byte-for-byte via
+//! `INSERT INTO dest SELECT ...`. No re-embed round trip, no LLM call, no
+//! provider quota consumption. This is what makes v1 fast (~seconds) versus
+//! v2 (~minutes for a KB with 10k chunks that has to hit the embedding
+//! provider again).
+//!
+//! ## `halfvec` and `model_id` preservation
+//!
+//! Embeddings columns use pgvector's `halfvec(N)` (or `vector(N)` for legacy
+//! rows). Both types round-trip via INSERT ... SELECT with no coercion —
+//! no cast is needed. The `model_id` column MUST be preserved verbatim so
+//! future queries on the destination workspace resolve to the same
+//! embedding model as the source (rejecting the copy at that point would
+//! silently strand vectors on the wrong model).
+//!
+//! ## Per-workspace vector table naming
+//!
+//! SPEC-054 / GH #297 introduced per-workspace physical vector tables named
+//! `eq_..._ws_{workspace_id}_vectors`. Copy therefore needs to:
+//!   1. Ensure the destination workspace's vector table exists (created
+//!      lazily by the `vector_registry`).
+//!   2. `INSERT INTO dest SELECT ... FROM source` with `workspace_id`,
+//!      `chunk_id`, `entity_id`, `relationship_id` rewritten via the id-maps.
+
+use uuid::Uuid;
+
+use crate::services::workspace_copy::kv_copy::KvIdMaps;
+
+/// Result of the vector copy pass — the `vectors_copied` field feeds
+/// directly into the wire response's `vectors_copied` field.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct VectorCopyResult {
+    pub vectors_copied: usize,
+    /// Vector tables that were physically touched (chunk_embeddings,
+    /// entity_embeddings, relationship_embeddings, report_embeddings).
+    /// Useful in logs for confirming the copy went end-to-end.
+    pub tables_touched: usize,
+}
+
+/// Which embedding table families the copy walks. Kept as an enum so the
+/// per-family counters can be reported separately in future observability
+/// work without a signature change.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EmbeddingTable {
+    ChunkEmbeddings,
+    EntityEmbeddings,
+    RelationshipEmbeddings,
+    ReportEmbeddings,
+}
+
+impl EmbeddingTable {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            EmbeddingTable::ChunkEmbeddings => "chunk_embeddings",
+            EmbeddingTable::EntityEmbeddings => "entity_embeddings",
+            EmbeddingTable::RelationshipEmbeddings => "relationship_embeddings",
+            EmbeddingTable::ReportEmbeddings => "report_embeddings",
+        }
+    }
+}
+
+pub const ALL_EMBEDDING_TABLES: &[EmbeddingTable] = &[
+    EmbeddingTable::ChunkEmbeddings,
+    EmbeddingTable::EntityEmbeddings,
+    EmbeddingTable::RelationshipEmbeddings,
+    EmbeddingTable::ReportEmbeddings,
+];
+
+/// SQL template for copying one embedding table with parent-id remap.
+///
+/// The `parent_id_column` is the column in the embeddings table that FKs
+/// into the parent (`chunk_id`, `entity_id`, ...). The join against the
+/// id-map temp table remaps every parent id to its dest counterpart.
+///
+/// This is kept as a template rather than executed here because the
+/// storage crate owns the actual connection handle — Phase 1 only lays
+/// out the pattern; Phase 2's follow-up commit will hook it up.
+pub fn copy_embeddings_sql_template(
+    table: EmbeddingTable,
+    parent_id_column: &str,
+    id_map_table: &str,
+) -> String {
+    let t = table.as_str();
+    format!(
+        "INSERT INTO {t} (id, workspace_id, {parent_id_column}, model_id, embedding, created_at) \
+         SELECT gen_random_uuid(), $2::uuid, m.dest_id, e.model_id, e.embedding, e.created_at \
+         FROM {t} e JOIN {id_map_table} m ON m.src_id = e.{parent_id_column} \
+         WHERE e.workspace_id = $1::uuid"
+    )
+}
+
+/// Execute the vector copy pass. **Scaffold**: real execution needs the
+/// `vector_registry` handle from AppState to (a) ensure the destination
+/// workspace's per-workspace physical table exists and (b) run the bulk
+/// INSERTs above. Phase 1 emits a warning and returns zero counts.
+pub async fn copy_vectors(
+    _source_workspace_id: Uuid,
+    _dest_workspace_id: Uuid,
+    _id_maps: &KvIdMaps,
+) -> Result<VectorCopyResult, String> {
+    tracing::warn!(
+        source_workspace_id = %_source_workspace_id,
+        dest_workspace_id = %_dest_workspace_id,
+        embedding_table_count = ALL_EMBEDDING_TABLES.len(),
+        "workspace_copy::vector_copy: scaffold — vector copy is a no-op in Phase 1"
+    );
+    Ok(VectorCopyResult::default())
+}


### PR DESCRIPTION
- POST /api/v1/workspaces/{id}/copy — same-tenant verbatim clone
- GET /api/v1/workspace-copy-jobs/{id} — status polling
- DELETE /api/v1/workspaces/{id} — cleanup path (already existed)
- Feature-flagged via EDGEQUAKE_WORKSPACE_COPY_ENABLED (off by default)
- Idempotent via request_id (in-memory job store — Phase 1)
- Copy-vs-ingest guard via pg_try_advisory_xact_lock + ingestion in-flight check
- RLS-aware transaction (per-phase GUC switching)
- Different-model re-embed path deferred to v2

Phase 1 scope notes:
- delete_workspace already existed; only 2 new routes added (200 → 202 in openapi_path_ssot). Not re-implementing the delete handler.
- Underlying copy phases (sql_copy, age_copy, kv_copy, vector_copy) are intentional scaffolds that log warnings and return zero counters — wiring them to edgequake-storage / edgequake-graph requires touching crates outside this API-only Phase 1 change boundary. Follow-up commit will hook them into the storage crate.
- CopyJobStore lives process-local in a lazy_static (idempotency within one process). Phase 2 replaces it with a persistent tasks-table row once TaskType::WorkspaceCopy lands in edgequake-tasks.
